### PR TITLE
feat: add MCL fields to PatientInfo + wire into matcher

### DIFF
--- a/tests/services/patient_info/test_resolve_normalize_json.py
+++ b/tests/services/patient_info/test_resolve_normalize_json.py
@@ -122,3 +122,52 @@ class TestBuildInMemoryRegression:
         }
         pi = _build_in_memory(data)
         assert pi.genetic_mutations == [{'gene': 'tp53'}]
+
+
+class TestMclFieldRoundTrip:
+    """Round-trip MCL-specific PatientInfo fields through the resolver (#38)."""
+
+    @pytest.mark.django_db
+    def test_mcl_fields_round_trip_through_resolve(self):
+        data = {
+            'disease': 'mantle cell lymphoma',
+            'morphologic_variant': 'blastoid',
+            'lesion_size_mcl': 7.5,
+            'disease_behavior': 'classic',
+            'disease_subtype': 'nodal',
+            'extranodal_sites': ['bone_marrow', 'gi_tract'],
+            'mipi_risk': 'intermediate',
+            'mipi_c_risk': 'high_intermediate',
+            'bulky_disease_criteria': ['largest_node_ge_10cm'],
+        }
+        pi = _build_in_memory(data)
+        assert pi.disease == 'mantle cell lymphoma'
+        assert pi.morphologic_variant == 'blastoid'
+        assert pi.lesion_size_mcl == 7.5
+        assert pi.disease_behavior == 'classic'
+        assert pi.disease_subtype == 'nodal'
+        assert pi.extranodal_sites == ['bone_marrow', 'gi_tract']
+        assert pi.mipi_risk == 'intermediate'
+        assert pi.mipi_c_risk == 'high_intermediate'
+        assert pi.bulky_disease_criteria == ['largest_node_ge_10cm']
+
+    @pytest.mark.django_db
+    def test_mcl_fields_camel_case_round_trip(self):
+        # API surface uses camelCase; resolve._to_snake_case handles conversion
+        data = {
+            'disease': 'mantle cell lymphoma',
+            'morphologicVariant': 'pleomorphic',
+            'lesionSizeMcl': 5.0,
+            'mipiRisk': 'low',
+        }
+        pi = _build_in_memory(data)
+        assert pi.morphologic_variant == 'pleomorphic'
+        assert pi.lesion_size_mcl == 5.0
+        assert pi.mipi_risk == 'low'
+
+    @pytest.mark.django_db
+    def test_mcl_list_fields_default_to_empty_list(self):
+        data = {'disease': 'mantle cell lymphoma'}
+        pi = _build_in_memory(data)
+        assert pi.extranodal_sites == []
+        assert pi.bulky_disease_criteria == []

--- a/tests/services/patient_info/test_resolve_normalize_json.py
+++ b/tests/services/patient_info/test_resolve_normalize_json.py
@@ -171,3 +171,27 @@ class TestMclFieldRoundTrip:
         pi = _build_in_memory(data)
         assert pi.extranodal_sites == []
         assert pi.bulky_disease_criteria == []
+
+    @pytest.mark.django_db
+    def test_mcl_list_fields_none_coerced_to_empty_list(self):
+        # Caller sends explicit null — default=list contract must hold so
+        # downstream iteration (matcher overlap checks) doesn't crash.
+        data = {
+            'disease': 'mantle cell lymphoma',
+            'extranodal_sites': None,
+            'bulky_disease_criteria': None,
+        }
+        pi = _build_in_memory(data)
+        assert pi.extranodal_sites == []
+        assert pi.bulky_disease_criteria == []
+
+    @pytest.mark.django_db
+    def test_mcl_list_fields_drop_non_string_items(self):
+        data = {
+            'disease': 'mantle cell lymphoma',
+            'extranodal_sites': ['bone_marrow', 42, None, '  gi_tract  ', ''],
+            'bulky_disease_criteria': [{'nested': 'dict'}, 'largest_node_ge_10cm'],
+        }
+        pi = _build_in_memory(data)
+        assert pi.extranodal_sites == ['bone_marrow', 'gi_tract']
+        assert pi.bulky_disease_criteria == ['largest_node_ge_10cm']

--- a/trials/services/patient_info/configs.py
+++ b/trials/services/patient_info/configs.py
@@ -135,6 +135,14 @@ TRIAL_ATTRS_JSON_AS_A_LIST = (
     "richter_transformations_excluded",
     "tumor_burdens_required",
     "disease_activities_required",
+    "morphologic_variants_required",
+    "morphologic_variants_excluded",
+    "disease_behaviors_required",
+    "disease_subtypes_required",
+    "extranodal_sites_required",
+    "bulky_disease_criteria_required",
+    "mipi_risks_required",
+    "mipi_c_risks_required",
 )
 
 USER_TO_TRIAL_ATTRS_MAPPING = {
@@ -483,6 +491,90 @@ USER_TO_TRIAL_ATTRS_MAPPING = {
         "attr": "bone_marrow_involvement_required",
     },
     # CLL-specific END
+
+    # MCL-specific START
+    "morphologic_variant": {
+        "type": ATTR_MAPPING_TYPE_COMPUTED,
+        "custom_search": True,
+        "disease": "MCL",
+        "attr": ["morphologic_variants_required", "morphologic_variants_excluded"],
+        "uvalue_function": {
+            "morphologic_variants_required":
+                lambda patient_info: patient_info.morphologic_variant,
+            "morphologic_variants_excluded":
+                lambda patient_info: patient_info.morphologic_variant,
+        }
+    },
+    "lesion_size_mcl": {
+        "type": "min_max_value",
+        "custom_search": True,
+        "searchable": True,
+        "disease": "MCL",
+        "attr_min": "lesion_size_mcl_min",
+        "attr_max": "lesion_size_mcl_max",
+        "attr": ["lesion_size_mcl_min", "lesion_size_mcl_max"],
+    },
+    "disease_behavior": {
+        "type": ATTR_MAPPING_TYPE_COMPUTED,
+        "custom_search": True,
+        "disease": "MCL",
+        "attr": ["disease_behaviors_required"],
+        "uvalue_function": {
+            "disease_behaviors_required":
+                lambda patient_info: patient_info.disease_behavior,
+        }
+    },
+    "disease_subtype": {
+        "type": ATTR_MAPPING_TYPE_COMPUTED,
+        "custom_search": True,
+        "disease": "MCL",
+        "attr": ["disease_subtypes_required"],
+        "uvalue_function": {
+            "disease_subtypes_required":
+                lambda patient_info: patient_info.disease_subtype,
+        }
+    },
+    "extranodal_sites": {
+        "type": ATTR_MAPPING_TYPE_COMPUTED,
+        "custom_search": True,
+        "disease": "MCL",
+        "attr": ["extranodal_sites_required"],
+        "uvalue_function": {
+            "extranodal_sites_required":
+                lambda patient_info: patient_info.extranodal_sites,
+        }
+    },
+    "mipi_risk": {
+        "type": ATTR_MAPPING_TYPE_COMPUTED,
+        "custom_search": True,
+        "disease": "MCL",
+        "attr": ["mipi_risks_required"],
+        "uvalue_function": {
+            "mipi_risks_required":
+                lambda patient_info: patient_info.mipi_risk,
+        }
+    },
+    "mipi_c_risk": {
+        "type": ATTR_MAPPING_TYPE_COMPUTED,
+        "custom_search": True,
+        "disease": "MCL",
+        "attr": ["mipi_c_risks_required"],
+        "uvalue_function": {
+            "mipi_c_risks_required":
+                lambda patient_info: patient_info.mipi_c_risk,
+        }
+    },
+    "bulky_disease_criteria": {
+        "type": ATTR_MAPPING_TYPE_COMPUTED,
+        "custom_search": True,
+        "disease": "MCL",
+        "attr": ["bulky_disease_criteria_required"],
+        "uvalue_function": {
+            "bulky_disease_criteria_required":
+                lambda patient_info: patient_info.bulky_disease_criteria,
+        }
+    },
+    # MCL-specific END
 
     # BC-specific START
     "menopausal_status": {

--- a/trials/services/patient_info/patient_info.py
+++ b/trials/services/patient_info/patient_info.py
@@ -211,6 +211,15 @@ _FIELDS = [
     _f(FloatField, 'clonal_bone_marrow_b_lymphocytes'),
     _f(IntegerField, 'clonal_b_lymphocyte_count'),
     _f(BooleanField, 'bone_marrow_involvement'),
+    # MCL-specific
+    _f(TextField, 'morphologic_variant'),
+    _f(FloatField, 'lesion_size_mcl'),
+    _f(TextField, 'disease_behavior'),
+    _f(TextField, 'disease_subtype'),
+    _f(JSONField, 'extranodal_sites', default=list),
+    _f(TextField, 'mipi_risk'),
+    _f(TextField, 'mipi_c_risk'),
+    _f(JSONField, 'bulky_disease_criteria', default=list),
 ]
 
 _FIELD_MAP = {f.name: f for f in _FIELDS}

--- a/trials/services/patient_info/patient_info.py
+++ b/trials/services/patient_info/patient_info.py
@@ -212,6 +212,9 @@ _FIELDS = [
     _f(IntegerField, 'clonal_b_lymphocyte_count'),
     _f(BooleanField, 'bone_marrow_involvement'),
     # MCL-specific
+    # mipi_risk / mipi_c_risk / bulky_disease_criteria will be computed in
+    # normalize.py per #41. Caller-supplied values are accepted now (for
+    # forward compat) but will be overwritten by the normalizer once wired.
     _f(TextField, 'morphologic_variant'),
     _f(FloatField, 'lesion_size_mcl'),
     _f(TextField, 'disease_behavior'),

--- a/trials/services/patient_info/resolve.py
+++ b/trials/services/patient_info/resolve.py
@@ -134,6 +134,19 @@ def _normalize_structured_json_fields(data: dict):
         else:
             data['genetic_mutations'] = [item for item in val if isinstance(item, dict)]
 
+    # MCL list-of-strings fields: code lists (e.g. ['bone_marrow', 'gi_tract']).
+    # Coerce None / non-list / non-string items to [] so the default=list
+    # contract holds when CB sends `null` or `_coerce_json_fields` falls
+    # through on malformed input (which sets the value to None).
+    for key in ('extranodal_sites', 'bulky_disease_criteria'):
+        val = data.get(key)
+        if key not in data:
+            continue
+        if not isinstance(val, list):
+            data[key] = []
+            continue
+        data[key] = [s.strip() for s in val if isinstance(s, str) and s.strip()]
+
 
 def _coerce_json_fields(data: dict, model_cls):
     """Parse string-encoded JSON/Python-repr values for JSONField columns."""


### PR DESCRIPTION
## Summary

Third PR of the MCL series. Adds 8 MCL-specific fields to the stateless `PatientInfo` Python class **and** wires them into `USER_TO_TRIAL_ATTRS_MAPPING` so the matcher actually filters MCL trials on these fields.

The matcher wiring was originally planned as #39 but bundled into this PR after a pre-landing self-review showed that without it, MCL trials silently admit patients who shouldn't be eligible (e.g., a patient with `lesion_size_mcl=1.0` would pass a trial requiring `lesion_size_mcl_min=10`). The trial-side fields (#71) are already merged, so the window where MCL filtering is broken is closed by landing this PR.

Closes #38, closes #39.

## Patient-side fields

| Field | Type | Notes |
|---|---|---|
| `morphologic_variant` | TextField | classic / blastoid / pleomorphic |
| `lesion_size_mcl` | FloatField | numeric |
| `disease_behavior` | TextField | |
| `disease_subtype` | TextField | |
| `extranodal_sites` | JSONField (list of strings) | |
| `mipi_risk` | TextField | low / intermediate / high — will be derived in #41 |
| `mipi_c_risk` | TextField | 4-tier — will be derived in #41 |
| `bulky_disease_criteria` | JSONField (list of strings) | will be derived in #41 |

No migration — `PatientInfo` is a stateless Python class, not a Django model.

## Matcher wiring (was #39)

Eight new entries in `USER_TO_TRIAL_ATTRS_MAPPING` mapping each patient field to the corresponding Trial-side `*_required` column (mirrors the existing CLL `binet_stage` / `protein_expressions` patterns):

- `morphologic_variant` → `morphologic_variants_required` + `_excluded` pair
- `lesion_size_mcl` → `lesion_size_mcl_min` / `_max` (`min_max_value`)
- `disease_behavior`, `disease_subtype`, `extranodal_sites`, `mipi_risk`, `mipi_c_risk`, `bulky_disease_criteria` → respective `*_required` columns (`ATTR_MAPPING_TYPE_COMPUTED`)

The 8 corresponding trial-side JSONField columns are registered in `TRIAL_ATTRS_JSON_AS_A_LIST` so the mapper treats them as list-valued.

NOT in this PR (deferred): extending existing CLL entries (`hepatomegaly`, `splenomegaly`, `largest_lymph_node_size`, etc.) to also apply to MCL. That requires clinical decisions about which CLL constraints overlap with MCL semantics — separate scope.

## Hardening

`_normalize_structured_json_fields` now coerces `None` / non-list / non-string items to `[]` for `extranodal_sites` and `bulky_disease_criteria`. Without this, an inbound `{"extranodalSites": null}` payload — or a malformed string that `_coerce_json_fields` fails to parse — would override the field's `default=list`, crashing downstream overlap checks with `TypeError: 'NoneType' object is not iterable`.

Narrow fix: only the two new MCL list fields are hardened. The same latent pattern exists for `stem_cell_transplant_history` and the existing therapy-list fields; addressing that uniformly is tracked separately.

## Why no serializer / factory changes

- `PatientInfoSerializer.to_representation` dumps `vars(instance)` — new fields auto-appear in output
- `resolve._build_in_memory` filters by `PatientInfo._meta.get_fields()` which derives from the same `_FIELDS` list

So adding a field to `_FIELDS` propagates everywhere automatically. No factory updates either — EXACT has no `PatientInfoFactory`; tests instantiate `PatientInfo(disease=...)` directly per the stateless pattern.

## Tests

`tests/services/patient_info/test_resolve_normalize_json.py::TestMclFieldRoundTrip` covers:
- snake_case round-trip through `_build_in_memory` (all 8 fields)
- camelCase round-trip (verifies `_to_snake_case` handles MCL keys)
- JSON list fields default to `[]` when omitted
- JSON list fields with explicit `null` coerce to `[]` (hardening)
- JSON list fields drop non-string items and trim whitespace (hardening)

## Files

- `trials/services/patient_info/patient_info.py` — 8 `_f(...)` entries + derivation comment
- `trials/services/patient_info/configs.py` — 8 mapping entries + 8 entries in `TRIAL_ATTRS_JSON_AS_A_LIST`
- `trials/services/patient_info/resolve.py` — JSON list hardening for the two new fields
- `tests/services/patient_info/test_resolve_normalize_json.py` — 5 round-trip + hardening tests

Total: +190 / 0.

## Next in series

- #40 — MCL enums in `value_options.py`
- #41 — MIPI / MIPI-C / bulky_disease_criteria scoring derivation in `normalize.py` (will overwrite caller-supplied values for the three derived fields)

🤖 Generated with [Claude Code](https://claude.com/claude-code)