### PR TITLE
test: regression guards for dropdown opt-out options (#58 + #59 + #61)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,7 @@ from trials.services.loaders.load_ethnicity_options import LoadEthnicityOptions
 from trials.services.loaders.load_genetic_mutations import LoadGeneticMutations
 from trials.services.loaders.load_markers import LoadMarkers
 from trials.services.loaders.load_mcl_options import LoadMclOptions
+from trials.services.loaders.load_planned_therapy_options import LoadPlannedTherapyOptions
 from trials.services.loaders.load_supportive_therapies import LoadSupportiveTherapies
 from trials.services.loaders.load_therapies import LoadTherapies
 from trials.services.loaders.load_toxicity_grade_options import LoadToxicityGradeOptions
@@ -27,6 +28,7 @@ def django_db_setup(django_db_setup, django_db_blocker):
         LoadGeneticMutations().load_all(skip_genes_origins=False)
         LoadBcOptions().load_all(skip_hrd=False, skip_hr=False, skip_histologic_types=False)
         LoadMclOptions().load_all()
+        LoadPlannedTherapyOptions().load_all(skip_diseases=False)
 
 
 @pytest.fixture

--- a/tests/services/test_value_options_dropdown_defaults.py
+++ b/tests/services/test_value_options_dropdown_defaults.py
@@ -1,0 +1,94 @@
+"""
+Regression guards for #58 / #59 / #61 — dropdown options that a frontend
+needs to expose "no marker / no neuropathy / no planned therapy" as an
+explicit, selectable choice.
+
+All three production fixes are already in EXACT (carried forward from CB
+ports). Without these tests, a future change that drops any of the
+sentinel options (e.g. removing the `{'none': 'None', ...}` prepend) would
+land silently and re-introduce the original UX bug where patients had no
+way to opt out.
+"""
+import pytest
+
+from trials.services.value_options import ValueOptions
+
+
+class TestMarkerDropdownNoneOption:
+    """#58 / CB #4216: cytogenic and molecular marker dropdowns must let
+    patients explicitly select 'None' so trials requiring no marker can
+    match instead of falling through to Potential.
+    """
+
+    @pytest.mark.django_db
+    def test_cytogenic_markers_include_none(self):
+        opts = ValueOptions().cytogenic_markers
+        assert 'none' in opts
+        assert opts['none'] == 'None'
+
+    @pytest.mark.django_db
+    def test_molecular_markers_include_none(self):
+        opts = ValueOptions().molecular_markers
+        assert 'none' in opts
+        assert opts['none'] == 'None'
+
+    @pytest.mark.django_db
+    def test_none_is_first_entry_in_both_marker_dropdowns(self):
+        # Insertion order matters: 'none' should appear at the top of the
+        # multiselect so patients see it before the long marker list.
+        assert list(ValueOptions().cytogenic_markers.keys())[0] == 'none'
+        assert list(ValueOptions().molecular_markers.keys())[0] == 'none'
+
+
+class TestPeripheralNeuropathyGradeOptions:
+    """#59 / CB #4307: dropdown must offer Grade 0 (no neuropathy) and
+    label the empty value 'Unknown', not 'None' — otherwise patients
+    confused 'None' with 'Grade 0' and selected the wrong thing.
+    """
+
+    def test_unknown_sentinel_uses_unknown_label(self):
+        opts = ValueOptions().peripheral_neuropathy_grades
+        assert opts[''] == 'Unknown'
+
+    def test_grade_zero_is_a_distinct_selectable_option(self):
+        opts = ValueOptions().peripheral_neuropathy_grades
+        assert '0' in opts
+        assert opts['0'] == 'Grade 0'
+
+    def test_full_grade_set(self):
+        opts = ValueOptions().peripheral_neuropathy_grades
+        assert set(opts.keys()) == {'', '0', '1', '2', '3', '4'}
+
+
+class TestPlannedTherapiesNoneOption:
+    """#61 / CB 33f7525a: planned-therapies multiselect must let patients
+    opt out by selecting 'No planned therapy' — otherwise trials that
+    require no planned therapy aren't reachable.
+
+    LoadPlannedTherapyOptions only seeds MM/FL/BC connections (no CLL/MCL),
+    so the parametrize is limited to the diseases that actually exercise
+    the prepend-then-spread merge against real items.
+    """
+
+    @pytest.mark.django_db
+    @pytest.mark.parametrize('disease_code', ['MM', 'FL', 'BC'])
+    def test_none_option_present_and_first_for_seeded_diseases(self, disease_code):
+        opts = ValueOptions().planned_therapies(disease_code)
+        assert 'none' in opts
+        assert opts['none'] == 'No planned therapy'
+        # Real planned therapies must be present too (otherwise the test is
+        # tautological: a dict of length 1 trivially has 'none' first).
+        assert len(opts) > 1, (
+            f'{disease_code} should have seeded planned therapies; got {list(opts.keys())}'
+        )
+        # Insertion order: 'none' surfaces above the seeded therapies so the
+        # frontend renders the opt-out as the first multiselect option.
+        assert list(opts.keys())[0] == 'none'
+
+    @pytest.mark.django_db
+    @pytest.mark.parametrize('disease_code', ['CLL', 'MCL'])
+    def test_none_option_present_for_unseeded_diseases(self, disease_code):
+        # CLL and MCL have no planned-therapy seed data today, but the opt-out
+        # must still appear so the frontend dropdown isn't empty.
+        opts = ValueOptions().planned_therapies(disease_code)
+        assert opts == {'none': 'No planned therapy'}


### PR DESCRIPTION
## Summary

Closes #58, #59, #61. Test-only — all three production fixes were already in EXACT.

## Background

Each of the three issues describes a missing or mislabeled dropdown option that left patients with no way to indicate "no marker / no neuropathy / no planned therapy", leaving the field unanswered and downgrading trials from Eligible to Potential. The fixes are sentinel options at the top of each enum:

- `value_options.py:283` / `:292` — `cytogenic_markers` and `molecular_markers` prepend `{'none': 'None', ...}`
- `value_options.py:425-433` — `peripheral_neuropathy_grades` labels the empty value `'Unknown'` and includes `'0': 'Grade 0'`
- `value_options.py:274` — `planned_therapies` prepends `{'none': 'No planned therapy', ...}`

All three are already on `main`. No prior test guarded any of them, so a future change that dropped the sentinel would land silently.

## Tests

`tests/services/test_value_options_dropdown_defaults.py` (new):

- **#58**: `cytogenic_markers` and `molecular_markers` include `'none'` with label `'None'`, and `'none'` is the first key (frontend insertion order).
- **#59**: `peripheral_neuropathy_grades` has `'': 'Unknown'`, includes `'0': 'Grade 0'`, and full key set is `{'', '0', '1', '2', '3', '4'}`.
- **#61**: `planned_therapies` parametrized over seeded diseases (MM/FL/BC) verifies the prepend-then-spread ordering against real content with a `len > 1` guard; parametrized over unseeded diseases (CLL/MCL) verifies the opt-out still appears in the empty case.

`tests/conftest.py`: adds `LoadPlannedTherapyOptions().load_all(skip_diseases=False)` to the session-scoped seed.

## Self-review

Codex `review` flagged no issues. Fresh-context Claude found a P1: the original planned-therapies parametrize was theatre — `LoadPlannedTherapyOptions` wasn't seeded in conftest, so every disease returned `{'none': 'No planned therapy'}` (length 1), making the `keys()[0] == 'none'` assertion trivially true. Fixed by seeding the loader, splitting the parametrize into seeded (MM/FL/BC) and unseeded (CLL/MCL) cases, and adding a `len > 1` guard so a future regression that drops the seeded therapies can't accidentally pass.

## Files

- `tests/conftest.py` (+2)
- `tests/services/test_value_options_dropdown_defaults.py` (new, ~95 lines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)