### PR TITLE
fix: harden docker eval pipeline against script-level failures (#47)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -20,6 +20,7 @@ jobs:
           type=sha,format=long
           type=ref,event=branch
           type=ref,event=tag
+          type=raw,value=latest,enable={{is_default_branch}}
 
     - name: Login to Docker Registry
       uses: docker/login-action@v3

--- a/tests/management/test_normalize_ctomop_row.py
+++ b/tests/management/test_normalize_ctomop_row.py
@@ -74,6 +74,11 @@ class TestStageNormalization:
     def test_roman_numeral_without_suffix_unchanged(self):
         assert _normalize_ctomop_row(_row(stage='IV'))['stage'] == 'IV'
 
+    def test_non_string_stage_does_not_crash(self):
+        # Defends re.sub against unexpected int/None coming from upstream
+        assert _normalize_ctomop_row(_row(stage=4))['stage'] == 4
+        assert _normalize_ctomop_row(_row(stage=None))['stage'] is None
+
     def test_stage_i_unchanged(self):
         assert _normalize_ctomop_row(_row(stage='I'))['stage'] == 'I'
 
@@ -260,6 +265,14 @@ class TestGeneticMutationsNormalization:
         row = _row(genetic_mutations=['some_string'])
         assert _normalize_ctomop_row(row)['genetic_mutations'] == ['some_string']
 
+    def test_non_string_gene_does_not_crash(self):
+        # Defends .lower() against numeric/None values that slipped through CTOMOP
+        row = _row(genetic_mutations=[{'gene': 1234, 'interpretation': None, 'origin': 42}])
+        result = _normalize_ctomop_row(row)['genetic_mutations'][0]
+        assert result['gene'] == 1234
+        assert result['interpretation'] is None
+        assert result['origin'] == 42
+
 
 # ---------------------------------------------------------------------------
 # Lab value fallbacks — CTOMOP renamed columns
@@ -321,6 +334,11 @@ class TestGenderNormalization:
     def test_existing_gender_not_overridden(self):
         result = _normalize_ctomop_row(_row(gender='F', gender_source_value='M'))
         assert result['gender'] == 'F'
+
+    def test_non_string_gender_source_value_does_not_crash(self):
+        # Defends .lower() against int gender_source_value (concept-id fallback used)
+        result = _normalize_ctomop_row(_row(gender_source_value=8507, gender_concept_id=8507))
+        assert result['gender'] == 'M'
 
 
 # ---------------------------------------------------------------------------

--- a/tests/management/test_search_trials_command.py
+++ b/tests/management/test_search_trials_command.py
@@ -1,0 +1,107 @@
+"""
+Tests for script-level robustness of `search_trials_for_patients`.
+
+Guards three regressions that would cause `scripts/trials4patients.sh` to fail
+silently or with a confusing downstream error:
+
+- patient DB fetch failure → CommandError (non-zero exit, shell stops)
+- trials DB reference-lookup failure → CommandError before the per-patient loop
+- non-JSON psql stdout lines → logged and skipped, not crash the script
+"""
+from subprocess import CompletedProcess
+from unittest.mock import patch
+
+import pytest
+from django.core.management import call_command
+from django.core.management.base import CommandError
+
+
+# ---------------------------------------------------------------------------
+# Fixture: shared --source-db-url avoids the "no URL" branch in handle()
+# ---------------------------------------------------------------------------
+
+_SOURCE_DB_URL = 'postgresql://test:test@host:5432/patients'
+
+
+@pytest.fixture
+def mock_lookup_ok():
+    """_build_code_lookup returns immediately — no real DB hit."""
+    with patch('trials.management.commands.search_trials_for_patients._build_code_lookup', return_value={'_therapy': {}}):
+        yield
+
+
+# ---------------------------------------------------------------------------
+# Fix 1 — _fetch_via_db returning None must raise CommandError
+# ---------------------------------------------------------------------------
+
+class TestFetchFailureExits:
+    def test_psql_nonzero_returncode_raises_command_error(self, mock_lookup_ok):
+        with patch('shutil.which', return_value='/usr/bin/psql'), \
+             patch('subprocess.run', return_value=CompletedProcess([], 1, '', 'connection refused')):
+            with pytest.raises(CommandError, match='Patient DB fetch failed'):
+                call_command('search_trials_for_patients', f'--source-db-url={_SOURCE_DB_URL}')
+
+    def test_psql_subprocess_exception_raises_command_error(self, mock_lookup_ok):
+        with patch('shutil.which', return_value='/usr/bin/psql'), \
+             patch('subprocess.run', side_effect=OSError('psql binary missing')):
+            with pytest.raises(CommandError, match='Patient DB fetch failed'):
+                call_command('search_trials_for_patients', f'--source-db-url={_SOURCE_DB_URL}')
+
+    def test_psql_not_in_path_raises_command_error(self, mock_lookup_ok):
+        with patch('shutil.which', return_value=None):
+            with pytest.raises(CommandError, match='Patient DB fetch failed'):
+                call_command('search_trials_for_patients', f'--source-db-url={_SOURCE_DB_URL}')
+
+
+# ---------------------------------------------------------------------------
+# Fix 3 — _build_code_lookup failure must raise CommandError before the loop
+# ---------------------------------------------------------------------------
+
+class TestReferenceLookupFailureExits:
+    def test_lookup_db_error_raises_command_error_with_context(self):
+        with patch(
+            'trials.management.commands.search_trials_for_patients._build_code_lookup',
+            side_effect=Exception('could not connect to trials DB'),
+        ):
+            with pytest.raises(CommandError, match='Trials DB reference lookup failed'):
+                call_command('search_trials_for_patients', f'--source-db-url={_SOURCE_DB_URL}')
+
+    def test_dry_run_skips_lookup_so_trials_db_outage_does_not_block_inspection(self):
+        # --dry-run only inspects the raw row from CTOMOP; it must not trip the
+        # trials DB lookup, so a sysadmin can debug patient data without trials DB.
+        stdout = '{"person_id": 1, "disease": "multiple myeloma"}\n'
+        with patch(
+            'trials.management.commands.search_trials_for_patients._build_code_lookup',
+            side_effect=Exception('trials DB offline'),
+        ), patch('shutil.which', return_value='/usr/bin/psql'), \
+             patch('subprocess.run', return_value=CompletedProcess([], 0, stdout, '')):
+            # No exception expected — dry-run prints and returns
+            call_command(
+                'search_trials_for_patients',
+                f'--source-db-url={_SOURCE_DB_URL}',
+                '--dry-run',
+            )
+
+
+# ---------------------------------------------------------------------------
+# Fix 2 — bad psql stdout lines are skipped with a warning, not crash
+# ---------------------------------------------------------------------------
+
+class TestPsqlStdoutToleratesNonJson:
+    def test_non_json_lines_skipped_and_valid_json_returned(self, mock_lookup_ok, capsys):
+        stdout = (
+            'NOTICE: connection encrypted via libssl\n'
+            '\n'
+            '{"person_id": 1, "disease": null}\n'
+            'garbage <not json> line\n'
+            '{"person_id": 2, "disease": null}\n'
+        )
+        with patch('shutil.which', return_value='/usr/bin/psql'), \
+             patch('subprocess.run', return_value=CompletedProcess([], 0, stdout, '')):
+            # Both rows have disease=None so per-patient loop skips them; the
+            # command should complete cleanly without exception.
+            call_command('search_trials_for_patients', f'--source-db-url={_SOURCE_DB_URL}')
+
+        captured = capsys.readouterr()
+        # Warning surfaces to stderr — operator sees the skipped lines
+        assert 'Skipped 2 non-JSON line' in captured.err

--- a/trials/management/commands/fetch_exact_for_patients.py
+++ b/trials/management/commands/fetch_exact_for_patients.py
@@ -31,6 +31,7 @@ Options
 import json
 import logging
 import os
+import sys
 from datetime import date
 from decimal import Decimal
 
@@ -72,10 +73,18 @@ def _psql_query_rows(db_url, sql):
     if result.returncode != 0:
         raise RuntimeError(f'psql error: {result.stderr.strip()}')
     rows = []
+    skipped = 0
     for line in result.stdout.splitlines():
         line = line.strip()
-        if line:
+        if not line:
+            continue
+        try:
             rows.append(json.loads(line))
+        except json.JSONDecodeError as exc:
+            skipped += 1
+            logger.warning('Skipping non-JSON line from psql: %.80s — %s', line, exc)
+    if skipped:
+        print(f'  Skipped {skipped} non-JSON line(s) from psql output.', file=sys.stderr)
     return rows
 
 

--- a/trials/management/commands/search_trials_for_patients.py
+++ b/trials/management/commands/search_trials_for_patients.py
@@ -38,7 +38,7 @@ from datetime import date
 from decimal import Decimal
 from functools import lru_cache
 
-from django.core.management.base import BaseCommand
+from django.core.management.base import BaseCommand, CommandError
 from trials.services.user_to_trial_attr_matcher import UserToTrialAttrMatcher
 
 
@@ -341,7 +341,7 @@ def _normalize_ctomop_row(row: dict) -> dict:
 
     # ── Stage — strip trailing sub-stage letter (IIA → II, IIIB → III) ─
     stage = row.get('stage')
-    if stage:
+    if isinstance(stage, str) and stage:
         row['stage'] = re.sub(r'[A-C]$', '', stage)
 
     # ── Therapy line outcomes — map full-text labels to abbreviated IDs ──────────
@@ -368,11 +368,11 @@ def _normalize_ctomop_row(row: dict) -> dict:
                 normalized.append(m)
                 continue
             m = dict(m)
-            if m.get('gene'):
+            if isinstance(m.get('gene'), str):
                 m['gene'] = m['gene'].lower()
-            if m.get('interpretation'):
+            if isinstance(m.get('interpretation'), str):
                 m['interpretation'] = m['interpretation'].lower().replace(' ', '_')
-            if m.get('origin'):
+            if isinstance(m.get('origin'), str):
                 raw_origin = m['origin'].lower()
                 m['origin'] = raw_origin if raw_origin in ('somatic', 'germline') else None
             # Rename 'mutation' → 'variant' and normalize to EXACT code format
@@ -461,9 +461,9 @@ def _normalize_ctomop_row(row: dict) -> dict:
         gsv = row.get('gender_source_value', '')
         if gsv in ('M', 'F'):
             row['gender'] = gsv
-        elif gsv and gsv.lower().startswith('m'):
+        elif isinstance(gsv, str) and gsv.lower().startswith('m'):
             row['gender'] = 'M'
-        elif gsv and gsv.lower().startswith('f'):
+        elif isinstance(gsv, str) and gsv.lower().startswith('f'):
             row['gender'] = 'F'
         else:
             gci = row.get('gender_concept_id')
@@ -710,10 +710,20 @@ class Command(BaseCommand):
         if options['person_ids']:
             person_ids = [int(x.strip()) for x in options['person_ids'].split(',') if x.strip()]
 
+        # Pre-warm the reference DB lookup so a connection/permission failure
+        # surfaces as a single clear error instead of N identical per-patient
+        # exceptions inside the loop. Skipped for --dry-run, which only inspects
+        # the raw row and doesn't call _normalize_ctomop_row.
+        if not options['dry_run']:
+            try:
+                _build_code_lookup()
+            except Exception as exc:
+                raise CommandError(f'Trials DB reference lookup failed: {exc}')
+
         rows = self._fetch_via_db(options, person_ids)
 
         if rows is None:
-            return  # error already reported
+            raise CommandError('Patient DB fetch failed — see error above.')
 
         all_results = []
         processed = 0
@@ -840,10 +850,20 @@ class Command(BaseCommand):
             return None
 
         rows = []
+        skipped = 0
         for line in result.stdout.splitlines():
             line = line.strip()
-            if line:
+            if not line:
+                continue
+            try:
                 rows.append(json.loads(line))
+            except json.JSONDecodeError as exc:
+                skipped += 1
+                logger.warning('Skipping non-JSON line from psql: %.80s — %s', line, exc)
+        if skipped:
+            self.stderr.write(self.style.WARNING(
+                f'  Skipped {skipped} non-JSON line(s) from psql output.'
+            ))
 
         return rows
 


### PR DESCRIPTION
Closes #47

## What was actually wrong

Verified live against the Harvard trials DB + ctomop.render.com patient DB (env file from #47 comment):

| Tag | Last pushed | Behavior on `person_id=20258` |
|---|---|---|
| `cancerbot/exact:latest` | 2026-04-16 | **AttributeError 'str' object has no attribute 'get'** — exact #47 repro |
| `cancerbot/exact:dev` / `:main` | 2026-05-21 (after PR #46) | 101 patients, 0 errors |

**Root cause:** PR #46 fixed the crash but `:latest` was never re-tagged. CI workflow `docker.yml` only emits SHA / branch / tag refs — no `:latest`.

## Changes

### CI — `latest` auto-tag (`.github/workflows/docker.yml`)
Add `type=raw,value=latest,enable={{is_default_branch}}` so every push to `main` re-tags `:latest`. One-line change; still needs a one-time manual republish to backfill.

### `search_trials_for_patients.py`

Beyond PR #46, three script-level failure modes still silently swallowed errors. Codex-paired audit + verified live in docker:

| Scenario | Before | After |
|---|---|---|
| Bad `PATIENT_DATABASE_URL` | exit 0, no JSON written, `trials4patients.sh` step 3 then `FileNotFoundError` | exit 1, `CommandError: Patient DB fetch failed` |
| Bad `TRIALS_DATABASE_URL` | exit 0, every patient errors with `OperationalError` | exit 1, single clean `CommandError: Trials DB reference lookup failed: <reason>` |
| psql stdout has notice/warning lines | uncaught `JSONDecodeError`, script aborts | logged + skipped count surfaced to stderr |
| Non-string `stage` / `gene` / `interpretation` / `origin` / `gender_source_value` | per-patient `.lower()` / `re.sub` crash | guarded with `isinstance(val, str)` |

The lookup pre-warm is skipped when `--dry-run` so patient-row inspection works even with trials DB down (codex review caught this in pass 2).

### `fetch_exact_for_patients.py`
Same defensive `json.loads` pattern with operator-visible skipped count.

### Tests

- `tests/management/test_search_trials_command.py` — new file. Covers: fetch failure → CommandError, lookup failure → CommandError, dry-run skips lookup pre-warm, non-JSON psql output skipped (not crash).
- `tests/management/test_normalize_ctomop_row.py` — 3 new cases for the isinstance guards.

## Verification (live, against real DBs)

- 101 patients on `exact:fix-issue47` (this branch): 0 errors, exit 0 (no regression vs `:dev`).
- Bad patient URL: exit 1 with clear message ✓
- Bad trials URL: exit 1 with clear message ✓

## Post-merge action

Manually republish `cancerbot/exact:latest` once to backfill — the CI change will keep it fresh going forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)