### PR TITLE
feat: add MCL-specific fields to Trial model

### DIFF
--- a/trials/migrations/0003_trial_mcl_fields.py
+++ b/trials/migrations/0003_trial_mcl_fields.py
@@ -1,0 +1,118 @@
+from django.contrib.postgres.indexes import GinIndex
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('trials', '0002_morphologicvariant'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='trial',
+            name='lesion_size_mcl_min',
+            field=models.FloatField(blank=True, null=True),
+        ),
+        migrations.AddField(
+            model_name='trial',
+            name='lesion_size_mcl_max',
+            field=models.FloatField(blank=True, null=True),
+        ),
+        migrations.AddField(
+            model_name='trial',
+            name='morphologic_variants_required',
+            field=models.JSONField(blank=True, default=list),
+        ),
+        migrations.AddField(
+            model_name='trial',
+            name='morphologic_variants_excluded',
+            field=models.JSONField(blank=True, default=list),
+        ),
+        migrations.AddField(
+            model_name='trial',
+            name='disease_behaviors_required',
+            field=models.JSONField(blank=True, default=list),
+        ),
+        migrations.AddField(
+            model_name='trial',
+            name='disease_subtypes_required',
+            field=models.JSONField(blank=True, default=list),
+        ),
+        migrations.AddField(
+            model_name='trial',
+            name='extranodal_sites_required',
+            field=models.JSONField(blank=True, default=list),
+        ),
+        migrations.AddField(
+            model_name='trial',
+            name='bulky_disease_criteria_required',
+            field=models.JSONField(blank=True, default=list),
+        ),
+        migrations.AddField(
+            model_name='trial',
+            name='mipi_risks_required',
+            field=models.JSONField(blank=True, default=list),
+        ),
+        migrations.AddField(
+            model_name='trial',
+            name='mipi_c_risks_required',
+            field=models.JSONField(blank=True, default=list),
+        ),
+        migrations.AddIndex(
+            model_name='trial',
+            index=GinIndex(
+                fields=['morphologic_variants_required', 'morphologic_variants_excluded'],
+                name='idx_morph_variants_pair_gin',
+                opclasses=['jsonb_ops', 'jsonb_ops'],
+            ),
+        ),
+        migrations.AddIndex(
+            model_name='trial',
+            index=GinIndex(
+                fields=['disease_behaviors_required'],
+                name='idx_disease_behaviors_gin',
+                opclasses=['jsonb_ops'],
+            ),
+        ),
+        migrations.AddIndex(
+            model_name='trial',
+            index=GinIndex(
+                fields=['disease_subtypes_required'],
+                name='idx_disease_subtypes_gin',
+                opclasses=['jsonb_ops'],
+            ),
+        ),
+        migrations.AddIndex(
+            model_name='trial',
+            index=GinIndex(
+                fields=['extranodal_sites_required'],
+                name='idx_extranodal_sites_gin',
+                opclasses=['jsonb_ops'],
+            ),
+        ),
+        migrations.AddIndex(
+            model_name='trial',
+            index=GinIndex(
+                fields=['bulky_disease_criteria_required'],
+                name='idx_bulky_disease_gin',
+                opclasses=['jsonb_ops'],
+            ),
+        ),
+        migrations.AddIndex(
+            model_name='trial',
+            index=GinIndex(
+                fields=['mipi_risks_required'],
+                name='idx_mipi_risks_gin',
+                opclasses=['jsonb_ops'],
+            ),
+        ),
+        migrations.AddIndex(
+            model_name='trial',
+            index=GinIndex(
+                fields=['mipi_c_risks_required'],
+                name='idx_mipi_c_risks_gin',
+                opclasses=['jsonb_ops'],
+            ),
+        ),
+    ]

--- a/trials/models.py
+++ b/trials/models.py
@@ -550,6 +550,18 @@ class Trial(TimeStampMixin):
     clonal_b_lymphocyte_count_max = models.IntegerField(blank=True, null=True)
     bone_marrow_involvement_required = models.BooleanField(blank=True, null=True, db_index=True)
 
+    # MCL
+    lesion_size_mcl_min = models.FloatField(blank=True, null=True)
+    lesion_size_mcl_max = models.FloatField(blank=True, null=True)
+    morphologic_variants_required = models.JSONField(blank=True, null=False, default=list)
+    morphologic_variants_excluded = models.JSONField(blank=True, null=False, default=list)
+    disease_behaviors_required = models.JSONField(blank=True, null=False, default=list)
+    disease_subtypes_required = models.JSONField(blank=True, null=False, default=list)
+    extranodal_sites_required = models.JSONField(blank=True, null=False, default=list)
+    bulky_disease_criteria_required = models.JSONField(blank=True, null=False, default=list)
+    mipi_risks_required = models.JSONField(blank=True, null=False, default=list)
+    mipi_c_risks_required = models.JSONField(blank=True, null=False, default=list)
+
     locations = models.ManyToManyField(
         'Location',
         blank=True,
@@ -595,6 +607,13 @@ class Trial(TimeStampMixin):
             GinIndex(fields=['tumor_stages_required', 'tumor_stages_excluded'], name='idx_tumor_stages_pair_gin', opclasses=['jsonb_ops', 'jsonb_ops']),
             GinIndex(fields=['nodes_stages_required', 'nodes_stages_excluded'], name='idx_nodes_stages_pair_gin', opclasses=['jsonb_ops', 'jsonb_ops']),
             GinIndex(fields=['distant_metastasis_stages_required', 'distant_metastasis_stages_excluded'], name='idx_d_m_stages_pair_gin', opclasses=['jsonb_ops', 'jsonb_ops']),
+            GinIndex(fields=['morphologic_variants_required', 'morphologic_variants_excluded'], name='idx_morph_variants_pair_gin', opclasses=['jsonb_ops', 'jsonb_ops']),
+            GinIndex(fields=['disease_behaviors_required'], name='idx_disease_behaviors_gin', opclasses=['jsonb_ops']),
+            GinIndex(fields=['disease_subtypes_required'], name='idx_disease_subtypes_gin', opclasses=['jsonb_ops']),
+            GinIndex(fields=['extranodal_sites_required'], name='idx_extranodal_sites_gin', opclasses=['jsonb_ops']),
+            GinIndex(fields=['bulky_disease_criteria_required'], name='idx_bulky_disease_gin', opclasses=['jsonb_ops']),
+            GinIndex(fields=['mipi_risks_required'], name='idx_mipi_risks_gin', opclasses=['jsonb_ops']),
+            GinIndex(fields=['mipi_c_risks_required'], name='idx_mipi_c_risks_gin', opclasses=['jsonb_ops']),
         ]
 
     def attrs_to_fill_in(self, counts):


### PR DESCRIPTION
## Summary

Second PR of the MCL series. Adds 10 MCL-specific Trial fields + 7 GinIndex entries.

Closes #37.

## Fields

| Field | Type | Notes |
|---|---|---|
| `lesion_size_mcl_min` / `_max` | FloatField | MCL lesion size range |
| `morphologic_variants_required` / `_excluded` | JSONField list | classic / blastoid / pleomorphic (seeded in #36) |
| `disease_behaviors_required` | JSONField list | |
| `disease_subtypes_required` | JSONField list | |
| `extranodal_sites_required` | JSONField list | |
| `bulky_disease_criteria_required` | JSONField list | |
| `mipi_risks_required` | JSONField list | low / intermediate / high |
| `mipi_c_risks_required` | JSONField list | low / low_intermediate / high_intermediate / high |

## Indexes

7 new GinIndex entries on `Trial.Meta.indexes`:
- One paired index for `morphologic_variants_required` + `_excluded` (mirrors existing pair pattern)
- Six solo indexes for the other required-only fields

Migration `AddIndex` matches `Meta.indexes`, so `makemigrations --check` reports no changes (CI verifies).

## Serializers

Per existing EXACT pattern, eligibility-criteria fields don't appear in `TrialDetailsSerializer`'s explicit field list — they flow through `TrialTemplates` / `TrialAttributes` via the `details` field. So no serializer changes needed; the wiring lands with #39 (USER_TO_TRIAL_ATTRS_MAPPING) and #40 (value_options).

## Files

- `trials/models.py` — 10 fields + 7 index entries
- `trials/migrations/0003_trial_mcl_fields.py` — new migration (AddField × 10 + AddIndex × 7)

Total: +137 / 0.

## Test plan

- [ ] CI passes (incl. `makemigrations --check` + `migrate`)
- [ ] After merge: `#39` wires fields into matcher, `#40` adds value_options, `#41` adds scoring derivation

🤖 Generated with [Claude Code](https://claude.com/claude-code)