### PR TITLE
fix: port 7 dropdown/display fixes from CancerBot

### DIFF
--- a/tests/services/trial_details/test_trial_templates.py
+++ b/tests/services/trial_details/test_trial_templates.py
@@ -209,9 +209,11 @@ class TestTrialTemplates:
 
     @pytest.mark.django_db
     def test_potential_attributes_first_view_having_select_potential(self, patient_info):
-        t1 = TrialFactory(tumor_grade_min=20, tumor_grade_max=40)
+        # Grade 4 (40) was removed from the FL Tumor Grade dropdown — use
+        # Grade 3B (32) as the max-bound fixture value instead.
+        t1 = TrialFactory(tumor_grade_min=20, tumor_grade_max=32)
         t2 = TrialFactory(tumor_grade_min=20, tumor_grade_max=None)
-        t3 = TrialFactory(tumor_grade_min=None, tumor_grade_max=40)
+        t3 = TrialFactory(tumor_grade_min=None, tumor_grade_max=32)
         t4 = TrialFactory(tumor_grade_min=None, tumor_grade_max=None)
 
         pi = patient_info
@@ -224,7 +226,7 @@ class TestTrialTemplates:
             'name': 'tumorGrade',
             'label': 'Tumor Grade Range',
             'type': 'string',
-            'value': 'Grade 2 - Grade 4',
+            'value': 'Grade 2 - Grade 3B',
             'options': None,
             'ufield': 'tumorGrade',
             'uvalue': None,
@@ -236,7 +238,6 @@ class TestTrialTemplates:
                 {'value': '30', 'label': 'Grade 3'},
                 {'value': '31', 'label': 'Grade 3A'},
                 {'value': '32', 'label': 'Grade 3B'},
-                {'value': '40', 'label': 'Grade 4'}
             ], 'dependencies': [],
             'ureadonly': False,
             'matchingType': 'unknown'
@@ -260,7 +261,6 @@ class TestTrialTemplates:
                 {'value': '30', 'label': 'Grade 3'},
                 {'value': '31', 'label': 'Grade 3A'},
                 {'value': '32', 'label': 'Grade 3B'},
-                {'value': '40', 'label': 'Grade 4'}
             ], 'dependencies': [],
             'ureadonly': False,
             'matchingType': 'unknown'
@@ -272,7 +272,7 @@ class TestTrialTemplates:
             'name': 'tumorGradeMax',
             'label': 'Tumor Grade Maximum',
             'type': 'string',
-            'value': 'Grade 4',
+            'value': 'Grade 3B',
             'options': None,
             'ufield': 'tumorGrade',
             'uvalue': None,
@@ -284,7 +284,6 @@ class TestTrialTemplates:
                 {'value': '30', 'label': 'Grade 3'},
                 {'value': '31', 'label': 'Grade 3A'},
                 {'value': '32', 'label': 'Grade 3B'},
-                {'value': '40', 'label': 'Grade 4'}
             ], 'dependencies': [],
             'ureadonly': False,
             'matchingType': 'unknown'

--- a/trials/services/trial_details/trial_attributes.py
+++ b/trials/services/trial_details/trial_attributes.py
@@ -57,9 +57,13 @@ class TrialAttributes:
         self.all_options['mutationOriginsRequired'] = self.all_options['geneticMutationAllOrigins']
         self.all_options['mutationInterpretationsRequired'] = self.all_options['geneticMutationAllInterpretations']
 
-        self.all_options['firstLineOutcome'] = self.all_options['therapyOutcome']
-        self.all_options['secondLineOutcome'] = self.all_options['therapyOutcome']
-        self.all_options['laterOutcome'] = self.all_options['therapyOutcome']
+        # Per #4137 the treatment-outcome dropdown is disease-aware: BC drops
+        # the MM-specific IMWG categories (sCR / VGPR / MRD). Other diseases
+        # still see the full enum.
+        outcome_options_key = self._therapy_outcome_options_key()
+        self.all_options['firstLineOutcome'] = self.all_options[outcome_options_key]
+        self.all_options['secondLineOutcome'] = self.all_options[outcome_options_key]
+        self.all_options['laterOutcome'] = self.all_options[outcome_options_key]
         self.all_options['preExistingConditionsExcluded'] = self.all_options['preExistingConditionCategories']
         self.all_options['therapyTypesRequired'] = self.all_options['therapyTypesAll']
         self.all_options['therapyTypesExcluded'] = self.all_options['therapyTypesAll']
@@ -147,6 +151,22 @@ class TrialAttributes:
         for k, v in self.all_options.items():
             self._all_value_options[k] = v
             self._all_value_options[f'u{k}'] = v
+
+    # Map PatientInfo.disease (title, lowercased) → the per-disease therapy
+    # outcomes options key in all_options. Diseases not listed here fall back
+    # to the union `therapyOutcome` key.
+    _DISEASE_TO_OUTCOME_KEY = {
+        'multiple myeloma': 'therapyOutcomeMm',
+        'follicular lymphoma': 'therapyOutcomeFl',
+        'breast cancer': 'therapyOutcomeBc',
+        'chronic lymphocytic leukemia': 'therapyOutcomeCll',
+    }
+
+    def _therapy_outcome_options_key(self):
+        if not self._patient_info:
+            return 'therapyOutcome'
+        disease = (self._patient_info.disease or '').lower()
+        return self._DISEASE_TO_OUTCOME_KEY.get(disease, 'therapyOutcome')
 
     def get_context_from_user(self):
         out = {}

--- a/trials/services/value_options.py
+++ b/trials/services/value_options.py
@@ -234,7 +234,6 @@ class ValueOptions:
             '30': 'Grade 3',
             '31': 'Grade 3A',
             '32': 'Grade 3B',
-            '40': 'Grade 4',
         }
 
     @property
@@ -256,7 +255,7 @@ class ValueOptions:
     def planned_therapies(self, disease_code):
         from trials.models import PlannedTherapy
         items = PlannedTherapy.objects.filter(plannedtherapydiseaseconnection__disease__code__in=[disease_code.lower(), disease_code.upper()]).order_by('id')
-        return {x.code: x.title for x in items}
+        return {'none': 'No planned therapy', **{x.code: x.title for x in items}}
 
     @property
     def cytogenic_markers(self):
@@ -265,7 +264,7 @@ class ValueOptions:
         category = MarkerCategory.objects.get(code='cytogenic')
         markers = Marker.objects.filter(categories=category).order_by('id')
 
-        return {x.code: x.title for x in markers}
+        return {'none': 'None', **{x.code: x.title for x in markers}}
 
     @property
     def molecular_markers(self):
@@ -274,7 +273,7 @@ class ValueOptions:
         category = MarkerCategory.objects.get(code='molecular')
         markers = Marker.objects.filter(categories=category).order_by('id')
 
-        return {x.code: x.title for x in markers}
+        return {'none': 'None', **{x.code: x.title for x in markers}}
 
     @property
     def gelf_criteria_statuses(self):
@@ -338,6 +337,7 @@ class ValueOptions:
             "1": "1",
             "2": "2",
             "3": "3",
+            "4": "4",
         }
 
     @property
@@ -378,6 +378,25 @@ class ValueOptions:
             'PD': 'Progressive Disease (PD)',
         }
 
+    def therapy_outcomes_by_disease_code(self, disease_code):
+        """Return the clinically-applicable treatment outcomes per disease.
+
+        Per #4137: Breast Cancer doesn't use IMWG-derived categories
+        (sCR / VGPR / MRD) — those are MM-specific. BC patients should see
+        only CR / PR / SD / PD. All other diseases keep the full enum
+        until product asks otherwise.
+        """
+        bc_outcomes = {
+            'CR': self.therapy_outcomes['CR'],
+            'PR': self.therapy_outcomes['PR'],
+            'SD': self.therapy_outcomes['SD'],
+            'PD': self.therapy_outcomes['PD'],
+        }
+        per_disease = {
+            'BC': bc_outcomes,
+        }
+        return per_disease.get((disease_code or '').upper(), self.therapy_outcomes)
+
     @property
     def ethnicities(self):
         from trials.models import Ethnicity
@@ -387,12 +406,12 @@ class ValueOptions:
     @property
     def peripheral_neuropathy_grades(self):
         return {
-            '': 'None',
+            '': 'Unknown',
+            '0': 'Grade 0',
             '1': 'Grade 1',
             '2': 'Grade 2',
             '3': 'Grade 3',
             '4': 'Grade 4',
-            '5': 'Grade 5',
         }
 
     @property
@@ -751,6 +770,20 @@ class ValueOptions:
             },
             'therapyOutcome': {
                 'options': self.to_value_and_label(self.therapy_outcomes)
+            },
+            # Per-disease outcome enums (#4137). Keep `therapyOutcome` above as
+            # the union for back-compat with callers that haven't been updated.
+            'therapyOutcomeMm': {
+                'options': self.to_value_and_label(self.therapy_outcomes_by_disease_code('MM'))
+            },
+            'therapyOutcomeFl': {
+                'options': self.to_value_and_label(self.therapy_outcomes_by_disease_code('FL'))
+            },
+            'therapyOutcomeBc': {
+                'options': self.to_value_and_label(self.therapy_outcomes_by_disease_code('BC'))
+            },
+            'therapyOutcomeCll': {
+                'options': self.to_value_and_label(self.therapy_outcomes_by_disease_code('CLL'))
             },
             'ethnicity': {
                 'options': self.to_value_and_label(self.ethnicities)


### PR DESCRIPTION
## Summary

Ports the CB→EXACT display batch (per `cb_to_exact_port_reference.md`).

7 fixes, mostly one-liners in `value_options.py`. The biggest (#60) adds a small disease-aware aliasing layer in `trial_attributes.py`.

| # | Fix | CB ref |
|---|---|---|
| #55 | ECOG=4 missing from dropdown | `fa77c97b` |
| #56 | Remove Tumor Grade 4 (FL) | `a8fd82c2` |
| #57 | Remove Peripheral Neuropathy Grade 5 | `887be4d9` |
| #58 | Add 'None' to molecular/cytogenic markers | #4216 (`05fba563`) |
| #59 | Add Grade 0 + relabel '' as Unknown in peripheralNeuropathyGrade | #4307 (`4ad80a1f`) |
| #60 | BC treatment outcome dropdown is CR/PR/SD/PD only | #4137 (`383bc946`) |
| #61 | Add 'No planned therapy' option | `33f7525a` |

Closes #55, #56, #57, #58, #59, #60, #61.

## Files (2)

- `trials/services/value_options.py` — 6 of the 7 fixes
- `trials/services/trial_details/trial_attributes.py` — #60 aliasing helper

Total: +62 / -9. #57 and #59 share the same dict and were folded into one edit.

## Note on MCL

CB's #60 also adds `therapyOutcomeMcl` to `all_options()`. EXACT doesn't support MCL yet (tracked in #36), so MCL is omitted here and will be added with the MCL foundation work.

## Test plan

- [ ] CI matcher / queryset / form_settings groups pass
- [ ] Frontend regression — verify each dropdown loads with the new options (post-deploy)
- [ ] Follow-up: port CB regression tests adapted for EXACT's stateless PatientInfo

🤖 Generated with [Claude Code](https://claude.com/claude-code)