### PR TITLE
feat: wire MCL into trial_attributes.py disease branches

### DIFF
--- a/tests/services/test_value_options_mcl.py
+++ b/tests/services/test_value_options_mcl.py
@@ -66,6 +66,8 @@ class TestMclFormSettingsRegistry:
             'concomitantMedicationsMcl',
             'stagesMcl',
             'bulkyDiseaseCriteria',
+            'therapiesMcl',
+            'plannedTherapiesMcl',
         }
         missing = expected_keys - set(all_opts.keys())
         assert not missing, f'MCL keys not in get_all_options(): {missing}'

--- a/tests/services/trial_details/test_trial_attributes.py
+++ b/tests/services/trial_details/test_trial_attributes.py
@@ -50,3 +50,53 @@ class TestTrialAttributes:
 
         assert TrialAttributes(trial=trial, patient_info=patient_info).is_blank('negativePregnancyTestResultRequired', True, None) is False
         assert TrialAttributes(trial=trial, patient_info=patient_info).is_blank('noPregnancyOrLactationRequired', True, None) is False
+
+
+class TestMclTrialAttributes:
+    """Verify the MCL disease branch in __init__ aliases therapy / stage option
+    lists to the MCL-specific keys, mirroring the CLL pattern (#73).
+    """
+
+    @pytest.mark.django_db
+    def test_mcl_trial_aliases_therapy_options_to_mcl_keys(self):
+        patient_info = PatientInfo(disease='mantle cell lymphoma')
+        trial = TrialFactory(disease='mantle cell lymphoma')
+
+        attrs = TrialAttributes(trial, patient_info=patient_info)
+
+        # Each canonical key the UI consumes for trial detail rendering must
+        # point at the MCL-specific options list, not the union or any other
+        # disease.
+        for canonical, mcl_key in [
+            ('firstLineTherapy', 'therapiesFirstLineMcl'),
+            ('secondLineTherapy', 'therapiesSecondLineMcl'),
+            ('laterTherapy', 'therapiesLaterLineMcl'),
+            ('supportiveTherapiesRequired', 'supportiveTherapiesMcl'),
+            ('supportiveTherapiesExcluded', 'supportiveTherapiesMcl'),
+            ('therapiesRequired', 'therapiesMcl'),
+            ('therapiesExcluded', 'therapiesMcl'),
+            ('plannedTherapies', 'plannedTherapiesMcl'),
+            ('plannedTherapiesRequired', 'plannedTherapiesMcl'),
+            ('plannedTherapiesExcluded', 'plannedTherapiesMcl'),
+            ('stage', 'stagesMcl'),
+            ('stages', 'stagesMcl'),
+        ]:
+            assert attrs.all_options[canonical] is attrs.all_options[mcl_key], \
+                f'{canonical} should point at {mcl_key} for an MCL trial'
+
+    @pytest.mark.django_db
+    def test_non_mcl_trial_does_not_get_mcl_aliases(self):
+        # A CLL trial must continue to alias the canonical keys to CLL options,
+        # not MCL.
+        patient_info = PatientInfo(disease='chronic lymphocytic leukemia')
+        trial = TrialFactory(disease='chronic lymphocytic leukemia')
+
+        attrs = TrialAttributes(trial, patient_info=patient_info)
+
+        assert attrs.all_options['firstLineTherapy'] is attrs.all_options['therapiesFirstLineCll']
+        assert attrs.all_options['stages'] is attrs.all_options['stagesCll']
+        # CLL options must NOT be wired to MCL options. Identity check, not
+        # equality: both keys may resolve to a structurally identical
+        # `Unknown/Other`-only placeholder in the test DB (no MCL or CLL
+        # therapy-round seed data), so dict equality is meaningless.
+        assert attrs.all_options['therapiesFirstLineCll'] is not attrs.all_options['therapiesFirstLineMcl']

--- a/trials/services/trial_details/trial_attributes.py
+++ b/trials/services/trial_details/trial_attributes.py
@@ -147,6 +147,20 @@ class TrialAttributes:
             self.all_options['plannedTherapiesExcluded'] = self.all_options['plannedTherapiesCll']
             self.all_options['stage'] = self.all_options['stagesCll']
             self.all_options['stages'] = self.all_options['stagesCll']
+        elif self._trial.disease.lower() == 'mantle cell lymphoma':
+            self.all_options['firstLineTherapy'] = self.all_options['therapiesFirstLineMcl']
+            self.all_options['secondLineTherapy'] = self.all_options['therapiesSecondLineMcl']
+            self.all_options['laterTherapy'] = self.all_options['therapiesLaterLineMcl']
+            self.all_options['laterTherapies'] = self.all_options['laterTherapy']
+            self.all_options['supportiveTherapiesRequired'] = self.all_options['supportiveTherapiesMcl']
+            self.all_options['supportiveTherapiesExcluded'] = self.all_options['supportiveTherapiesMcl']
+            self.all_options['therapiesRequired'] = self.all_options['therapiesMcl']
+            self.all_options['therapiesExcluded'] = self.all_options['therapiesMcl']
+            self.all_options['plannedTherapies'] = self.all_options['plannedTherapiesMcl']
+            self.all_options['plannedTherapiesRequired'] = self.all_options['plannedTherapiesMcl']
+            self.all_options['plannedTherapiesExcluded'] = self.all_options['plannedTherapiesMcl']
+            self.all_options['stage'] = self.all_options['stagesMcl']
+            self.all_options['stages'] = self.all_options['stagesMcl']
 
         for k, v in self.all_options.items():
             self._all_value_options[k] = v

--- a/trials/services/value_options.py
+++ b/trials/services/value_options.py
@@ -892,6 +892,9 @@ class ValueOptions:
             'plannedTherapiesCll': {
                 'options': self.to_value_and_label(self.planned_therapies('CLL'))
             },
+            'plannedTherapiesMcl': {
+                'options': self.to_value_and_label(self.planned_therapies('MCL'))
+            },
             'cytogenicMarkers': {
                 'options': self.to_value_and_label(self.cytogenic_markers)
             },
@@ -954,6 +957,9 @@ class ValueOptions:
             },
             'therapiesCll': {
                 'options': self.to_value_and_label(self.therapies_by_disease_code('CLL'))
+            },
+            'therapiesMcl': {
+                'options': self.to_value_and_label(self.therapies_by_disease_code('MCL'))
             },
             'therapyComponentsMm': {
                 'options': self.to_value_and_label(self.therapy_components_by_disease_code('mm'))


### PR DESCRIPTION
## Summary

Sixth PR of the MCL series. Closes the trial-detail rendering gap that #74's self-review surfaced — MCL trials now get MCL-specific therapy / planned-therapy / stage dropdowns instead of falling through silently.

Closes #73.

## What changes

Three edits, ~70 lines total:

1. **`trials/services/trial_details/trial_attributes.py`** — adds an `elif disease.lower() == 'mantle cell lymphoma':` branch in `TrialAttributes.__init__` aliasing 12 canonical UI keys (`firstLineTherapy`, `secondLineTherapy`, `laterTherapy`, `supportiveTherapiesRequired/Excluded`, `therapiesRequired/Excluded`, `plannedTherapies/Required/Excluded`, `stage`, `stages`) to MCL-specific option lists. Mirrors the CLL branch exactly with `Cll` → `Mcl` substitutions.

2. **`trials/services/value_options.py`** — adds the two missing registry keys the new branch consumes (`therapiesMcl`, `plannedTherapiesMcl`). #74 added the line-specific therapy keys but missed these two aggregates.

3. **`tests/services/trial_details/test_trial_attributes.py`** — verifies each canonical key points at the MCL-specific options list for an MCL trial, and that a CLL trial keeps CLL aliases.

## Self-review

Both Codex and a fresh-context Claude pass caught the same P0 in my first test draft: a `!=` assertion comparing CLL vs MCL therapy options. In the test DB no CLL/MCL therapy-round seed data exists, so both registries reduce to the same `Unknown/Other`-only placeholder dict — the inequality is structurally `False`. Fixed inline by switching to identity check (`is not`), which actually proves the wiring routes through distinct registry entries.

Claude P1 flagged the wiring tests as content-tautological — the `is` checks prove the alias but don't prove the inner list has real therapies. Accepted: this PR is about wiring, not seed data. MCL therapy seeding is separate scope.

## Out of scope (intentionally deferred)

- `_DISEASE_TO_OUTCOME_KEY` map (`trial_attributes.py:172-177`) doesn't include MCL. MCL falls through to the union `therapyOutcome` (CR/sCR/VGPR/PR/MRD/SD/PD). Matches MM/FL/CLL behavior since `therapy_outcomes_by_disease_code` only differentiates BC today. Add both the registry key and the map entry if MCL ever needs disease-specific response criteria.
- Seeding MCL therapies, planned therapies, and concomitant medications — separate clinical-content task.

## Files

- `trials/services/trial_details/trial_attributes.py` (+14)
- `trials/services/value_options.py` (+6)
- `tests/services/trial_details/test_trial_attributes.py` (+50)
- `tests/services/test_value_options_mcl.py` (+2 — add `therapiesMcl`, `plannedTherapiesMcl` to the expected-keys set)

🤖 Generated with [Claude Code](https://claude.com/claude-code)