### PR TITLE
fix: port 5 correctness fixes from CancerBot matcher

### DIFF
--- a/trials/querysets/trial.py
+++ b/trials/querysets/trial.py
@@ -21,6 +21,7 @@ from trials.services.patient_info.configs import (
     USER_TO_TRIAL_ATTRS_MAPPING,
     THERAPY_LINES_ATTRS_UNDERSCORED,
     ATTR_MAPPING_TYPE_COMPUTED, SCT_HISTORY_EXCLUDED_MAPPING,
+    sct_value_is_none,
 )
 from trials.services.patient_info.genetic_mutations import GeneticMutations
 from trials.services.patient_info.patient_info_flipi_score import PatientInfoFlipyScore
@@ -914,7 +915,10 @@ class TrialQuerySet(models.QuerySet):
         if stem_cell_transplant_history is None or str(stem_cell_transplant_history) == '':
             return self
 
-        if str(stem_cell_transplant_history).lower() == 'none':
+        # See sct_value_is_none() — tolerates both storage shapes
+        # ('None' bare string from signal cleanup; ['None'] list from
+        # the multiselect) and whitespace/casing variants (#4333, #4340).
+        if sct_value_is_none(stem_cell_transplant_history):
             return self.exclude(stem_cell_transplant_history_required=True)
 
         if not isinstance(stem_cell_transplant_history, (list, tuple)):
@@ -1187,12 +1191,14 @@ class TrialQuerySet(models.QuerySet):
             else:
                 user_attr_type = type(patient_info.__class__._meta.get_field(user_attr))
 
-            if user_attr_type in ['int', models.fields.IntegerField] and user_attr_value == 0:
-                continue
-            if user_attr_type in ['float', models.fields.DecimalField] and user_attr_value == 0.0:
-                continue
-            if user_attr_type in ['float', models.fields.FloatField] and user_attr_value == 0.0:
-                continue
+            allow_blank_values = trial_attr_meta.get("allow_blank_values", False)
+            if not allow_blank_values:
+                if user_attr_type in ['int', models.fields.IntegerField] and user_attr_value == 0:
+                    continue
+                if user_attr_type in ['float', models.fields.DecimalField] and user_attr_value == 0.0:
+                    continue
+                if user_attr_type in ['float', models.fields.FloatField] and user_attr_value == 0.0:
+                    continue
 
             # do the search now
             trial_attr_name = trial_attr_meta["attr"]
@@ -1339,14 +1345,14 @@ class TrialQuerySet(models.QuerySet):
                     attr_min_name = trial_attr_meta["attr_min"]
                 else:
                     attr_min_name = f'{trial_attr_meta["attr"]}_min'
-                scope = scope.eligible_for_min_max_value(attr_min_name, None, user_attr_value)
+                scope = scope.eligible_for_min_max_value(attr_min_name, None, user_attr_value, skip_blank=not allow_blank_values)
 
             elif trial_attr_meta["type"] == "max_value":
                 if 'attr_max' in trial_attr_meta:
                     attr_max_name = trial_attr_meta["attr_max"]
                 else:
                     attr_max_name = f'{trial_attr_meta["attr"]}_max'
-                scope = scope.eligible_for_min_max_value(None, attr_max_name, user_attr_value)
+                scope = scope.eligible_for_min_max_value(None, attr_max_name, user_attr_value, skip_blank=not allow_blank_values)
 
             elif trial_attr_meta["type"] == "min_max_value":
                 if "attr_min" in trial_attr_meta:
@@ -1357,7 +1363,7 @@ class TrialQuerySet(models.QuerySet):
                     attr_max_name = trial_attr_meta["attr_max"]
                 else:
                     attr_max_name = f'{trial_attr_meta["attr"]}_max'
-                scope = scope.eligible_for_min_max_value(attr_min_name, attr_max_name, user_attr_value)
+                scope = scope.eligible_for_min_max_value(attr_min_name, attr_max_name, user_attr_value, skip_blank=not allow_blank_values)
 
                 user_attr_value_uln = patient_info_attr.get_uln_value(user_attr)
                 if user_attr_value_uln:

--- a/trials/services/patient_info/configs.py
+++ b/trials/services/patient_info/configs.py
@@ -64,6 +64,32 @@ SCT_HISTORY_EXCLUDED_MAPPING = {
     'completedAllogeneicSCT': ['priorAllogeneicSCT']
 }
 
+
+def sct_value_is_none(value):
+    """True iff `value` represents "no SCT history", tolerant to shape.
+
+    `stem_cell_transplant_history` is stored as a JSONField but two
+    canonical "no SCT" shapes coexist:
+      - bare string `'None'`  (signal cleanup at trials/signals.py:105)
+      - one-element list `['None']`  (user picked "None" from the
+        multiselect on the form)
+
+    Defensive against whitespace + casing drift on either shape so that
+    `[' None ']`, `['none']`, `'NONE'`, etc. all match — preventing the
+    silent require-SCT match regression class (#4333) from returning
+    under casing/whitespace variants (#4340).
+
+    Python `None` is rejected: it means "patient hasn't answered"
+    (Unknown), which is semantically distinct from the explicit "None"
+    answer.
+    """
+    if value is None:
+        return False
+    if isinstance(value, (list, tuple)):
+        return len(value) == 1 and str(value[0]).strip().lower() == 'none'
+    return str(value).strip().lower() == 'none'
+
+
 TRIAL_ATTRS_JSON_AS_A_LIST = (
     "planned_therapies_required",
     "planned_therapies_excluded",
@@ -189,6 +215,7 @@ USER_TO_TRIAL_ATTRS_MAPPING = {
     "karnofsky_performance_score": {
         "type": "min_max_value",
         "searchable": True,
+        "allow_blank_values": True,
         "attr": "karnofsky_performance_score",
     },
     "ecog_performance_status": {
@@ -211,6 +238,7 @@ USER_TO_TRIAL_ATTRS_MAPPING = {
     "peripheral_neuropathy_grade": {
         "type": "min_max_value",
         "searchable": True,
+        "allow_blank_values": True,
         "attr": "peripheral_neuropathy_grade",
     },
 
@@ -258,6 +286,7 @@ USER_TO_TRIAL_ATTRS_MAPPING = {
         "disease": "MM",
         "searchable": True,
         "is_computed_value": True,
+        "under_user_control": True,
         "attr": "measurable_disease_imwg_required",
     },
     # MM-specific END
@@ -923,7 +952,7 @@ USER_TO_TRIAL_ATTRS_MAPPING = {
         "type": "bool_restriction",
         "searchable": True,
         "is_computed_value": True,
-        # "under_user_control": True,
+        "under_user_control": True,
         "attr": "meets_slim",
     },
     # "meets_lugano": {

--- a/trials/services/patient_info/normalize.py
+++ b/trials/services/patient_info/normalize.py
@@ -202,10 +202,16 @@ def _normalize_measurable_disease_imwg(pi) -> None:
             return False
         return pi.kappa_flc >= 100 or pi.lambda_flc >= 100
 
-    for component in [serum_m_protein_high(), serum_m_urine_high(), kappa_lambda_abnormal_and_high()]:
+    components = [serum_m_protein_high(), serum_m_urine_high(), kappa_lambda_abnormal_and_high()]
+    for component in components:
         if component is True:
             pi.measurable_disease_imwg = True
             return
+    # All components None → no relevant lab data, result is unknown.
+    # Avoids the "shows No by default" UX bug (#4143 / #4156).
+    if all(c is None for c in components):
+        pi.measurable_disease_imwg = None
+        return
     pi.measurable_disease_imwg = False
 
 

--- a/trials/services/patient_info/patient_info_attributes.py
+++ b/trials/services/patient_info/patient_info_attributes.py
@@ -325,6 +325,11 @@ class PatientInfoAttributes:
             if component is True:
                 return True
 
+        # All components None → no relevant lab data, result is unknown.
+        # Avoids the "shows No by default" UX bug (#4143 / #4156).
+        if all(c is None for c in components):
+            return None
+
         return False
 
     @cached_property

--- a/trials/services/user_to_trial_attr_matcher.py
+++ b/trials/services/user_to_trial_attr_matcher.py
@@ -6,6 +6,7 @@ from trials.services.patient_info.configs import (
     USER_TO_TRIAL_ATTRS_MAPPING,
     THERAPY_LINES_ATTRS_UNDERSCORED,
     ATTR_MAPPING_TYPE_COMPUTED, SCT_HISTORY_EXCLUDED_MAPPING,
+    sct_value_is_none,
 )
 from trials.services.patient_info.genetic_mutations import GeneticMutations
 from trials.services.patient_info.patient_info_attributes import PatientInfoAttributes
@@ -265,23 +266,26 @@ class UserToTrialAttrMatcher:
                 trial_attr_sct_history_required = getattr(self.trial, 'stem_cell_transplant_history_required')
                 trial_attr_sct_history_excluded = getattr(self.trial, 'stem_cell_transplant_history_excluded')
 
-                user_has_sct = str(patient_info_attr_value).lower() == 'none'
+                # See sct_value_is_none() — tolerates both storage shapes
+                # ('None' bare string from signal cleanup; ['None'] list
+                # from the multiselect) and whitespace/casing variants
+                # (#4333, #4340).
+                user_has_no_sct = sct_value_is_none(patient_info_attr_value)
                 if not trial_attr_sct_history_required and not trial_attr_sct_history_excluded:
                     return 'matched'
 
                 if patient_info_attr_is_blank:
                     return 'unknown'
 
-                if trial_attr_sct_history_required and user_has_sct:
+                if trial_attr_sct_history_required and user_has_no_sct:
                     return 'not_matched'
 
                 def has_mapped_items(pi_vals, excluded_list):
                     mapped_items = []
+                    if sct_value_is_none(pi_vals):
+                        return False
                     if not isinstance(pi_vals, (list, tuple)):
                         pi_vals = [pi_vals]
-
-                    if pi_vals == ['None']:
-                        return False
 
                     for pi_val in pi_vals:
                         for rec in SCT_HISTORY_EXCLUDED_MAPPING.get(pi_val, [pi_val]):
@@ -390,7 +394,8 @@ class UserToTrialAttrMatcher:
                 if trial_attr_active_required is not True and trial_attr_smoldering_required is not True:
                     return 'matched'
 
-                if patient_info_attr_value is None:
+                # "Unknown" is sent from the UI as an empty string (see ValueOptions.progressions)
+                if patient_info_attr_value is None or patient_info_attr_value == '':
                     return 'unknown'
 
                 if patient_info_attr_value == 'active' and trial_attr_smoldering_required is not True:


### PR DESCRIPTION
## Summary

Ports the recommended starter batch of CB→EXACT correctness fixes (per `cb_to_exact_port_reference.md`).

All five fixes affect matcher output:

| # | Fix | CB ref |
|---|---|---|
| #50 | SCT `'None'` list-form not recognized + `sct_value_is_none()` helper + rename `user_has_sct` → `user_has_no_sct` + Karnofsky 0 | #4333, #4340, #4339 |
| #51 | `relapse_count=0` treated as blank in eligibility filter | #4186 |
| #52 | empty-string progression treated as Unknown | #4306 |
| #53 | Grade 0 peripheral_neuropathy_grade not matched | #4307 |
| #54 | `meets_slim` / `measurable_disease_imwg` shown as Ineligible instead of Potential | #4143 / #4156 |

Closes #50, #51, #52, #53, #54.

## Files changed (5)

- `trials/services/user_to_trial_attr_matcher.py` — #50 (rename + helper use), #52 (empty-string check)
- `trials/querysets/trial.py` — #50 (helper use), #51 (allow_blank_values plumbing)
- `trials/services/patient_info/configs.py` — #50 (helper definition + Karnofsky flag), #53 (Grade 0 flag), #54 (under_user_control flags)
- `trials/services/patient_info/patient_info_attributes.py` — #54 (None when all IMWG components None)
- `trials/services/patient_info/normalize.py` — #54 (same fix in the parallel normalize path; EXACT has both)

Total: +69 / -18.

## Notes on test coverage

CB's mirrored tests rely on the Django PatientInfo model + signal recompute path. EXACT's `PatientInfo` is a stateless Python class with a different fixture shape (see `cb_to_exact_port_reference.md`), so tests need to be re-shaped rather than copied. Filing as a follow-up.

The CI test suite in this repo should still catch any regression in the matcher/queryset behaviour the fixes touch — please verify the green build before merging.

## Test plan

- [ ] CI matcher + queryset test groups pass
- [ ] No drift in CI test snapshots (matchScore / counts)
- [ ] Follow-up: port CB regression tests adapted for EXACT's stateless PatientInfo

🤖 Generated with [Claude Code](https://claude.com/claude-code)