### PR TITLE
test: regression guard for relapse_count=0 in trial eligibility filter

### DIFF
--- a/tests/querysets/test_trial_querysets.py
+++ b/tests/querysets/test_trial_querysets.py
@@ -1227,6 +1227,44 @@ class TestTrialQuerySet:
 
         assert Trial.objects.filter_by_patient_info(patient_info)[0].count() == 1
 
+    @pytest.mark.django_db
+    def test_filter_by_patient_info_relapse_count_zero(self):
+        """Regression for #51 / CB #4186: relapse_count=0 must be treated as a
+        real value, not blank, so trials requiring relapse_count_min >= 1 are
+        excluded for never-relapsed patients."""
+        t_no_req = TrialFactory(
+            relapse_count_min=None, relapse_count_max=None, disease='multiple myeloma',
+        )
+        t_min_1 = TrialFactory(
+            relapse_count_min=1, relapse_count_max=None, disease='multiple myeloma',
+        )
+        t_min_0 = TrialFactory(
+            relapse_count_min=0, relapse_count_max=None, disease='multiple myeloma',
+        )
+
+        patient_zero = PatientInfo(
+            disease='multiple myeloma', relapse_count=0, prior_therapy='None',
+        )
+        result_ids = set(
+            Trial.objects.filter_by_patient_info(patient_zero)[0].values_list('id', flat=True)
+        )
+        assert t_no_req.id in result_ids
+        assert t_min_0.id in result_ids
+        assert t_min_1.id not in result_ids, (
+            'Trial requiring relapse_count_min=1 must be excluded when '
+            'patient has relapse_count=0 (never relapsed).'
+        )
+
+        # Patient with relapse_count=None (truly missing) still matches all
+        # three trials — unchanged behavior.
+        patient_blank = PatientInfo(
+            disease='multiple myeloma', relapse_count=None, prior_therapy='None',
+        )
+        blank_ids = set(
+            Trial.objects.filter_by_patient_info(patient_blank)[0].values_list('id', flat=True)
+        )
+        assert {t_no_req.id, t_min_0.id, t_min_1.id}.issubset(blank_ids)
+
     # weights used throughout goodness score tests
     _BENEFIT_W, _BURDEN_W, _RISK_W, _DIST_W = 50, 25, 15, 10
 


### PR DESCRIPTION
## Summary

Closes #51. Adds a regression test for `relapse_count=0`.

## Background

The production guard for "integer 0 is a real value, not blank" was already in EXACT:
- `trials/querysets/trial.py:1194-1201` — gates the integer-zero skip on `allow_blank_values`
- `trials/querysets/trial.py:1348 / 1355 / 1366` — plumbs `skip_blank=not allow_blank_values` through the call sites
- `trials/services/patient_info/configs.py:885` — `relapse_count` mapping has `allow_blank_values: True`

But no test exercised the zero edge case. A future change that flipped the gate (e.g. removing `if not allow_blank_values:` or the `skip_blank` plumbing) would land silently. CB landed both the fix AND a test in commit `135f5108`; EXACT only had the fix.

## Test

`test_filter_by_patient_info_relapse_count_zero`:
- Creates 3 MM trials differing only in `relapse_count_min` (None / 0 / 1).
- Patient with `relapse_count=0` matches the `None` and `=0` trials, NOT the `>=1` trial.
- Patient with `relapse_count=None` (truly missing) matches all 3 trials (unchanged blank semantics).

The trials are intentionally minimal (only `relapse_count_min` differs) so any divergence in match results is attributable to the relapse_count filter — no false-positive exclusion path.

## Self-review

Both Codex `review` and a fresh-context Claude pass independently verified the test reaches the production guard:
- `is_attr_blank('relapse_count')` returns False for value=0 because `allow_blank_values=True` short-circuits the zero check at `patient_info_attributes.py:49`.
- `eligible_for_min_max_value(..., 0, skip_blank=False)` does not early-return for 0 when `skip_blank=False`, then applies `relapse_count_min__lte=0 OR isnull` and `relapse_count_max__gte=0 OR isnull`.

Verified no pre-existing coverage of the zero case (`grep relapse_count` shows only `relapse_count=2` in unrelated multi-attribute integration tests).

## Files

- `tests/querysets/test_trial_querysets.py` (+38)

🤖 Generated with [Claude Code](https://claude.com/claude-code)