### PR TITLE
fix: BC therapyOutcome dropdown is RECIST 4-value subset via form-settings

### DIFF
--- a/tests/services/test_value_options_mcl.py
+++ b/tests/services/test_value_options_mcl.py
@@ -68,6 +68,7 @@ class TestMclFormSettingsRegistry:
             'bulkyDiseaseCriteria',
             'therapiesMcl',
             'plannedTherapiesMcl',
+            'therapyOutcomeMcl',
         }
         missing = expected_keys - set(all_opts.keys())
         assert not missing, f'MCL keys not in get_all_options(): {missing}'

--- a/tests/views/test_form_settings_therapy_outcome.py
+++ b/tests/views/test_form_settings_therapy_outcome.py
@@ -1,0 +1,100 @@
+"""
+Tests for disease-aware therapyOutcome in /form-settings/ (#60 / #70).
+
+Calling /form-settings/?disease=BC must downgrade the union therapyOutcome
+enum to the BC-applicable 4-value subset (CR / PR / SD / PD). All other
+diseases (MM / FL / CLL / MCL) still see the full 7-value enum. Without
+this override, BC patients on a frontend that reads /form-settings/
+therapyOutcome see MM-specific IMWG categories (sCR / VGPR / MRD) that
+don't apply clinically.
+"""
+import pytest
+from unittest.mock import MagicMock
+
+from trials.api.trials_views import FormSettingsViewSet
+from trials.services.value_options import ValueOptions
+
+
+def _form_settings_response(disease_param):
+    """Drive FormSettingsViewSet.list with a query-param request, bypass auth."""
+    view = FormSettingsViewSet()
+    mock_request = MagicMock()
+    mock_request.query_params = {'disease': disease_param} if disease_param else {}
+    return view.list(mock_request).data
+
+
+class TestTherapyOutcomesByDiseaseCode:
+    """Unit-level: per-disease subsetting in ValueOptions."""
+
+    def test_bc_returns_recist_only(self):
+        result = ValueOptions().therapy_outcomes_by_disease_code('BC')
+        assert set(result.keys()) == {'CR', 'PR', 'SD', 'PD'}
+
+    @pytest.mark.parametrize('code', ['MM', 'FL', 'CLL', 'MCL'])
+    def test_non_bc_returns_full_enum(self, code):
+        result = ValueOptions().therapy_outcomes_by_disease_code(code)
+        # Full IMWG set: CR + sCR + VGPR + PR + MRD + SD + PD.
+        assert set(result.keys()) == {'CR', 'sCR', 'VGPR', 'PR', 'MRD', 'SD', 'PD'}
+
+    def test_unknown_disease_falls_through_to_union(self):
+        result = ValueOptions().therapy_outcomes_by_disease_code('UNKNOWN')
+        assert set(result.keys()) == {'CR', 'sCR', 'VGPR', 'PR', 'MRD', 'SD', 'PD'}
+
+    def test_lowercase_disease_code_is_normalized(self):
+        # therapy_outcomes_by_disease_code uppercases the input; lowercase 'bc'
+        # must yield the BC subset.
+        result = ValueOptions().therapy_outcomes_by_disease_code('bc')
+        assert set(result.keys()) == {'CR', 'PR', 'SD', 'PD'}
+
+
+class TestFormSettingsTherapyOutcomeOverride:
+    """Integration-level: FormSettingsViewSet.list substitutes therapyOutcome."""
+
+    @pytest.mark.django_db
+    def test_no_disease_param_returns_union(self):
+        data = _form_settings_response('')
+        codes = [opt['value'] for opt in data['therapyOutcome']['options']]
+        assert set(codes) == {'CR', 'sCR', 'VGPR', 'PR', 'MRD', 'SD', 'PD'}
+
+    @pytest.mark.django_db
+    def test_bc_disease_downgrades_therapy_outcome_to_recist(self):
+        data = _form_settings_response('breast cancer')
+        codes = [opt['value'] for opt in data['therapyOutcome']['options']]
+        assert set(codes) == {'CR', 'PR', 'SD', 'PD'}, \
+            'BC ?disease= must downgrade therapyOutcome to RECIST 4-value subset'
+
+    @pytest.mark.django_db
+    @pytest.mark.parametrize('disease,_code', [
+        ('multiple myeloma', 'MM'),
+        ('follicular lymphoma', 'FL'),
+        ('chronic lymphocytic leukemia', 'CLL'),
+        ('mantle cell lymphoma', 'MCL'),
+    ])
+    def test_non_bc_disease_keeps_full_enum(self, disease, _code):
+        data = _form_settings_response(disease)
+        codes = [opt['value'] for opt in data['therapyOutcome']['options']]
+        assert set(codes) == {'CR', 'sCR', 'VGPR', 'PR', 'MRD', 'SD', 'PD'}
+
+    @pytest.mark.django_db
+    @pytest.mark.parametrize('shortcode', ['MM', 'BC', 'FL', 'CLL', 'MCL'])
+    def test_disease_shortcodes_route_through_override(self, shortcode):
+        # _normalize_disease_code must accept every supported shortcode, not
+        # just MM/BC/FL/CLL. Without MCL in the tuple, ?disease=MCL falls
+        # through to disease_code='', the override block is skipped, and the
+        # union therapyOutcome leaks out.
+        data = _form_settings_response(shortcode)
+        codes = [opt['value'] for opt in data['therapyOutcome']['options']]
+        if shortcode == 'BC':
+            assert set(codes) == {'CR', 'PR', 'SD', 'PD'}
+        else:
+            assert set(codes) == {'CR', 'sCR', 'VGPR', 'PR', 'MRD', 'SD', 'PD'}
+
+    @pytest.mark.django_db
+    def test_per_disease_outcome_keys_still_present(self):
+        # Sanity: the per-disease registry keys remain (they're what the
+        # trial-detail layer at trial_attributes._DISEASE_TO_OUTCOME_KEY
+        # consumes).
+        data = _form_settings_response('')
+        for key in ('therapyOutcomeMm', 'therapyOutcomeFl', 'therapyOutcomeBc',
+                    'therapyOutcomeCll', 'therapyOutcomeMcl'):
+            assert key in data, f'Missing {key} in form-settings response'

--- a/trials/api/trials_views.py
+++ b/trials/api/trials_views.py
@@ -278,12 +278,17 @@ class FormSettingsViewSet(viewsets.ViewSet):
         if disease_code:
             trial_types = ValueOptions.trial_types_by_disease_code(disease_code)
             out['trialType'] = {'options': ValueOptions.to_value_and_label(trial_types)}
+            # Disease-aware treatment outcomes (#60 / #70 / CB #4137).
+            # Without this override callers reading the union `therapyOutcome`
+            # would still see IMWG-specific sCR / VGPR / MRD for BC patients.
+            outcomes = ValueOptions().therapy_outcomes_by_disease_code(disease_code)
+            out['therapyOutcome'] = {'options': ValueOptions.to_value_and_label(outcomes)}
         return Response(out)
 
     def _normalize_disease_code(self, disease_param: str) -> str:
         if not disease_param:
             return ''
         lower = disease_param.lower().strip()
-        if lower.upper() in ('MM', 'BC', 'FL', 'CLL'):
+        if lower.upper() in ('MM', 'BC', 'FL', 'CLL', 'MCL'):
             return lower.upper()
         return self.DISEASE_NAME_TO_CODE.get(lower, '')

--- a/trials/services/value_options.py
+++ b/trials/services/value_options.py
@@ -874,6 +874,9 @@ class ValueOptions:
             'therapyOutcomeCll': {
                 'options': self.to_value_and_label(self.therapy_outcomes_by_disease_code('CLL'))
             },
+            'therapyOutcomeMcl': {
+                'options': self.to_value_and_label(self.therapy_outcomes_by_disease_code('MCL'))
+            },
             'ethnicity': {
                 'options': self.to_value_and_label(self.ethnicities)
             },


### PR DESCRIPTION
## Summary

Closes #60 and #70. Plus a related pre-existing MCL shortcode bug surfaced by self-review.

## The gaps

The trial-detail layer at `trial_attributes.py:172-177` already aliased `firstLineOutcome` / `secondLineOutcome` / `laterOutcome` per disease (PR #66). But:

1. **#60** — `value_options.therapy_outcomes_by_disease_code` exists with BC subsetting (CR/PR/SD/PD), but no caller exposed it to BC patient-side flows.
2. **#70** — `/form-settings/?disease=BC` still returned the union `therapyOutcome` (CR/sCR/VGPR/PR/MRD/SD/PD). Any frontend / API consumer reading it directly saw MM-specific IMWG codes for BC patients.
3. **MCL was missing** — `therapyOutcomeMcl` wasn't in the registry, and `_normalize_disease_code` excluded `'MCL'` from its shortcode tuple, so `?disease=MCL` silently fell through to `disease_code=''` and bypassed every disease override (including the pre-existing `trialType` one).

## Fix

`FormSettingsViewSet.list` now substitutes `out['therapyOutcome']` with `therapy_outcomes_by_disease_code(disease_code)` when `?disease=` is set, mirroring the existing `trialType` substitution at the same call site. BC patients get the 4-value RECIST subset; MM/FL/CLL/MCL keep the full IMWG enum.

Adds the missing `therapyOutcomeMcl` registry entry. Adds `'MCL'` to the shortcode tuple alongside `MM/BC/FL/CLL` so all 5 shortcodes route through every disease override.

## Tests

- `tests/views/test_form_settings_therapy_outcome.py` (new): BC subset, MM/FL/CLL/MCL full enum, no-disease fallback, parametrized shortcode regression (the gap that the self-review caught), unknown disease, case-insensitivity, per-disease keys retention.
- `tests/services/test_value_options_mcl.py`: extends `expected_keys` for `therapyOutcomeMcl`.

## Self-review

Codex `review` flagged no issues. Fresh-context Claude pass found the MCL shortcode bypass at `trials_views.py:292` — pre-existing scaffolding but newly load-bearing for this fix. Auto-fixed inline; test parametrize covers it.

One P2 noted as follow-up: `therapy_outcomes_by_disease_code('MCL')` returns the union, but MCL response criteria (Cheson/Lugano) are CR/PR/SD/PD only — sCR/VGPR/MRD don't apply. Out of scope per #60 issue text (says MM/FL/CLL still see the full set), but worth its own ticket.

## Files

- `trials/api/trials_views.py` (+7 / -1)
- `trials/services/value_options.py` (+3)
- `tests/views/test_form_settings_therapy_outcome.py` (new, ~100 lines)
- `tests/services/test_value_options_mcl.py` (+1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)