### PR TITLE
test: measurable_disease_imwg + meets_slim show as Potential not Ineligible

### DIFF
--- a/tests/services/test_user_to_trial_attr_matcher.py
+++ b/tests/services/test_user_to_trial_attr_matcher.py
@@ -1,6 +1,7 @@
 import pytest
 
 from trials.services.patient_info.patient_info import PatientInfo
+from trials.services.patient_info.normalize import normalize_patient_info
 from trials.services.user_to_trial_attr_matcher import UserToTrialAttrMatcher
 from tests.factories import TrialFactory
 
@@ -229,6 +230,85 @@ class TestUserToTrialAttrMatcher:
         # 'smoldering' patient against active-required trial → not_matched
         pi.progression = 'smoldering'
         assert matcher.attr_match_status('progression') == 'not_matched'
+
+    @pytest.mark.django_db
+    def test_measurable_disease_imwg_unknown_for_empty_labs(self):
+        """Regression for #54 / CB #4143-#4156: a patient with no IMWG-relevant
+        lab values must show as Potential ('unknown'), not Ineligible
+        ('not_matched'), against a trial requiring measurable_disease_imwg.
+
+        Even when labs ARE present but the patient doesn't qualify (real False),
+        the matcher should still return 'unknown' because measurable_disease_imwg
+        is a derived/computed field the user cannot directly answer — surfacing
+        the trial as Potential is the desired UX. The under_user_control flag
+        in configs.py is what enforces this.
+        """
+        # Patient with all IMWG lab inputs blank → measurable_disease_imwg=None.
+        pi = PatientInfo(
+            disease='multiple myeloma',
+            monoclonal_protein_serum=None,
+            monoclonal_protein_urine=None,
+            kappa_flc=None,
+            lambda_flc=None,
+        )
+        normalize_patient_info(pi)
+        assert pi.measurable_disease_imwg is None
+
+        # Trial doesn't require → matched regardless of patient value.
+        trial_no_req = TrialFactory(measurable_disease_imwg_required=None)
+        assert UserToTrialAttrMatcher(trial_no_req, pi).attr_match_status('measurable_disease_imwg') == 'matched'
+
+        # Trial requires + empty labs → 'unknown' (NOT 'not_matched').
+        trial_requires = TrialFactory(measurable_disease_imwg_required=True)
+        assert UserToTrialAttrMatcher(trial_requires, pi).attr_match_status('measurable_disease_imwg') == 'unknown'
+
+        # Patient has qualifying labs (serum M-protein >= 0.5) → 'matched'.
+        pi.monoclonal_protein_serum = 5
+        normalize_patient_info(pi)
+        assert pi.measurable_disease_imwg is True
+        assert UserToTrialAttrMatcher(trial_requires, pi).attr_match_status('measurable_disease_imwg') == 'matched'
+
+        # Patient has labs but doesn't qualify (real False) → still 'unknown'
+        # because under_user_control prefers Potential over hard-reject on a
+        # derived value the user couldn't have answered themselves.
+        pi.monoclonal_protein_serum = 0.1  # below 0.5 g/dL threshold
+        normalize_patient_info(pi)
+        assert pi.measurable_disease_imwg is False
+        assert UserToTrialAttrMatcher(trial_requires, pi).attr_match_status('measurable_disease_imwg') == 'unknown'
+
+    @pytest.mark.django_db
+    def test_meets_slim_unknown_for_empty_labs(self):
+        """Regression for #54 / CB #4143-#4156: same UX rule for meets_slim.
+
+        The derivation (PatientInfoAttributes.meets_slim) already returns None
+        for all-blank inputs, but without under_user_control in the config the
+        matcher coerced None -> False and returned 'not_matched'. The fix is
+        the under_user_control flag added when the meets_slim entry was
+        uncommented in configs.py.
+        """
+        pi = PatientInfo(
+            disease='multiple myeloma',
+            clonal_plasma_cells=None,
+            kappa_flc=None,
+            lambda_flc=None,
+            bone_lesions='',
+        )
+        normalize_patient_info(pi)
+        assert pi.meets_slim is None
+
+        # Trial doesn't require → matched.
+        trial_no_req = TrialFactory(meets_slim=None)
+        assert UserToTrialAttrMatcher(trial_no_req, pi).attr_match_status('meets_slim') == 'matched'
+
+        # Trial requires + empty labs → 'unknown' (NOT 'not_matched').
+        trial_requires = TrialFactory(meets_slim=True)
+        assert UserToTrialAttrMatcher(trial_requires, pi).attr_match_status('meets_slim') == 'unknown'
+
+        # Patient meets SLiM via the S component (>=60% clonal plasma cells).
+        pi.clonal_plasma_cells = 65
+        normalize_patient_info(pi)
+        assert pi.meets_slim is True
+        assert UserToTrialAttrMatcher(trial_requires, pi).attr_match_status('meets_slim') == 'matched'
 
     @pytest.mark.django_db
     def test_peripheral_neuropathy_grade_zero_matches(self):


### PR DESCRIPTION
## Summary

Closes #54. Test-only — all three production fixes were already in EXACT.

## Background

Both `measurable_disease_imwg` and `meets_slim` are derived/computed fields on PatientInfo. The user cannot directly answer them — they are derived from blood-protein and bone-marrow lab inputs. When those inputs are missing, the desired UX is to surface trials requiring these fields as Potential (matcher returns `unknown`), not Ineligible (`not_matched`).

The production fixes:
- `trials/services/patient_info/configs.py:297` — `measurable_disease_imwg` has `under_user_control: True`
- `trials/services/patient_info/configs.py:1043-1049` — `meets_slim` entry is uncommented and has `under_user_control: True`
- `trials/services/patient_info/normalize.py:213-215` — `_normalize_measurable_disease_imwg` returns `None` when all source components (`monoclonal_protein_serum`, `monoclonal_protein_urine`, `kappa_flc`+`lambda_flc`) are None

The matcher's bool_restriction branch coerces None → False at the restriction check, but the `under_user_control` flag rescues both None and a real-False derived value by returning `unknown` instead of `not_matched`. No prior test exercised this path.

## Tests

**`test_measurable_disease_imwg_unknown_for_empty_labs`** — three patient states against a trial requiring `measurable_disease_imwg=True`:
- All 4 lab inputs None → derived None → `unknown` (the regression path)
- `monoclonal_protein_serum=5` (>= 0.5 g/dL) → derived True → `matched`
- `monoclonal_protein_serum=0.1` (below 0.5 g/dL) → derived False → still `unknown` because `under_user_control` prefers Potential over hard-reject on a derived value

**`test_meets_slim_unknown_for_empty_labs`** — parallel structure:
- All inputs None → derived None → `unknown`
- `clonal_plasma_cells=65` triggers the S component (>= 60%) → derived True → `matched`

Both tests use `normalize_patient_info(pi)` to populate the derived field on the stateless PatientInfo, then call `attr_match_status(...)` on `UserToTrialAttrMatcher`.

## Self-review

Codex `review` and a fresh-context Claude pass independently verified:
- Production fixes exist at the claimed lines.
- `normalize_patient_info` produces the asserted derived values for each lab combination (traced via `_normalize_measurable_disease_imwg` and `PatientInfoAttributes.meets_slim`).
- The matcher's bool_restriction + `under_user_control` branch returns `unknown` for both None and False patient values when the trial requires True.
- No `TrialFactory` defaults short-circuit the `attr_match_status` per-attribute path (disease gating only applies in `trial_match_status()`, not `attr_match_status()`).

Adjacent pre-existing bug noted (not blocking, sibling of #51/#52/#53 cluster): `_normalize_measurable_disease_imwg` lines 180 and 185 use `if not pi.monoclonal_protein_serum: return None`, which treats integer 0 (a clinically meaningful "absent M-protein" value) as missing. Worth filing as a follow-up issue.

## Files

- `tests/services/test_user_to_trial_attr_matcher.py` (+80)

🤖 Generated with [Claude Code](https://claude.com/claude-code)