### PR TITLE
feat: compute MIPI, MIPI-C, and bulky-disease criteria for MCL patients

### DIFF
--- a/tests/services/patient_info/test_mcl_derivations.py
+++ b/tests/services/patient_info/test_mcl_derivations.py
@@ -1,0 +1,241 @@
+"""
+Unit tests for MCL risk-score derivations (#41).
+
+Covers MIPI / MIPI-C bucket boundaries, bulky-disease threshold rules, and
+the wiring through normalize_patient_info() that overwrites caller-supplied
+values for MCL patients.
+"""
+import pytest
+
+from trials.services.patient_info.patient_info import PatientInfo
+from trials.services.patient_info.patient_info_attributes import PatientInfoAttributes
+from trials.services.patient_info.normalize import normalize_patient_info
+
+
+def _mcl_patient(**kwargs):
+    """Build an MCL PatientInfo with sensible defaults so derivations exercise
+    only the field under test."""
+    defaults = dict(
+        disease='mantle cell lymphoma',
+        patient_age=70,
+        ecog_performance_status=0,
+        white_blood_cell_count=8e9,
+        white_blood_cell_count_units='CELLS/L',
+        lactate_dehydrogenase_level=250,
+        ki67_proliferation_index=15,
+    )
+    defaults.update(kwargs)
+    return PatientInfo(**defaults)
+
+
+class TestMipiRiskBuckets:
+    """Hoster 2008 MIPI cutoffs: low < 5.7, intermediate < 6.5, high >= 6.5."""
+
+    def test_low_for_healthy_inputs(self):
+        # score ≈ 3.32 — well below 5.7
+        pi = _mcl_patient(patient_age=70, ecog_performance_status=0,
+                          white_blood_cell_count=8e9, lactate_dehydrogenase_level=250)
+        assert PatientInfoAttributes(pi).mipi_risk == 'low'
+
+    def test_intermediate_for_moderate_disease(self):
+        # score ≈ 5.91 — in [5.7, 6.5)
+        pi = _mcl_patient(patient_age=85, ecog_performance_status=2,
+                          white_blood_cell_count=50e9, lactate_dehydrogenase_level=700)
+        assert PatientInfoAttributes(pi).mipi_risk == 'intermediate'
+
+    def test_high_for_aggressive_disease(self):
+        # score ≈ 7.10 — well above 6.5
+        pi = _mcl_patient(patient_age=90, ecog_performance_status=2,
+                          white_blood_cell_count=200e9, lactate_dehydrogenase_level=1500)
+        assert PatientInfoAttributes(pi).mipi_risk == 'high'
+
+    def test_ecog_zero_does_not_add_penalty(self):
+        # ECOG 0 and 1 both contribute 0 (predicate is ecog >= 2)
+        low_ecog = _mcl_patient(ecog_performance_status=0)
+        med_ecog = _mcl_patient(ecog_performance_status=1)
+        attrs_low = PatientInfoAttributes(low_ecog)
+        attrs_med = PatientInfoAttributes(med_ecog)
+        assert attrs_low.mipi_risk == attrs_med.mipi_risk
+
+    @pytest.mark.parametrize('missing', [
+        {'patient_age': None},
+        {'ecog_performance_status': None},
+        {'white_blood_cell_count': None},
+        {'lactate_dehydrogenase_level': None},
+    ])
+    def test_returns_none_when_any_input_missing(self, missing):
+        pi = _mcl_patient(**missing)
+        assert PatientInfoAttributes(pi).mipi_risk is None
+
+    @pytest.mark.parametrize('bad', [
+        {'white_blood_cell_count': 0},
+        {'white_blood_cell_count': -1e9},
+        {'lactate_dehydrogenase_level': 0},
+        {'lactate_dehydrogenase_level': -50},
+    ])
+    def test_returns_none_for_non_positive_wbc_or_ldh(self, bad):
+        # log10 of <=0 is undefined; algorithm must guard.
+        pi = _mcl_patient(**bad)
+        assert PatientInfoAttributes(pi).mipi_risk is None
+
+    def test_unit_conversion_when_wbc_in_cells_per_ul(self):
+        # 8000 CELLS/UL == 8e9 CELLS/L; should give the same MIPI as the
+        # CELLS/L canonical input above.
+        canonical = _mcl_patient(white_blood_cell_count=8e9,
+                                 white_blood_cell_count_units='CELLS/L')
+        ul_form = _mcl_patient(white_blood_cell_count=8000,
+                               white_blood_cell_count_units='CELLS/UL')
+        assert PatientInfoAttributes(canonical).mipi_risk == \
+               PatientInfoAttributes(ul_form).mipi_risk
+
+
+class TestMipiCRiskMatrix:
+    """4-tier MIPI-C matrix from Hoster 2014: combines MIPI with Ki-67 < 30 vs >= 30."""
+
+    def test_low_mipi_plus_low_ki67_is_low(self):
+        pi = _mcl_patient(ki67_proliferation_index=15)  # low MIPI by default
+        assert PatientInfoAttributes(pi).mipi_c_risk == 'low'
+
+    def test_low_mipi_plus_high_ki67_is_low_intermediate(self):
+        pi = _mcl_patient(ki67_proliferation_index=45)
+        assert PatientInfoAttributes(pi).mipi_c_risk == 'low_intermediate'
+
+    def test_intermediate_mipi_plus_low_ki67_is_low_intermediate(self):
+        pi = _mcl_patient(patient_age=85, ecog_performance_status=2,
+                          white_blood_cell_count=50e9, lactate_dehydrogenase_level=700,
+                          ki67_proliferation_index=20)
+        assert PatientInfoAttributes(pi).mipi_c_risk == 'low_intermediate'
+
+    def test_intermediate_mipi_plus_high_ki67_is_high_intermediate(self):
+        pi = _mcl_patient(patient_age=85, ecog_performance_status=2,
+                          white_blood_cell_count=50e9, lactate_dehydrogenase_level=700,
+                          ki67_proliferation_index=50)
+        assert PatientInfoAttributes(pi).mipi_c_risk == 'high_intermediate'
+
+    def test_high_mipi_plus_low_ki67_is_high_intermediate(self):
+        pi = _mcl_patient(patient_age=90, ecog_performance_status=2,
+                          white_blood_cell_count=200e9, lactate_dehydrogenase_level=1500,
+                          ki67_proliferation_index=20)
+        assert PatientInfoAttributes(pi).mipi_c_risk == 'high_intermediate'
+
+    def test_high_mipi_plus_high_ki67_is_high(self):
+        pi = _mcl_patient(patient_age=90, ecog_performance_status=2,
+                          white_blood_cell_count=200e9, lactate_dehydrogenase_level=1500,
+                          ki67_proliferation_index=60)
+        assert PatientInfoAttributes(pi).mipi_c_risk == 'high'
+
+    def test_ki67_boundary_at_30_falls_into_upper_bucket(self):
+        # Predicate is `ki67 < 30`, so 30 itself goes to the upper bucket.
+        pi = _mcl_patient(ki67_proliferation_index=29)
+        assert PatientInfoAttributes(pi).mipi_c_risk == 'low'
+        pi_30 = _mcl_patient(ki67_proliferation_index=30)
+        assert PatientInfoAttributes(pi_30).mipi_c_risk == 'low_intermediate'
+
+    @pytest.mark.parametrize('missing', [
+        {'patient_age': None},
+        {'ki67_proliferation_index': None},
+    ])
+    def test_returns_none_when_inputs_missing(self, missing):
+        pi = _mcl_patient(**missing)
+        assert PatientInfoAttributes(pi).mipi_c_risk is None
+
+
+class TestBulkyDiseaseCriteria:
+    """Lesion / node use >= thresholds; spleen uses > thresholds at 13/15/20
+    plus a >= 20 variant — mirrors CB so trials matching either spleen
+    predicate work."""
+
+    def test_no_size_inputs_returns_empty_list(self):
+        pi = _mcl_patient()
+        assert PatientInfoAttributes(pi).bulky_disease_criteria == []
+
+    def test_lesion_5cm_alone(self):
+        pi = _mcl_patient(lesion_size_mcl=5)
+        assert PatientInfoAttributes(pi).bulky_disease_criteria == ['bulky_lesion_5cm']
+
+    def test_lesion_10cm_fires_all_three_lesion_thresholds(self):
+        pi = _mcl_patient(lesion_size_mcl=12)
+        assert PatientInfoAttributes(pi).bulky_disease_criteria == [
+            'bulky_lesion_5cm', 'bulky_lesion_7_5cm', 'bulky_lesion_10cm',
+        ]
+
+    def test_lesion_under_5cm_does_not_fire(self):
+        pi = _mcl_patient(lesion_size_mcl=4.9)
+        assert PatientInfoAttributes(pi).bulky_disease_criteria == []
+
+    def test_node_5cm_alone(self):
+        pi = _mcl_patient(largest_lymph_node_size=5)
+        assert PatientInfoAttributes(pi).bulky_disease_criteria == ['bulky_node_5cm']
+
+    def test_node_10cm_fires_all_three_node_thresholds(self):
+        pi = _mcl_patient(largest_lymph_node_size=10)
+        assert PatientInfoAttributes(pi).bulky_disease_criteria == [
+            'bulky_node_5cm', 'bulky_node_7_5cm', 'bulky_node_10cm',
+        ]
+
+    def test_spleen_uses_strict_gt_thresholds(self):
+        # Spleen 13 itself does NOT fire bulky_spleen_13cm (predicate is > 13)
+        pi_13 = _mcl_patient(spleen_size=13)
+        assert PatientInfoAttributes(pi_13).bulky_disease_criteria == []
+        pi_13_1 = _mcl_patient(spleen_size=13.1)
+        assert PatientInfoAttributes(pi_13_1).bulky_disease_criteria == ['bulky_spleen_13cm']
+
+    def test_spleen_20_exactly_fires_gte_only(self):
+        pi = _mcl_patient(spleen_size=20)
+        assert PatientInfoAttributes(pi).bulky_disease_criteria == [
+            'bulky_spleen_13cm', 'bulky_spleen_15cm', 'bulky_spleen_20cm_gte',
+        ]
+
+    def test_spleen_above_20_fires_both_gt_and_gte(self):
+        pi = _mcl_patient(spleen_size=21)
+        assert PatientInfoAttributes(pi).bulky_disease_criteria == [
+            'bulky_spleen_13cm', 'bulky_spleen_15cm',
+            'bulky_spleen_20cm_gt', 'bulky_spleen_20cm_gte',
+        ]
+
+    def test_multiple_anatomic_sites_combine(self):
+        pi = _mcl_patient(lesion_size_mcl=5, largest_lymph_node_size=5, spleen_size=14)
+        assert PatientInfoAttributes(pi).bulky_disease_criteria == [
+            'bulky_lesion_5cm', 'bulky_node_5cm', 'bulky_spleen_13cm',
+        ]
+
+
+class TestNormalizerWiring:
+    """normalize_patient_info() must overwrite caller-supplied MCL fields
+    for MCL patients and leave non-MCL patients untouched."""
+
+    @pytest.mark.django_db
+    def test_mcl_patient_caller_values_get_overwritten(self):
+        pi = _mcl_patient(
+            mipi_risk='high',  # caller-supplied; should be overwritten to 'low'
+            mipi_c_risk='high',
+            bulky_disease_criteria=['caller_supplied_garbage'],
+            lesion_size_mcl=12,
+        )
+        normalize_patient_info(pi)
+        assert pi.mipi_risk == 'low'  # actual derivation for the default inputs
+        assert pi.mipi_c_risk == 'low'
+        assert pi.bulky_disease_criteria == [
+            'bulky_lesion_5cm', 'bulky_lesion_7_5cm', 'bulky_lesion_10cm',
+        ]
+
+    @pytest.mark.django_db
+    def test_non_mcl_patient_mcl_fields_left_alone(self):
+        # An MM patient with caller-supplied MCL fields should NOT be touched
+        # (the field exists for forward-compat but doesn't apply clinically).
+        pi = PatientInfo(disease='multiple myeloma', mipi_risk='caller_value')
+        normalize_patient_info(pi)
+        assert pi.mipi_risk == 'caller_value'
+
+    @pytest.mark.django_db
+    @pytest.mark.parametrize('disease', [
+        'mantle cell lymphoma',
+        'Mantle Cell Lymphoma',
+        'MANTLE CELL LYMPHOMA',
+    ])
+    def test_disease_gate_is_case_insensitive(self, disease):
+        # str(pi.disease).lower() == 'mantle cell lymphoma' must accept any
+        # casing the API caller sends.
+        pi = _mcl_patient(disease=disease, lesion_size_mcl=6)
+        normalize_patient_info(pi)
+        assert pi.bulky_disease_criteria == ['bulky_lesion_5cm']

--- a/tests/services/patient_info/test_resolve_normalize_json.py
+++ b/tests/services/patient_info/test_resolve_normalize_json.py
@@ -125,7 +125,14 @@ class TestBuildInMemoryRegression:
 
 
 class TestMclFieldRoundTrip:
-    """Round-trip MCL-specific PatientInfo fields through the resolver (#38)."""
+    """Round-trip MCL-specific PatientInfo fields through the resolver (#38).
+
+    Note: mipi_risk / mipi_c_risk / bulky_disease_criteria are derived by
+    normalize._normalize_mcl_derivations (#41), so caller-supplied values
+    get overwritten. These tests assert the resolver preserves the
+    non-derived fields and that the derived ones reflect the algorithm
+    output, not the caller input.
+    """
 
     @pytest.mark.django_db
     def test_mcl_fields_round_trip_through_resolve(self):
@@ -136,20 +143,28 @@ class TestMclFieldRoundTrip:
             'disease_behavior': 'classic',
             'disease_subtype': 'nodal',
             'extranodal_sites': ['bone_marrow', 'gi_tract'],
+            # Caller-supplied derived values; will be overwritten by the
+            # normalizer (see assertions below).
             'mipi_risk': 'intermediate',
             'mipi_c_risk': 'high_intermediate',
-            'bulky_disease_criteria': ['largest_node_ge_10cm'],
+            'bulky_disease_criteria': ['caller_supplied_ignored'],
         }
         pi = _build_in_memory(data)
+        # Non-derived fields preserved.
         assert pi.disease == 'mantle cell lymphoma'
         assert pi.morphologic_variant == 'blastoid'
         assert pi.lesion_size_mcl == 7.5
         assert pi.disease_behavior == 'classic'
         assert pi.disease_subtype == 'nodal'
         assert pi.extranodal_sites == ['bone_marrow', 'gi_tract']
-        assert pi.mipi_risk == 'intermediate'
-        assert pi.mipi_c_risk == 'high_intermediate'
-        assert pi.bulky_disease_criteria == ['largest_node_ge_10cm']
+        # Derived fields overwritten: no age/ECOG/WBC/LDH/Ki67 in payload, so
+        # MIPI inputs are missing and the score is None. lesion_size_mcl=7.5
+        # fires the 5cm and 7.5cm bulky-lesion thresholds.
+        assert pi.mipi_risk is None
+        assert pi.mipi_c_risk is None
+        assert pi.bulky_disease_criteria == [
+            'bulky_lesion_5cm', 'bulky_lesion_7_5cm',
+        ]
 
     @pytest.mark.django_db
     def test_mcl_fields_camel_case_round_trip(self):
@@ -158,12 +173,14 @@ class TestMclFieldRoundTrip:
             'disease': 'mantle cell lymphoma',
             'morphologicVariant': 'pleomorphic',
             'lesionSizeMcl': 5.0,
-            'mipiRisk': 'low',
+            'mipiRisk': 'low',  # overwritten by derivation
         }
         pi = _build_in_memory(data)
         assert pi.morphologic_variant == 'pleomorphic'
         assert pi.lesion_size_mcl == 5.0
-        assert pi.mipi_risk == 'low'
+        # Caller-supplied mipi_risk overwritten; with no scoring inputs the
+        # derived value is None.
+        assert pi.mipi_risk is None
 
     @pytest.mark.django_db
     def test_mcl_list_fields_default_to_empty_list(self):
@@ -190,8 +207,11 @@ class TestMclFieldRoundTrip:
         data = {
             'disease': 'mantle cell lymphoma',
             'extranodal_sites': ['bone_marrow', 42, None, '  gi_tract  ', ''],
-            'bulky_disease_criteria': [{'nested': 'dict'}, 'largest_node_ge_10cm'],
+            # bulky_disease_criteria is overwritten by the normalizer (#41);
+            # exercise the resolver hardening on extranodal_sites only.
+            'bulky_disease_criteria': [{'nested': 'dict'}, 'caller_supplied_ignored'],
         }
         pi = _build_in_memory(data)
         assert pi.extranodal_sites == ['bone_marrow', 'gi_tract']
-        assert pi.bulky_disease_criteria == ['largest_node_ge_10cm']
+        # No size fields in payload, so derived bulky list is empty.
+        assert pi.bulky_disease_criteria == []

--- a/tests/services/test_value_options_mcl.py
+++ b/tests/services/test_value_options_mcl.py
@@ -65,6 +65,7 @@ class TestMclFormSettingsRegistry:
             'supportiveTherapiesMcl',
             'concomitantMedicationsMcl',
             'stagesMcl',
+            'bulkyDiseaseCriteria',
         }
         missing = expected_keys - set(all_opts.keys())
         assert not missing, f'MCL keys not in get_all_options(): {missing}'

--- a/trials/services/patient_info/normalize.py
+++ b/trials/services/patient_info/normalize.py
@@ -26,6 +26,7 @@ def normalize_patient_info(pi) -> None:
     _normalize_metastatic_status(pi)
     _normalize_measurable_disease_imwg(pi)
     _normalize_last_treatment(pi)
+    _normalize_mcl_derivations(pi)
 
     attr = PatientInfoAttributes(pi)
     pi.bmi = attr.bmi
@@ -217,3 +218,26 @@ def _normalize_measurable_disease_imwg(pi) -> None:
 
 def _normalize_last_treatment(pi) -> None:
     pi.last_treatment = pi.later_date or pi.second_line_date or pi.first_line_date
+
+
+def _normalize_mcl_derivations(pi) -> None:
+    """Overwrite caller-supplied MCL risk scores with derived values.
+
+    The PatientInfo field declarations note these are caller-settable for
+    forward-compat but always overwritten here (#41 / see
+    patient_info.py:215). Skips non-MCL patients so other diseases keep
+    whatever defaults / inputs they had.
+    """
+    if str(pi.disease).lower() != 'mantle cell lymphoma':
+        return
+
+    # Late import: PatientInfoAttributes imports normalize indirectly via
+    # configs -> matcher, so resolving it at module load creates a cycle.
+    from trials.services.patient_info.patient_info_attributes import PatientInfoAttributes
+    attr = PatientInfoAttributes(pi)
+    pi.mipi_risk = attr.mipi_risk
+    pi.mipi_c_risk = attr.mipi_c_risk
+    # Defensive copy: bulky_disease_criteria is a cached_property; without
+    # copying, downstream mutation of pi.bulky_disease_criteria would also
+    # mutate the cached property's stored list.
+    pi.bulky_disease_criteria = list(attr.bulky_disease_criteria)

--- a/trials/services/patient_info/patient_info.py
+++ b/trials/services/patient_info/patient_info.py
@@ -212,9 +212,10 @@ _FIELDS = [
     _f(IntegerField, 'clonal_b_lymphocyte_count'),
     _f(BooleanField, 'bone_marrow_involvement'),
     # MCL-specific
-    # mipi_risk / mipi_c_risk / bulky_disease_criteria will be computed in
-    # normalize.py per #41. Caller-supplied values are accepted now (for
-    # forward compat) but will be overwritten by the normalizer once wired.
+    # mipi_risk / mipi_c_risk / bulky_disease_criteria are derived in
+    # normalize._normalize_mcl_derivations from age / ECOG / WBC / LDH /
+    # Ki67 / sizes (#41). Caller-supplied values are overwritten when the
+    # patient's disease is MCL.
     _f(TextField, 'morphologic_variant'),
     _f(FloatField, 'lesion_size_mcl'),
     _f(TextField, 'disease_behavior'),

--- a/trials/services/patient_info/patient_info_attributes.py
+++ b/trials/services/patient_info/patient_info_attributes.py
@@ -1,3 +1,5 @@
+from math import log10
+
 import inflection
 from django.db import models
 from django.db.models import Q
@@ -551,3 +553,105 @@ class PatientInfoAttributes:
 
             self.patient_info.stem_cell_transplant_history = 'None'
             return
+
+    # ---------------------------------------------------------------------
+    # MCL derivations (#41).
+    # Ported from CB patient_info_attributes.py:488-567 with two adaptations:
+    # 1. bulky_disease_criteria returns a list (matches EXACT's JSONField),
+    #    not a comma-joined string.
+    # 2. Bulky lesion thresholds key off lesion_size_mcl (EXACT's MCL field),
+    #    not CB's largest_lesion_size.
+    # MIPI: Hoster et al. 2008 (Blood 111:558-565).
+    # MIPI-C: categorical MIPI x Ki-67 table (Hoster et al. 2014, ASH 2014
+    # abstract — full JCO 2016 publication uses a continuous variant).
+    # See follow-up issue for clinical-cutoff verification.
+    # ---------------------------------------------------------------------
+
+    @cached_property
+    def mipi_risk(self):
+        pi = self.patient_info
+        age = pi.patient_age
+        ecog = pi.ecog_performance_status
+        wbc = pi.white_blood_cell_count
+        ldh = pi.lactate_dehydrogenase_level
+
+        if any(v is None for v in (age, ecog, wbc, ldh)):
+            return None
+        if float(wbc) <= 0 or float(ldh) <= 0:
+            return None
+
+        wbc_in_cells_per_l = float(BaseConvertor.call(
+            wbc, pi.white_blood_cell_count_units or 'CELLS/L', 'CELLS/L'
+        ))
+        # MIPI = 0.03535*age + 0.6978*[ECOG>=2] + 1.367*log10(LDH/ULN) + 0.9393*log10(WBC[10^9/L])
+        # ULN proxy 250 mirrors CB; revisit if a per-lab ULN becomes available.
+        score = (
+            0.03535 * age
+            + 0.6978 * (1 if ecog >= 2 else 0)
+            + 1.367 * log10(float(ldh) / 250)
+            + 0.9393 * log10(wbc_in_cells_per_l / 1e9)
+        )
+
+        if score < 5.7:
+            return 'low'
+        elif score < 6.5:
+            return 'intermediate'
+        return 'high'
+
+    @cached_property
+    def mipi_c_risk(self):
+        mipi = self.mipi_risk
+        ki67 = self.patient_info.ki67_proliferation_index
+
+        if mipi is None or ki67 is None:
+            return None
+
+        # 4-tier table (Hoster 2014). Threshold Ki-67 = 30%.
+        if mipi == 'low':
+            return 'low' if ki67 < 30 else 'low_intermediate'
+        if mipi == 'intermediate':
+            return 'low_intermediate' if ki67 < 30 else 'high_intermediate'
+        # high
+        return 'high_intermediate' if ki67 < 30 else 'high'
+
+    @cached_property
+    def bulky_disease_criteria(self):
+        """Codes for each bulky-disease criterion the patient meets.
+
+        Multiple thresholds can fire at once (e.g. a 12cm lesion produces
+        bulky_lesion_5cm, _7_5cm, and _10cm) so trials requiring any one of
+        them all match. Returns [] when no inputs or no thresholds met.
+        """
+        pi = self.patient_info
+        criteria = []
+
+        lesion = pi.lesion_size_mcl
+        if lesion is not None:
+            if lesion >= 5:
+                criteria.append('bulky_lesion_5cm')
+            if lesion >= 7.5:
+                criteria.append('bulky_lesion_7_5cm')
+            if lesion >= 10:
+                criteria.append('bulky_lesion_10cm')
+
+        node = pi.largest_lymph_node_size
+        if node is not None:
+            if node >= 5:
+                criteria.append('bulky_node_5cm')
+            if node >= 7.5:
+                criteria.append('bulky_node_7_5cm')
+            if node >= 10:
+                criteria.append('bulky_node_10cm')
+
+        spleen = pi.spleen_size
+        if spleen is not None:
+            if spleen > 13:
+                criteria.append('bulky_spleen_13cm')
+            if spleen > 15:
+                criteria.append('bulky_spleen_15cm')
+            if spleen > 20:
+                criteria.append('bulky_spleen_20cm_gt')
+            if spleen >= 20:
+                criteria.append('bulky_spleen_20cm_gte')
+
+        return criteria

--- a/trials/services/value_options.py
+++ b/trials/services/value_options.py
@@ -789,6 +789,24 @@ class ValueOptions:
         }
 
     @property
+    def bulky_disease_criteria(self):
+        # Canonical codes emitted by PatientInfoAttributes.bulky_disease_criteria.
+        # Trial-side bulky_disease_criteria_required values must overlap with
+        # this set for the matcher to fire.
+        return {
+            'bulky_lesion_5cm': 'Largest lesion >= 5 cm',
+            'bulky_lesion_7_5cm': 'Largest lesion >= 7.5 cm',
+            'bulky_lesion_10cm': 'Largest lesion >= 10 cm',
+            'bulky_node_5cm': 'Largest lymph node >= 5 cm',
+            'bulky_node_7_5cm': 'Largest lymph node >= 7.5 cm',
+            'bulky_node_10cm': 'Largest lymph node >= 10 cm',
+            'bulky_spleen_13cm': 'Spleen > 13 cm',
+            'bulky_spleen_15cm': 'Spleen > 15 cm',
+            'bulky_spleen_20cm_gt': 'Spleen > 20 cm',
+            'bulky_spleen_20cm_gte': 'Spleen >= 20 cm',
+        }
+
+    @property
     def er_statuses(self):
         from trials.models import EstrogenReceptorStatus
         items = EstrogenReceptorStatus.objects.order_by('id')
@@ -1146,5 +1164,8 @@ class ValueOptions:
             },
             'mipiCRisks': {
                 'options': self.to_value_and_label(self.mipi_c_risks)
+            },
+            'bulkyDiseaseCriteria': {
+                'options': self.to_value_and_label(self.bulky_disease_criteria)
             },
         }


### PR DESCRIPTION
## Summary

Fifth PR of the MCL series. Closes the contract opened in #72 — `mipi_risk` / `mipi_c_risk` / `bulky_disease_criteria` are now derived by the normalizer for MCL patients rather than accepted as caller input.

Closes #41. Follow-ups: #73 (trial-detail rendering), #75 (clinical cutoff reconciliation).

## What this does

Three new `@cached_property` derivations on `PatientInfoAttributes`:

| Property | Inputs | Output | Returns None when |
|---|---|---|---|
| `mipi_risk` | `patient_age`, `ecog_performance_status`, `white_blood_cell_count` (+units), `lactate_dehydrogenase_level` | `low` / `intermediate` / `high` | any input missing, or WBC/LDH non-positive |
| `mipi_c_risk` | `mipi_risk` + `ki67_proliferation_index` | `low` / `low_intermediate` / `high_intermediate` / `high` | MIPI inputs missing or Ki-67 missing |
| `bulky_disease_criteria` | `lesion_size_mcl`, `largest_lymph_node_size`, `spleen_size` | list of bulky-flag codes | `[]` when no inputs or no thresholds met |

Wired via `normalize._normalize_mcl_derivations(pi)` which gates on `disease.lower() == 'mantle cell lymphoma'` and overwrites caller-supplied values. Skipped for non-MCL patients so other diseases keep their defaults.

## Formula

**MIPI** (Hoster et al., Blood 2008;111:558-565):
```
MIPI = 0.03535*age + 0.6978*[ECOG>=2] + 1.367*log10(LDH/ULN) + 0.9393*log10(WBC[10^9/L])
```
Cutoffs: `< 5.7 → low`, `< 6.5 → intermediate`, `>= 6.5 → high`. ULN proxy = 250 U/L (mirrors CB).

**MIPI-C**: 4-cell categorical lookup over (MIPI bucket) x (Ki-67 < 30 vs >= 30). Mirrors CB at `patient_info_attributes.py:511-525`.

**Bulky disease**: 10 threshold-flag codes (matches CB exactly):
- `bulky_lesion_5cm` / `_7_5cm` / `_10cm` — lesion >= threshold
- `bulky_node_5cm` / `_7_5cm` / `_10cm` — node >= threshold
- `bulky_spleen_13cm` / `_15cm` / `_20cm_gt` — spleen > threshold (strict)
- `bulky_spleen_20cm_gte` — spleen >= 20 (overlapping with `_20cm_gt` so trials defining either match)

Multiple thresholds fire at once (a 12cm lesion produces `5cm`, `7.5cm`, AND `10cm`) so trials requiring any subset can match without separate "or" logic.

## Adaptations from CB

1. `bulky_disease_criteria` returns a list (matches EXACT's JSONField declaration), not the comma-joined string CB returns.
2. Bulky lesion thresholds key off `lesion_size_mcl` (EXACT's MCL-specific field), not CB's `largest_lesion_size`.

## value_options enum

Adds `bulkyDiseaseCriteria` to `/form-settings/` with all 10 canonical codes and human-readable labels. Frontend dropdowns now have a source-of-truth for what the matcher overlaps against. Surfaced by the self-review — without it, trial-side `bulky_disease_criteria_required` codes would drift from patient-side emit silently.

## Open clinical question (deferred to #75)

Codex flagged that CB's MIPI cutoff `5.7 / 6.5` and MIPI-C categorical lookup may diverge from the published Hoster 2008 (`5.7 / 6.2`) and Hoster 2016 (continuous combined formula) values. This PR mirrors CB for port-fidelity; #75 tracks reconciling CB+EXACT against the literature together.

## Tests

`tests/services/patient_info/test_mcl_derivations.py` (new, ~240 lines):
- MIPI: each output bucket, missing-input → None, WBC/LDH non-positive → None, ECOG 0 vs 1 equivalence, unit conversion from CELLS/UL
- MIPI-C: full 6-cell matrix, Ki-67 boundary at 30, missing inputs → None
- Bulky: empty inputs, each threshold boundary, multiple simultaneous criteria, the spleen `> 20 / >= 20` overlap
- Normalizer wiring: MCL fields get overwritten on MCL patients, non-MCL patients untouched
- Disease gate case-insensitivity (`'mantle cell lymphoma'` / `'Mantle Cell Lymphoma'` / `'MANTLE CELL LYMPHOMA'`)

`tests/services/patient_info/test_resolve_normalize_json.py`:
- Updates three pre-existing #72 MCL round-trip tests to reflect the new derived-overwrite contract (caller-supplied derived values no longer survive `_build_in_memory`)

`tests/services/test_value_options_mcl.py`:
- Adds `bulkyDiseaseCriteria` to the expected-keys set

## Files

- `trials/services/patient_info/patient_info_attributes.py` — 3 cached_property derivations (+104)
- `trials/services/patient_info/normalize.py` — `_normalize_mcl_derivations` hook (+24)
- `trials/services/patient_info/patient_info.py` — update forward-compat comment (+5 / -3)
- `trials/services/value_options.py` — `bulkyDiseaseCriteria` enum + registry entry (+21)
- `tests/services/patient_info/test_mcl_derivations.py` — new (+241)
- `tests/services/patient_info/test_resolve_normalize_json.py` — update 3 round-trip tests (+27 / -11)
- `tests/services/test_value_options_mcl.py` — add `bulkyDiseaseCriteria` (+1)

Total: +424 / -12

## Self-review history

Fresh-context Claude review caught that the new normalizer breaks 5 pre-existing assertions in `test_resolve_normalize_json.py` (#72 tests asserted caller values survived round-trip, but the #72 PR body explicitly said #41 would overwrite them). Fixed inline. Also caught the vocabulary-anchor gap that led to adding `bulkyDiseaseCriteria` to value_options. Codex flagged the clinical-cutoff disagreement with the published Hoster literature — deferred to #75 per port-fidelity choice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)