### PR TITLE
fix: IMWG normalizer treats 0 as real value + MCL therapy outcomes Cheson/Lugano

### DIFF
--- a/tests/services/test_user_to_trial_attr_matcher.py
+++ b/tests/services/test_user_to_trial_attr_matcher.py
@@ -277,6 +277,58 @@ class TestUserToTrialAttrMatcher:
         assert UserToTrialAttrMatcher(trial_requires, pi).attr_match_status('measurable_disease_imwg') == 'unknown'
 
     @pytest.mark.django_db
+    def test_measurable_disease_imwg_zero_lab_is_real_false(self):
+        """Regression for #81: serum / urine M-protein / FLC = 0 are real
+        clinical measurements, not missing data. The IMWG normalizer
+        previously used `if not pi.X` on serum and urine, and
+        `if not ratio` on the kappa/lambda ratio — all three collapsed
+        0 to None or False, misclassifying patients with real zero values.
+        """
+        # Patient with serum=0 + urine=0 + no FLC → serum and urine
+        # components produce real False (was None pre-fix), FLC stays None.
+        # Outer function: components=[False, False, None] → not-all-None →
+        # derived value is False, not None.
+        pi = PatientInfo(
+            disease='multiple myeloma',
+            monoclonal_protein_serum=0,
+            monoclonal_protein_urine=0,
+            kappa_flc=None,
+            lambda_flc=None,
+        )
+        normalize_patient_info(pi)
+        assert pi.measurable_disease_imwg is False
+
+        # End-to-end: matcher must still bucket this as 'unknown' against
+        # a requiring trial because measurable_disease_imwg is under user
+        # control (#54 contract preserved by this PR).
+        trial_requires = TrialFactory(measurable_disease_imwg_required=True)
+        assert UserToTrialAttrMatcher(trial_requires, pi).attr_match_status('measurable_disease_imwg') == 'unknown'
+
+        # Patient with serum=0 + qualifying urine → True (urine wins).
+        pi.monoclonal_protein_urine = 300  # >= 200 threshold
+        normalize_patient_info(pi)
+        assert pi.measurable_disease_imwg is True
+
+        # Kappa FLC = 0, lambda FLC = 200: ratio = 0.0, well below the
+        # 0.26 abnormal threshold. Pre-fix `if not ratio` returned False
+        # here; post-fix the ratio is treated as the real abnormal value
+        # it is. Lambda >= 100 makes kappa_lambda_abnormal_and_high True,
+        # so derived IMWG flips to True.
+        pi.monoclonal_protein_serum = None
+        pi.monoclonal_protein_urine = None
+        pi.kappa_flc = 0
+        pi.lambda_flc = 200
+        normalize_patient_info(pi)
+        assert pi.measurable_disease_imwg is True
+
+        # Sanity: all-None inputs (true missing data) still derive None
+        # (the #54 contract — Potential bucket).
+        pi.kappa_flc = None
+        pi.lambda_flc = None
+        normalize_patient_info(pi)
+        assert pi.measurable_disease_imwg is None
+
+    @pytest.mark.django_db
     def test_meets_slim_unknown_for_empty_labs(self):
         """Regression for #54 / CB #4143-#4156: same UX rule for meets_slim.
 

--- a/tests/services/trial_details/test_trial_attributes.py
+++ b/tests/services/trial_details/test_trial_attributes.py
@@ -100,3 +100,28 @@ class TestMclTrialAttributes:
         # `Unknown/Other`-only placeholder in the test DB (no MCL or CLL
         # therapy-round seed data), so dict equality is meaningless.
         assert attrs.all_options['therapiesFirstLineCll'] is not attrs.all_options['therapiesFirstLineMcl']
+
+    @pytest.mark.django_db
+    def test_mcl_patient_outcome_aliases_to_mcl_subset(self):
+        """Regression for #83 second leg: MCL patients must see Cheson/Lugano
+        4-value outcome options on firstLineOutcome / secondLineOutcome /
+        laterOutcome. The patient disease drives _therapy_outcome_options_key.
+        Without 'mantle cell lymphoma' in _DISEASE_TO_OUTCOME_KEY, MCL fell
+        through to the union 'therapyOutcome' (7-value IMWG enum), leaking
+        sCR / VGPR / MRD codes that don't apply clinically.
+        """
+        patient_info = PatientInfo(disease='mantle cell lymphoma')
+        trial = TrialFactory(disease='mantle cell lymphoma')
+
+        attrs = TrialAttributes(trial, patient_info=patient_info)
+
+        # Each outcome key must alias to therapyOutcomeMcl, NOT the union.
+        for canonical in ('firstLineOutcome', 'secondLineOutcome', 'laterOutcome'):
+            assert attrs.all_options[canonical] is attrs.all_options['therapyOutcomeMcl'], \
+                f'{canonical} should point at therapyOutcomeMcl for an MCL patient'
+            assert attrs.all_options[canonical] is not attrs.all_options['therapyOutcome'], \
+                f'{canonical} must not leak the union 7-value enum for MCL'
+
+        # Sanity: the MCL outcome set is the 4-value Cheson/Lugano subset.
+        codes = {opt['value'] for opt in attrs.all_options['firstLineOutcome']['options']}
+        assert codes == {'CR', 'PR', 'SD', 'PD'}

--- a/tests/views/test_form_settings_therapy_outcome.py
+++ b/tests/views/test_form_settings_therapy_outcome.py
@@ -1,12 +1,12 @@
 """
-Tests for disease-aware therapyOutcome in /form-settings/ (#60 / #70).
+Tests for disease-aware therapyOutcome in /form-settings/ (#60 / #70 / #83).
 
-Calling /form-settings/?disease=BC must downgrade the union therapyOutcome
-enum to the BC-applicable 4-value subset (CR / PR / SD / PD). All other
-diseases (MM / FL / CLL / MCL) still see the full 7-value enum. Without
-this override, BC patients on a frontend that reads /form-settings/
-therapyOutcome see MM-specific IMWG categories (sCR / VGPR / MRD) that
-don't apply clinically.
+Calling /form-settings/?disease=BC or ?disease=MCL downgrades the union
+therapyOutcome enum to the 4-value RECIST / Cheson-Lugano subset
+(CR / PR / SD / PD). MM / FL / CLL still see the full 7-value IMWG
+enum. Without this override, BC or MCL patients on a frontend that
+reads /form-settings/ therapyOutcome see MM-specific IMWG categories
+(sCR / VGPR / MRD) that don't apply clinically.
 """
 import pytest
 from unittest.mock import MagicMock
@@ -26,12 +26,15 @@ def _form_settings_response(disease_param):
 class TestTherapyOutcomesByDiseaseCode:
     """Unit-level: per-disease subsetting in ValueOptions."""
 
-    def test_bc_returns_recist_only(self):
-        result = ValueOptions().therapy_outcomes_by_disease_code('BC')
+    @pytest.mark.parametrize('code', ['BC', 'MCL'])
+    def test_recist_diseases_return_four_value_subset(self, code):
+        # BC uses RECIST, MCL uses Cheson 2014 / Lugano 2014 — both yield
+        # the same 4-value CR/PR/SD/PD subset.
+        result = ValueOptions().therapy_outcomes_by_disease_code(code)
         assert set(result.keys()) == {'CR', 'PR', 'SD', 'PD'}
 
-    @pytest.mark.parametrize('code', ['MM', 'FL', 'CLL', 'MCL'])
-    def test_non_bc_returns_full_enum(self, code):
+    @pytest.mark.parametrize('code', ['MM', 'FL', 'CLL'])
+    def test_imwg_diseases_return_full_enum(self, code):
         result = ValueOptions().therapy_outcomes_by_disease_code(code)
         # Full IMWG set: CR + sCR + VGPR + PR + MRD + SD + PD.
         assert set(result.keys()) == {'CR', 'sCR', 'VGPR', 'PR', 'MRD', 'SD', 'PD'}
@@ -40,10 +43,10 @@ class TestTherapyOutcomesByDiseaseCode:
         result = ValueOptions().therapy_outcomes_by_disease_code('UNKNOWN')
         assert set(result.keys()) == {'CR', 'sCR', 'VGPR', 'PR', 'MRD', 'SD', 'PD'}
 
-    def test_lowercase_disease_code_is_normalized(self):
-        # therapy_outcomes_by_disease_code uppercases the input; lowercase 'bc'
-        # must yield the BC subset.
-        result = ValueOptions().therapy_outcomes_by_disease_code('bc')
+    @pytest.mark.parametrize('lower', ['bc', 'mcl'])
+    def test_lowercase_disease_code_is_normalized(self, lower):
+        # therapy_outcomes_by_disease_code uppercases the input.
+        result = ValueOptions().therapy_outcomes_by_disease_code(lower)
         assert set(result.keys()) == {'CR', 'PR', 'SD', 'PD'}
 
 
@@ -57,20 +60,20 @@ class TestFormSettingsTherapyOutcomeOverride:
         assert set(codes) == {'CR', 'sCR', 'VGPR', 'PR', 'MRD', 'SD', 'PD'}
 
     @pytest.mark.django_db
-    def test_bc_disease_downgrades_therapy_outcome_to_recist(self):
-        data = _form_settings_response('breast cancer')
+    @pytest.mark.parametrize('disease', ['breast cancer', 'mantle cell lymphoma'])
+    def test_recist_diseases_downgrade_therapy_outcome(self, disease):
+        data = _form_settings_response(disease)
         codes = [opt['value'] for opt in data['therapyOutcome']['options']]
         assert set(codes) == {'CR', 'PR', 'SD', 'PD'}, \
-            'BC ?disease= must downgrade therapyOutcome to RECIST 4-value subset'
+            f'{disease!r} ?disease= must downgrade therapyOutcome to 4-value subset'
 
     @pytest.mark.django_db
     @pytest.mark.parametrize('disease,_code', [
         ('multiple myeloma', 'MM'),
         ('follicular lymphoma', 'FL'),
         ('chronic lymphocytic leukemia', 'CLL'),
-        ('mantle cell lymphoma', 'MCL'),
     ])
-    def test_non_bc_disease_keeps_full_enum(self, disease, _code):
+    def test_imwg_diseases_keep_full_enum(self, disease, _code):
         data = _form_settings_response(disease)
         codes = [opt['value'] for opt in data['therapyOutcome']['options']]
         assert set(codes) == {'CR', 'sCR', 'VGPR', 'PR', 'MRD', 'SD', 'PD'}
@@ -84,7 +87,7 @@ class TestFormSettingsTherapyOutcomeOverride:
         # union therapyOutcome leaks out.
         data = _form_settings_response(shortcode)
         codes = [opt['value'] for opt in data['therapyOutcome']['options']]
-        if shortcode == 'BC':
+        if shortcode in ('BC', 'MCL'):
             assert set(codes) == {'CR', 'PR', 'SD', 'PD'}
         else:
             assert set(codes) == {'CR', 'sCR', 'VGPR', 'PR', 'MRD', 'SD', 'PD'}

--- a/trials/services/patient_info/normalize.py
+++ b/trials/services/patient_info/normalize.py
@@ -177,12 +177,14 @@ def _normalize_metastatic_status(pi) -> None:
 
 def _normalize_measurable_disease_imwg(pi) -> None:
     def serum_m_protein_high():
-        if not pi.monoclonal_protein_serum:
+        # Use `is None` not `not X`: 0 is a real clinical measurement
+        # ("no monoclonal protein detected"), not missing data (#81).
+        if pi.monoclonal_protein_serum is None:
             return None
         return pi.monoclonal_protein_serum >= 0.5
 
     def serum_m_urine_high():
-        if not pi.monoclonal_protein_urine:
+        if pi.monoclonal_protein_urine is None:
             return None
         return pi.monoclonal_protein_urine >= 200
 
@@ -197,7 +199,10 @@ def _normalize_measurable_disease_imwg(pi) -> None:
         if pi.kappa_flc is None or pi.lambda_flc is None:
             return None
         ratio = kappa_lambda_ratio()
-        if not ratio:
+        # Use `is None` not `not ratio`: ratio=0 (kappa=0/lambda>0) is a
+        # real clinical signal — well below the 0.26 abnormal threshold —
+        # not missing data (#81).
+        if ratio is None:
             return False
         if not (ratio < 0.26 or ratio > 1.65):
             return False

--- a/trials/services/trial_details/trial_attributes.py
+++ b/trials/services/trial_details/trial_attributes.py
@@ -174,6 +174,7 @@ class TrialAttributes:
         'follicular lymphoma': 'therapyOutcomeFl',
         'breast cancer': 'therapyOutcomeBc',
         'chronic lymphocytic leukemia': 'therapyOutcomeCll',
+        'mantle cell lymphoma': 'therapyOutcomeMcl',
     }
 
     def _therapy_outcome_options_key(self):

--- a/trials/services/value_options.py
+++ b/trials/services/value_options.py
@@ -398,19 +398,20 @@ class ValueOptions:
     def therapy_outcomes_by_disease_code(self, disease_code):
         """Return the clinically-applicable treatment outcomes per disease.
 
-        Per #4137: Breast Cancer doesn't use IMWG-derived categories
-        (sCR / VGPR / MRD) — those are MM-specific. BC patients should see
-        only CR / PR / SD / PD. All other diseases keep the full enum
-        until product asks otherwise.
+        Per #4137 / #83: Breast Cancer uses RECIST (CR/PR/SD/PD) and Mantle
+        Cell Lymphoma uses Cheson 2014 / Lugano 2014 (also CR/PR/SD/PD).
+        Neither uses IMWG-derived sCR/VGPR/MRD categories — those are
+        MM-specific. MM/FL/CLL keep the full enum.
         """
-        bc_outcomes = {
+        recist_outcomes = {
             'CR': self.therapy_outcomes['CR'],
             'PR': self.therapy_outcomes['PR'],
             'SD': self.therapy_outcomes['SD'],
             'PD': self.therapy_outcomes['PD'],
         }
         per_disease = {
-            'BC': bc_outcomes,
+            'BC': recist_outcomes,
+            'MCL': recist_outcomes,
         }
         return per_disease.get((disease_code or '').upper(), self.therapy_outcomes)
 


### PR DESCRIPTION
## Summary

Closes #81 and #83. Cross-model self-review surfaced a trial-detail half-fix for #83 — landed in this PR too.

## #81 — IMWG falsy-zero normalizer

`_normalize_measurable_disease_imwg` had three sites using `if not pi.X` / `if not ratio`. Integer 0 (a real clinical measurement: "no monoclonal protein detected", "no kappa free light chain") collapsed to None alongside genuinely missing values, misclassifying patients with confirmed-zero labs as if their labs were never run.

Three call sites fixed:
- `monoclonal_protein_serum is None` (line 181)
- `monoclonal_protein_urine is None` (line 186)
- `ratio is None` in `kappa_lambda_abnormal_and_high` (line 200) — sibling site flagged by fresh-context Claude review

## #83 — MCL therapy outcomes use Cheson/Lugano subset

`therapy_outcomes_by_disease_code` had only `'BC': bc_outcomes` in the per-disease map. MCL response criteria (Cheson 2014 / Lugano 2014) are CR/PR/SD/PD only — IMWG-specific sCR/VGPR/MRD don't apply to MCL. Renamed `bc_outcomes` to `recist_outcomes` and added MCL alongside.

**Plus trial-detail half-fix**: `_DISEASE_TO_OUTCOME_KEY` at `trial_attributes.py:172-177` was missing `'mantle cell lymphoma'`. So even after #83's form-settings fix, MCL trial detail's `firstLineOutcome`/`secondLineOutcome`/`laterOutcome` aliases fell through to the union `therapyOutcome` (full 7-value enum). Added the missing map entry so patient-side and trial-detail layers agree.

## Tests

- `monoclonal_protein_serum=0 + urine=0` → derived False (was None); matcher still `unknown` against requiring trial (the #54 `under_user_control` contract is preserved)
- `monoclonal_protein_serum=0 + urine=300` → derived True
- `kappa_flc=0 + lambda_flc=200` → ratio 0.0 below 0.26 abnormal threshold + lambda ≥ 100 → derived True (was False under the falsy-0 anti-pattern)
- All-None inputs → derived None (#54 unchanged)
- MCL trial detail: firstLineOutcome / secondLineOutcome / laterOutcome alias to `therapyOutcomeMcl`
- Existing form-settings parametrize tests updated: MCL moved from `imwg_diseases` group to `recist_diseases` group

## Self-review

Codex `review` flagged the trial-detail MCL gap as P2. Fresh-context Claude flagged the same gap as P0 plus the sibling falsy-0 in `kappa_lambda_abnormal_and_high` as P2. Per user decision, both fixed in this PR.

## CB drift note

CB has only BC in `per_disease`. This PR intentionally diverges by adding MCL — Cheson/Lugano support is the clinical reason. Worth back-porting to CB.

## Files

- `trials/services/patient_info/normalize.py` (+8 / -3) — three falsy-0 sites fixed
- `trials/services/value_options.py` (+7 / -6) — MCL added to per_disease, local rename
- `trials/services/trial_details/trial_attributes.py` (+1) — MCL in _DISEASE_TO_OUTCOME_KEY
- `tests/services/test_user_to_trial_attr_matcher.py` (+45) — #81 regression with FLC=0 + matcher contract assertion
- `tests/services/trial_details/test_trial_attributes.py` (+25) — MCL outcome aliasing
- `tests/views/test_form_settings_therapy_outcome.py` (+23 / -24) — RECIST/IMWG bucket reorganization

🤖 Generated with [Claude Code](https://claude.com/claude-code)