### PR TITLE
test: regression guards for progression='' and peripheral_neuropathy_grade=0

### DIFF
--- a/tests/services/test_user_to_trial_attr_matcher.py
+++ b/tests/services/test_user_to_trial_attr_matcher.py
@@ -202,3 +202,60 @@ class TestUserToTrialAttrMatcher:
             pi.treatment_refractory_status = value
             assert matcher.attr_match_status('treatment_refractory_status') == 'matched', \
                 f'Expected matched for value={value!r}'
+
+    @pytest.mark.django_db
+    def test_progression_empty_string_is_unknown(self):
+        """Regression for #52 / CB #4306: the UI represents "Unknown"
+        progression as '' (see ValueOptions.progressions). The matcher must
+        treat '' the same as None, returning 'unknown' instead of falling
+        through to 'not_matched' against a trial requiring active disease.
+        """
+        trial = TrialFactory(disease_progression_active_required=True)
+        pi = PatientInfo(disease='multiple myeloma')
+        matcher = UserToTrialAttrMatcher(trial, pi)
+
+        # None → unknown (control, unchanged behavior)
+        pi.progression = None
+        assert matcher.attr_match_status('progression') == 'unknown'
+
+        # Empty string → unknown (the fix path)
+        pi.progression = ''
+        assert matcher.attr_match_status('progression') == 'unknown'
+
+        # 'active' patient → matched (sanity check)
+        pi.progression = 'active'
+        assert matcher.attr_match_status('progression') == 'matched'
+
+        # 'smoldering' patient against active-required trial → not_matched
+        pi.progression = 'smoldering'
+        assert matcher.attr_match_status('progression') == 'not_matched'
+
+    @pytest.mark.django_db
+    def test_peripheral_neuropathy_grade_zero_matches(self):
+        """Regression for #53 / CB #4307: Grade 0 is a real clinical value,
+        not blank. The configs.py entry must carry allow_blank_values=True
+        so is_attr_blank() does not coerce 0 to 'unknown' against trials
+        with peripheral_neuropathy_grade_max=0.
+        """
+        trial_no_limit = TrialFactory(disease='multiple myeloma')
+        trial_max_zero = TrialFactory(disease='multiple myeloma', peripheral_neuropathy_grade_max=0)
+        trial_max_two = TrialFactory(disease='multiple myeloma', peripheral_neuropathy_grade_max=2)
+
+        pi = PatientInfo(disease='multiple myeloma')
+
+        # Blank patient: no-limit trial matches; max=0 trial is unknown.
+        pi.peripheral_neuropathy_grade = None
+        assert UserToTrialAttrMatcher(trial_no_limit, pi).attr_match_status('peripheral_neuropathy_grade') == 'matched'
+        assert UserToTrialAttrMatcher(trial_max_zero, pi).attr_match_status('peripheral_neuropathy_grade') == 'unknown'
+
+        # Grade 0 patient: matches every trial (this is the fix path — used
+        # to be 'unknown' against max=0 because 0 was treated as blank).
+        pi.peripheral_neuropathy_grade = 0
+        assert UserToTrialAttrMatcher(trial_no_limit, pi).attr_match_status('peripheral_neuropathy_grade') == 'matched'
+        assert UserToTrialAttrMatcher(trial_max_zero, pi).attr_match_status('peripheral_neuropathy_grade') == 'matched'
+        assert UserToTrialAttrMatcher(trial_max_two, pi).attr_match_status('peripheral_neuropathy_grade') == 'matched'
+
+        # Grade 3 patient: excluded by any max< 3 trial.
+        pi.peripheral_neuropathy_grade = 3
+        assert UserToTrialAttrMatcher(trial_max_zero, pi).attr_match_status('peripheral_neuropathy_grade') == 'not_matched'
+        assert UserToTrialAttrMatcher(trial_max_two, pi).attr_match_status('peripheral_neuropathy_grade') == 'not_matched'


### PR DESCRIPTION
## Summary

Closes #52 and #53. Test-only — production fixes were already in EXACT.

## Background

Both bugs share the "missing-data classification" anti-pattern: a real value (empty string, integer 0) was being treated as blank by the matcher, downgrading trial eligibility from Potential / matched to Ineligible / not_matched.

The production fixes:

- `trials/services/user_to_trial_attr_matcher.py:400` — the `progression` custom_search branch accepts both `None` and `''` for the unknown check. The UI sends `''` when the user selects "Unknown" (see `ValueOptions.progressions`).
- `trials/services/patient_info/configs.py:249` — `peripheral_neuropathy_grade` has `allow_blank_values: True`, which prevents `is_attr_blank()` at `patient_info_attributes.py:54` from coercing 0 to 'unknown' against trials with `peripheral_neuropathy_grade_max=0`.

Both lines already exist on `main`. No prior test exercised the zero / empty-string edge cases, so a future change that dropped either guard would land silently. CB landed both fixes alongside tests in commits `d8e33c80` (#52) and `8dceb78f` (#53); EXACT only had the fixes.

## Tests

**`test_progression_empty_string_is_unknown`** — trial with `disease_progression_active_required=True`. Asserts:
- `pi.progression=None` → 'unknown' (control)
- `pi.progression=''` → 'unknown' (the fix path; would be 'not_matched' without the empty-string check)
- `pi.progression='active'` → 'matched'
- `pi.progression='smoldering'` → 'not_matched'

**`test_peripheral_neuropathy_grade_zero_matches`** — three trials differing only in `peripheral_neuropathy_grade_max` (None / 0 / 2). Asserts:
- Blank patient: no-limit trial matched, max=0 trial unknown.
- Grade 0 patient: matches all three trials (the fix path).
- Grade 3 patient: excluded by both limited trials.

## Self-review

Codex `review` and a fresh-context Claude pass independently verified the production fix lines exist where claimed and the new tests reach the fix paths via traced execution. No `TrialFactory` defaults short-circuit either trace; no pre-existing test overlap.

Note: the issue bodies (#52 line 393, #53 line 211) reference stale line numbers — the actual fix lines drifted to 400 and 249. Fixes are still in place, just on different lines.

## Files

- `tests/services/test_user_to_trial_attr_matcher.py` (+57)

🤖 Generated with [Claude Code](https://claude.com/claude-code)