### PR TITLE
feat: add MCL enumerations to value_options

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,7 @@ from trials.services.loaders.load_concomitant_medications import LoadConcomitant
 from trials.services.loaders.load_ethnicity_options import LoadEthnicityOptions
 from trials.services.loaders.load_genetic_mutations import LoadGeneticMutations
 from trials.services.loaders.load_markers import LoadMarkers
+from trials.services.loaders.load_mcl_options import LoadMclOptions
 from trials.services.loaders.load_supportive_therapies import LoadSupportiveTherapies
 from trials.services.loaders.load_therapies import LoadTherapies
 from trials.services.loaders.load_toxicity_grade_options import LoadToxicityGradeOptions
@@ -25,6 +26,7 @@ def django_db_setup(django_db_setup, django_db_blocker):
         LoadToxicityGradeOptions().load_all()
         LoadGeneticMutations().load_all(skip_genes_origins=False)
         LoadBcOptions().load_all(skip_hrd=False, skip_hr=False, skip_histologic_types=False)
+        LoadMclOptions().load_all()
 
 
 @pytest.fixture

--- a/tests/services/test_value_options_mcl.py
+++ b/tests/services/test_value_options_mcl.py
@@ -88,33 +88,3 @@ class TestExistingDiseasesUnchanged:
         for key in ('therapiesCll', 'supportiveTherapiesCll', 'stagesCll',
                     'binetStages', 'proteinExpressions', 'diseaseActivities'):
             assert key in all_opts
-
-
-class TestAllOptionsCacheIsolation:
-    """all_options() must return a defensive copy so callers' top-level
-    mutations don't poison the LocMemCache reference and contaminate later
-    requests with the wrong per-disease overrides.
-
-    Regression for: FormSettingsViewSet.list adds 'trialType' per ?disease=
-    query; TrialAttributes.__init__ adds dozens of disease-specific aliased
-    keys. Both mutated the cached dict before this guard.
-    """
-
-    @pytest.mark.django_db
-    def test_caller_mutation_does_not_leak_to_next_call(self):
-        first = ValueOptions().all_options()
-        first['injectedKey'] = {'options': [{'value': 'x', 'label': 'X'}]}
-
-        second = ValueOptions().all_options()
-        assert 'injectedKey' not in second, \
-            'all_options() must return a fresh copy on each call'
-
-    @pytest.mark.django_db
-    def test_caller_overwrite_does_not_leak_to_next_call(self):
-        first = ValueOptions().all_options()
-        original_disease_options = first['disease']['options']
-        first['disease'] = {'options': [{'value': 'sentinel', 'label': 'Sentinel'}]}
-
-        second = ValueOptions().all_options()
-        assert second['disease']['options'] == original_disease_options, \
-            'overwriting a top-level key must not affect the cached value'

--- a/tests/services/test_value_options_mcl.py
+++ b/tests/services/test_value_options_mcl.py
@@ -1,0 +1,120 @@
+"""
+Smoke tests for MCL-specific value_options properties (#40).
+
+Each MCL option list must be non-empty and present in the central
+get_all_options() registry so /form-settings/ exposes them to the frontend.
+"""
+import pytest
+
+from trials.services.value_options import ValueOptions
+
+
+class TestMclStaticEnums:
+    """Static enum properties — no DB required."""
+
+    def test_mipi_risks_has_three_tiers(self):
+        opts = ValueOptions().mipi_risks
+        assert set(opts.keys()) == {'low', 'intermediate', 'high'}
+
+    def test_mipi_c_risks_has_four_tiers(self):
+        opts = ValueOptions().mipi_c_risks
+        assert set(opts.keys()) == {'low', 'low_intermediate', 'high_intermediate', 'high'}
+
+    def test_disease_behaviors_mcl_non_empty(self):
+        opts = ValueOptions().disease_behaviors_mcl
+        assert 'indolent' in opts
+        assert 'aggressive' in opts
+
+    def test_disease_subtypes_mcl_non_empty(self):
+        opts = ValueOptions().disease_subtypes_mcl
+        assert {'ismcn', 'cmcl', 'nnmcl'}.issubset(opts.keys())
+
+
+class TestMclDbBackedOptions:
+    """DB-backed properties — require LoadMclOptions seeding from conftest."""
+
+    @pytest.mark.django_db
+    def test_morphologic_variants_non_empty(self):
+        opts = ValueOptions().morphologic_variants
+        assert {'classic', 'blastoid', 'pleomorphic'}.issubset(opts.keys())
+
+    @pytest.mark.django_db
+    def test_protein_expressions_mcl_non_empty(self):
+        opts = ValueOptions().protein_expressions_mcl
+        # MCL panel: cyclin_d1, sox11, cd10, bcl6 (each +/-)
+        assert 'cyclin_d1_plus_ve' in opts
+        assert 'sox11_plus_ve' in opts
+
+
+class TestMclFormSettingsRegistry:
+    """Central options dict must expose every new MCL key."""
+
+    @pytest.mark.django_db
+    def test_all_mcl_keys_registered(self):
+        all_opts = ValueOptions().get_all_options()
+        expected_keys = {
+            'morphologicVariants',
+            'mipiRisks',
+            'mipiCRisks',
+            'diseaseBehaviorsMcl',
+            'diseaseSubtypesMcl',
+            'proteinExpressionsMcl',
+            'therapiesFirstLineMcl',
+            'therapiesSecondLineMcl',
+            'therapiesLaterLineMcl',
+            'supportiveTherapiesMcl',
+            'concomitantMedicationsMcl',
+            'stagesMcl',
+        }
+        missing = expected_keys - set(all_opts.keys())
+        assert not missing, f'MCL keys not in get_all_options(): {missing}'
+
+    @pytest.mark.django_db
+    def test_mcl_keys_have_options_field(self):
+        all_opts = ValueOptions().get_all_options()
+        for key in ('morphologicVariants', 'mipiRisks', 'mipiCRisks',
+                    'diseaseBehaviorsMcl', 'diseaseSubtypesMcl', 'stagesMcl'):
+            assert 'options' in all_opts[key]
+            assert isinstance(all_opts[key]['options'], list)
+            assert len(all_opts[key]['options']) > 0, f'{key} options list is empty'
+
+
+class TestExistingDiseasesUnchanged:
+    """Acceptance: existing disease enums unchanged."""
+
+    @pytest.mark.django_db
+    def test_cll_keys_still_present(self):
+        all_opts = ValueOptions().get_all_options()
+        for key in ('therapiesCll', 'supportiveTherapiesCll', 'stagesCll',
+                    'binetStages', 'proteinExpressions', 'diseaseActivities'):
+            assert key in all_opts
+
+
+class TestAllOptionsCacheIsolation:
+    """all_options() must return a defensive copy so callers' top-level
+    mutations don't poison the LocMemCache reference and contaminate later
+    requests with the wrong per-disease overrides.
+
+    Regression for: FormSettingsViewSet.list adds 'trialType' per ?disease=
+    query; TrialAttributes.__init__ adds dozens of disease-specific aliased
+    keys. Both mutated the cached dict before this guard.
+    """
+
+    @pytest.mark.django_db
+    def test_caller_mutation_does_not_leak_to_next_call(self):
+        first = ValueOptions().all_options()
+        first['injectedKey'] = {'options': [{'value': 'x', 'label': 'X'}]}
+
+        second = ValueOptions().all_options()
+        assert 'injectedKey' not in second, \
+            'all_options() must return a fresh copy on each call'
+
+    @pytest.mark.django_db
+    def test_caller_overwrite_does_not_leak_to_next_call(self):
+        first = ValueOptions().all_options()
+        original_disease_options = first['disease']['options']
+        first['disease'] = {'options': [{'value': 'sentinel', 'label': 'Sentinel'}]}
+
+        second = ValueOptions().all_options()
+        assert second['disease']['options'] == original_disease_options, \
+            'overwriting a top-level key must not affect the cached value'

--- a/trials/services/value_options.py
+++ b/trials/services/value_options.py
@@ -1,3 +1,5 @@
+import copy
+
 from django.utils.functional import cached_property
 from django.db.models import F
 
@@ -224,6 +226,22 @@ class ValueOptions:
     @cached_property
     def supportive_therapies_cll(self):
         return self.therapies_by_disease_code_and_line_code('CLL', 'supportive_therapy')
+
+    @cached_property
+    def therapies_first_line_mcl(self):
+        return self.therapies_by_disease_code_and_line_code('MCL', 'first_line_therapy')
+
+    @cached_property
+    def therapies_second_line_mcl(self):
+        return self.therapies_by_disease_code_and_line_code('MCL', 'second_line_therapy')
+
+    @cached_property
+    def therapies_later_mcl(self):
+        return self.therapies_by_disease_code_and_line_code('MCL', 'later_therapy')
+
+    @cached_property
+    def supportive_therapies_mcl(self):
+        return self.therapies_by_disease_code_and_line_code('MCL', 'supportive_therapy')
 
     @property
     def tumor_grades(self):
@@ -719,6 +737,60 @@ class ValueOptions:
         }
 
     @property
+    def disease_behaviors_mcl(self):
+        return {
+            '': 'Unknown',
+            'indolent': 'Indolent',
+            'aggressive': 'Aggressive',
+        }
+
+    @property
+    def disease_subtypes_mcl(self):
+        return {
+            '': 'Unknown',
+            'ismcn': 'In situ MCN (ISMCN)',
+            'cmcl': 'Conventional nodal MCL (cMCL)',
+            'nnmcl': 'Leukemic non-nodal MCL (nnMCL)',
+        }
+
+    @property
+    def protein_expressions_mcl(self):
+        from trials.models import ProteinExpression
+        mcl_codes = [
+            'cyclin_d1_plus_ve', 'cyclin_d1_minus_ve',
+            'sox11_plus_ve', 'sox11_minus_ve',
+            'cd10_plus_ve', 'cd10_minus_ve',
+            'bcl6_plus_ve', 'bcl6_minus_ve',
+        ]
+        items = ProteinExpression.objects.filter(code__in=mcl_codes).order_by('id')
+        out = {x.code: x.title for x in items}
+        return {'': 'Unknown', **out}
+
+    @property
+    def morphologic_variants(self):
+        from trials.models import MorphologicVariant
+        items = MorphologicVariant.objects.order_by('id')
+        out = {x.code: x.title for x in items}
+        return {'': 'Unknown', **out}
+
+    @property
+    def mipi_risks(self):
+        return {
+            'low': 'Low',
+            'intermediate': 'Intermediate',
+            'high': 'High',
+        }
+
+    @property
+    def mipi_c_risks(self):
+        return {
+            'low': 'Low',
+            'low_intermediate': 'Low-Intermediate',
+            'high_intermediate': 'High-Intermediate',
+            'high': 'High',
+        }
+
+    @property
     def er_statuses(self):
         from trials.models import EstrogenReceptorStatus
         items = EstrogenReceptorStatus.objects.order_by('id')
@@ -738,7 +810,12 @@ class ValueOptions:
         if result is None:
             result = self.get_all_options()
             cache.set(cache_key, result, timeout=3600)  # Cache for 1 hour
-        return result
+        # Defensive shallow copy: FormSettingsViewSet.list and
+        # TrialAttributes.__init__ mutate the returned dict by adding aliased
+        # keys (e.g. firstLineTherapy, trialType per disease). Without copying
+        # those mutations leak into the LocMemCache reference and poison later
+        # requests with wrong per-disease values.
+        return copy.copy(result)
 
     def get_all_options(self):
         return {
@@ -921,6 +998,15 @@ class ValueOptions:
             'therapiesLaterLineCll': {
                 'options': self.to_value_and_label(self.therapies_later_cll)
             },
+            'therapiesFirstLineMcl': {
+                'options': self.to_value_and_label(self.therapies_first_line_mcl)
+            },
+            'therapiesSecondLineMcl': {
+                'options': self.to_value_and_label(self.therapies_second_line_mcl)
+            },
+            'therapiesLaterLineMcl': {
+                'options': self.to_value_and_label(self.therapies_later_mcl)
+            },
             'supportiveTherapiesMm': {
                 'options': self.to_value_and_label(self.supportive_therapies_mm)
             },
@@ -933,6 +1019,9 @@ class ValueOptions:
             'supportiveTherapiesCll': {
                 'options': self.to_value_and_label(self.supportive_therapies_cll)
             },
+            'supportiveTherapiesMcl': {
+                'options': self.to_value_and_label(self.supportive_therapies_mcl)
+            },
             'concomitantMedicationsMm': {
                 'options': self.to_value_and_label(self.concomitant_medications_by_disease_code('MM'))
             },
@@ -941,6 +1030,9 @@ class ValueOptions:
             },
             'concomitantMedicationsBc': {
                 'options': self.to_value_and_label(self.concomitant_medications_by_disease_code('BC'))
+            },
+            'concomitantMedicationsMcl': {
+                'options': self.to_value_and_label(self.concomitant_medications_by_disease_code('MCL'))
             },
             'menopausalStatus': {
                 'options': self.to_value_and_label(self.menopausal_status)
@@ -1020,6 +1112,9 @@ class ValueOptions:
             'stagesCll': {
                 'options': self.to_value_and_label(self.stages('CLL'))
             },
+            'stagesMcl': {
+                'options': self.to_value_and_label(self.stages('MCL'))
+            },
             'languagesSkills': {
                 'options': self.to_value_and_label(self.languages_skills)
             },
@@ -1040,5 +1135,23 @@ class ValueOptions:
             },
             'diseaseActivities': {
                 'options': self.to_value_and_label(self.disease_activities)
+            },
+            'diseaseBehaviorsMcl': {
+                'options': self.to_value_and_label(self.disease_behaviors_mcl)
+            },
+            'diseaseSubtypesMcl': {
+                'options': self.to_value_and_label(self.disease_subtypes_mcl)
+            },
+            'proteinExpressionsMcl': {
+                'options': self.to_value_and_label(self.protein_expressions_mcl)
+            },
+            'morphologicVariants': {
+                'options': self.to_value_and_label(self.morphologic_variants)
+            },
+            'mipiRisks': {
+                'options': self.to_value_and_label(self.mipi_risks)
+            },
+            'mipiCRisks': {
+                'options': self.to_value_and_label(self.mipi_c_risks)
             },
         }

--- a/trials/services/value_options.py
+++ b/trials/services/value_options.py
@@ -1,5 +1,3 @@
-import copy
-
 from django.utils.functional import cached_property
 from django.db.models import F
 
@@ -810,12 +808,7 @@ class ValueOptions:
         if result is None:
             result = self.get_all_options()
             cache.set(cache_key, result, timeout=3600)  # Cache for 1 hour
-        # Defensive shallow copy: FormSettingsViewSet.list and
-        # TrialAttributes.__init__ mutate the returned dict by adding aliased
-        # keys (e.g. firstLineTherapy, trialType per disease). Without copying
-        # those mutations leak into the LocMemCache reference and poison later
-        # requests with wrong per-disease values.
-        return copy.copy(result)
+        return result
 
     def get_all_options(self):
         return {


### PR DESCRIPTION
## Summary

Fourth PR of the MCL series. Exposes MCL-specific enumerations through `/form-settings/` so the frontend can render MCL patient-info dropdowns and trial-search filters.

Closes #40. Follow-up: #73 wires MCL into `trial_attributes.py` disease branches so MCL trial detail rendering picks up these new option lists.

## New MCL properties

| Property | Type | Notes |
|---|---|---|
| `mipi_risks` | static dict | low / intermediate / high |
| `mipi_c_risks` | static dict | low / low_intermediate / high_intermediate / high |
| `disease_behaviors_mcl` | static dict | indolent / aggressive |
| `disease_subtypes_mcl` | static dict | ismcn / cmcl / nnmcl |
| `morphologic_variants` | DB-loaded | from `MorphologicVariant` model (seeded by `LoadMclOptions`) |
| `protein_expressions_mcl` | DB-loaded | filtered to 8 MCL codes: cyclin_d1 / sox11 / cd10 / bcl6 (each ±) |
| `therapies_first_line_mcl` | DB-loaded | mirrors CLL therapy-line pattern |
| `therapies_second_line_mcl` | DB-loaded | mirrors CLL therapy-line pattern |
| `therapies_later_mcl` | DB-loaded | mirrors CLL therapy-line pattern |
| `supportive_therapies_mcl` | DB-loaded | mirrors CLL therapy-line pattern |

## Central registry additions

12 new entries in `get_all_options()`: `morphologicVariants`, `mipiRisks`, `mipiCRisks`, `diseaseBehaviorsMcl`, `diseaseSubtypesMcl`, `proteinExpressionsMcl`, `therapiesFirstLineMcl` / `SecondLine` / `LaterLine`, `supportiveTherapiesMcl`, `concomitantMedicationsMcl`, `stagesMcl`.

`stages('MCL')` falls through to the default Lugano-style I/II/III/IV (matches CB; same as CLL/MM/FL).

## Tests

`tests/services/test_value_options_mcl.py`:
- Static enum shape (mipi 3 tiers, mipi-c 4 tiers, disease behaviors / subtypes)
- DB-backed `morphologic_variants` + `protein_expressions_mcl` non-empty (requires `LoadMclOptions`)
- Central registry includes all 12 new MCL keys
- Existing CLL keys (`therapiesCll`, `binetStages`, etc.) still present

`tests/conftest.py`:
- Added `LoadMclOptions().load_all()` to the session-scoped autouse fixture so MCL DB-backed properties have seed data.

## Self-review history

The first version of this PR included a `copy.copy()` wrapper in `ValueOptions.all_options()` and two "regression" tests claiming to fix a cache-poisoning bug surfaced by Codex during adversarial review. **A fresh-context Claude pass debunked the claim:** `LocMemCache.set` pickles on store (`django/core/cache/backends/locmem.py:53`) and `LocMemCache.get` unpickles on read (`locmem.py:42`), so each `cache.get()` returns a freshly deserialized dict. Mutations on one returned dict cannot reach another. Same isolation holds under Redis / Memcached / db backends since they all serialize.

The unnecessary wrapper, comment, and tests were reverted in `63c9c9b`. Lesson: when a reviewer flags a "pre-existing bug," verify it manifests before fixing.

## Files

- `trials/services/value_options.py` — 10 properties + 12 dict entries (+106)
- `tests/conftest.py` — seed MCL options (+2)
- `tests/services/test_value_options_mcl.py` — new (~90 lines)

## Out of scope

- `extranodal_sites` / `bulky_disease_criteria` enums — CB also lacks these in `value_options.py`; defer until ingestion pattern is decided
- MCL branch in `trial_attributes.py` — tracked in #73; would need its own PR with disease-detail UI verification

## Next in series

- #41 — MIPI / MIPI-C / bulky_disease_criteria scoring derivation in `normalize.py` (will overwrite caller-supplied values for the three derived fields, per the comment landed in #72)
- #73 — wire MCL into `trial_attributes.py` disease branches

🤖 Generated with [Claude Code](https://claude.com/claude-code)