### PR TITLE
fix: enforce list-of-dicts shape on PatientInfo JSON fields

### DIFF
--- a/tests/services/patient_info/test_resolve_normalize_json.py
+++ b/tests/services/patient_info/test_resolve_normalize_json.py
@@ -1,0 +1,124 @@
+"""
+Tests for _normalize_structured_json_fields in resolve.py.
+
+Guards the invariant that PatientInfo.later_therapies / supportive_therapies are
+list-of-dicts and genetic_mutations contains only dicts before downstream
+consumers (matcher, scoring, trial details) iterate items and call .get(...).
+"""
+import pytest
+
+from trials.services.patient_info.resolve import (
+    _build_in_memory,
+    _normalize_structured_json_fields,
+)
+
+
+class TestNormalizeStructuredJsonFields:
+    def test_bare_strings_in_supportive_therapies_coerced_to_dicts(self):
+        data = {'supportive_therapies': ['Dexamethasone', 'Methotrexate']}
+        _normalize_structured_json_fields(data)
+        assert data['supportive_therapies'] == [
+            {'therapy': 'Dexamethasone'},
+            {'therapy': 'Methotrexate'},
+        ]
+
+    def test_bare_strings_in_later_therapies_coerced_to_dicts(self):
+        data = {'later_therapies': ['Rituximab']}
+        _normalize_structured_json_fields(data)
+        assert data['later_therapies'] == [{'therapy': 'Rituximab'}]
+
+    def test_properly_shaped_dicts_pass_through_unchanged(self):
+        item = {'therapy': 'rituximab', 'startDate': '2023-01-01', 'endDate': '2023-06-01'}
+        data = {'later_therapies': [item]}
+        _normalize_structured_json_fields(data)
+        assert data['later_therapies'] == [item]
+
+    def test_mixed_list_keeps_dicts_coerces_strings_drops_other(self):
+        data = {'later_therapies': [{'therapy': 'a'}, 'b', None, 42, '  c  ']}
+        _normalize_structured_json_fields(data)
+        assert data['later_therapies'] == [
+            {'therapy': 'a'},
+            {'therapy': 'b'},
+            {'therapy': 'c'},  # whitespace trimmed
+        ]
+
+    def test_non_list_value_collapses_to_empty_list(self):
+        data = {'later_therapies': 'oops a string'}
+        _normalize_structured_json_fields(data)
+        assert data['later_therapies'] == []
+
+    def test_empty_and_whitespace_strings_dropped(self):
+        data = {'supportive_therapies': ['', '   ', 'real']}
+        _normalize_structured_json_fields(data)
+        assert data['supportive_therapies'] == [{'therapy': 'real'}]
+
+    def test_none_value_passes_through_untouched(self):
+        data = {'later_therapies': None, 'supportive_therapies': None, 'genetic_mutations': None}
+        _normalize_structured_json_fields(data)
+        assert data == {'later_therapies': None, 'supportive_therapies': None, 'genetic_mutations': None}
+
+    def test_missing_keys_are_noop(self):
+        data = {}
+        _normalize_structured_json_fields(data)
+        assert data == {}
+
+    def test_empty_list_stays_empty(self):
+        data = {'later_therapies': [], 'supportive_therapies': [], 'genetic_mutations': []}
+        _normalize_structured_json_fields(data)
+        assert data == {'later_therapies': [], 'supportive_therapies': [], 'genetic_mutations': []}
+
+    def test_genetic_mutations_drops_non_dict_items(self):
+        data = {'genetic_mutations': [{'gene': 'TP53'}, 'TP53', None, 42]}
+        _normalize_structured_json_fields(data)
+        assert data['genetic_mutations'] == [{'gene': 'TP53'}]
+
+    def test_genetic_mutations_non_list_collapses_to_empty(self):
+        data = {'genetic_mutations': 'oops'}
+        _normalize_structured_json_fields(data)
+        assert data['genetic_mutations'] == []
+
+    def test_unrelated_keys_left_alone(self):
+        data = {'patient_age': 65, 'disease': 'multiple myeloma', 'later_therapies': ['x']}
+        _normalize_structured_json_fields(data)
+        assert data['patient_age'] == 65
+        assert data['disease'] == 'multiple myeloma'
+        assert data['later_therapies'] == [{'therapy': 'x'}]
+
+
+class TestBuildInMemoryRegression:
+    """End-to-end regression — the crash reported for person_id=20258.
+
+    Before the fix, normalize_patient_info → stem_cell_transplant_history_from_therapy_lines
+    iterated patient_info.later_therapies and called .get('therapy') on each item,
+    raising AttributeError when items were bare strings. The validator now reshapes
+    items before PatientInfo construction.
+    """
+
+    @pytest.mark.django_db
+    def test_bare_string_later_therapies_does_not_crash(self):
+        data = {
+            'disease': 'multiple myeloma',
+            'prior_therapy': 'More than two lines of therapy',
+            'later_therapies': ['Bortezomib', 'Lenalidomide'],
+        }
+        pi = _build_in_memory(data)
+        assert pi.later_therapies == [{'therapy': 'Bortezomib'}, {'therapy': 'Lenalidomide'}]
+
+    @pytest.mark.django_db
+    def test_bare_string_supportive_therapies_does_not_crash(self):
+        data = {
+            'disease': 'multiple myeloma',
+            'prior_therapy': 'More than two lines of therapy',
+            'supportive_therapies': ['Dexamethasone'],
+        }
+        pi = _build_in_memory(data)
+        assert pi.supportive_therapies == [{'therapy': 'Dexamethasone'}]
+
+    @pytest.mark.django_db
+    def test_non_dict_genetic_mutations_dropped(self):
+        data = {
+            'disease': 'multiple myeloma',
+            'genetic_mutations': [{'gene': 'tp53'}, 'TP53', None],
+        }
+        pi = _build_in_memory(data)
+        assert pi.genetic_mutations == [{'gene': 'tp53'}]

--- a/trials/services/patient_info/resolve.py
+++ b/trials/services/patient_info/resolve.py
@@ -49,6 +49,8 @@ def _build_in_memory(data: dict):
     _coerce_numerics(filtered, PatientInfo)
     # Coerce string-encoded lists/dicts for JSONField columns (CB can send "[{...}]" as str)
     _coerce_json_fields(filtered, PatientInfo)
+    # Enforce per-field item shape on JSON list fields downstream code iterates as dicts
+    _normalize_structured_json_fields(filtered)
 
     pi = PatientInfo(**filtered)
 
@@ -102,6 +104,35 @@ def _coerce_numerics(data: dict, model_cls):
                 data[f.name] = Decimal(val)
             except (InvalidOperation, TypeError):
                 data[f.name] = None
+
+
+def _normalize_structured_json_fields(data: dict):
+    """Enforce list-of-dicts shape on JSON fields whose consumers call `.get(...)` per item.
+
+    Bare-string items (legacy rows, malformed CTOMOP input) would otherwise crash
+    the matcher and trial-details renderer with `'str' object has no attribute 'get'`.
+    """
+    for key in ('later_therapies', 'supportive_therapies'):
+        val = data.get(key)
+        if val is None:
+            continue
+        if not isinstance(val, list):
+            data[key] = []
+            continue
+        coerced = []
+        for item in val:
+            if isinstance(item, dict):
+                coerced.append(item)
+            elif isinstance(item, str) and item.strip():
+                coerced.append({'therapy': item.strip()})
+        data[key] = coerced
+
+    val = data.get('genetic_mutations')
+    if val is not None:
+        if not isinstance(val, list):
+            data['genetic_mutations'] = []
+        else:
+            data['genetic_mutations'] = [item for item in val if isinstance(item, dict)]
 
 
 def _coerce_json_fields(data: dict, model_cls):


### PR DESCRIPTION
## Summary

- Fix `AttributeError: 'str' object has no attribute 'get'` in the matcher when `PatientInfo.later_therapies` / `supportive_therapies` contains bare-string items (observed in docker eval for `person_id=20258`).
- Add `_normalize_structured_json_fields` in `resolve.py:_build_in_memory` as a single chokepoint covering both the API path (`resolve_patient_info`) and the CTOMOP management commands (`search_trials_for_patients`, `fetch_exact_for_patients`).
- Coerce bare-string therapy items to `{"therapy": item}`, drop non-dict `genetic_mutations` items, collapse non-list values to `[]`.

## Why a central validator

Five call sites iterate these JSON list fields and call `.get(...)` per item without an `isinstance` check (`patient_info_attributes.get_user_therapies`, `stem_cell_transplant_history_from_therapy_lines`, `GeneticMutations.mutation_*`, `trial_attributes.get_mutation`). Centralizing the shape invariant in `_build_in_memory` fixes all five at once instead of patching each consumer.

Codex review flagged a regression in an earlier draft (the `val = [val] if val else []` fallback in the two CTOMOP commands was load-bearing for scalar `stem_cell_transplant_history` strings like `'completedASCT'`). That fallback was preserved; the central validator carries the entire fix.

## Test plan

- [x] 12 pure-function unit tests for `_normalize_structured_json_fields` (dicts pass through, strings coerced, non-list collapses, empty-string items dropped, unrelated keys untouched, etc.) — verified locally
- [ ] 3 `@pytest.mark.django_db` regression tests through `_build_in_memory` exercising the original crash path (later_therapies / supportive_therapies / genetic_mutations) — will run in CI
- [ ] Existing test suite passes in CI (local env has unrelated GDAL + DB-permission issues)
- [ ] Re-run docker eval for `person_id=20258` after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)