### PR TITLE
fix: drop orphan CTOMOP tumor_grade=4 mapping (#56 + #57 + #69)

### DIFF
--- a/tests/management/test_normalize_ctomop_row.py
+++ b/tests/management/test_normalize_ctomop_row.py
@@ -79,13 +79,28 @@ class TestStageNormalization:
 
 
 # ---------------------------------------------------------------------------
-# Tumor grade — int (1-4) → EXACT code ('10', '20', '30', '40')
+# Tumor grade — int (1-3) → EXACT code ('10', '20', '30'). Any other int
+# (4+) collapses to None (#69): WHO FL grading is 1/2/3A/3B only, Grade 4
+# is clinically invalid, and orphan codes leave the UI rendering blank.
 # ---------------------------------------------------------------------------
 
 class TestTumorGrade:
-    @pytest.mark.parametrize('grade, expected', [(1, '10'), (2, '20'), (3, '30'), (4, '40')])
+    @pytest.mark.parametrize('grade, expected', [(1, '10'), (2, '20'), (3, '30')])
     def test_int_to_code(self, grade, expected):
         assert _normalize_ctomop_row(_row(tumor_grade=grade))['tumor_grade'] == expected
+
+    def test_grade_4_normalizes_to_none(self):
+        """Regression for #69 / paired with #56: WHO FL grading is 1/2/3A/3B
+        only — Grade 4 is clinically invalid. The previous mapping produced
+        '40', which had no matching dropdown label after PR #66 removed it
+        from value_options.tumor_grades, leaving the UI rendering blank."""
+        assert _normalize_ctomop_row(_row(tumor_grade=4))['tumor_grade'] is None
+
+    def test_unknown_int_grade_normalizes_to_none(self):
+        # Grade 5 / 6 / etc. — anything outside the WHO 1-3 range — collapses
+        # to None rather than producing an orphan code.
+        assert _normalize_ctomop_row(_row(tumor_grade=5))['tumor_grade'] is None
+        assert _normalize_ctomop_row(_row(tumor_grade=99))['tumor_grade'] is None
 
     def test_string_code_passes_through(self):
         # Already-normalised values must not be double-converted

--- a/tests/services/test_value_options_dropdown_defaults.py
+++ b/tests/services/test_value_options_dropdown_defaults.py
@@ -59,6 +59,35 @@ class TestPeripheralNeuropathyGradeOptions:
         opts = ValueOptions().peripheral_neuropathy_grades
         assert set(opts.keys()) == {'', '0', '1', '2', '3', '4'}
 
+    def test_grade_5_is_not_offered(self):
+        """Regression for #57 / CB 887be4d9: Grade 5 (CTCAE 'Death') is not
+        a self-reportable patient state. Removed from the dropdown."""
+        opts = ValueOptions().peripheral_neuropathy_grades
+        assert '5' not in opts
+
+
+class TestTumorGradeOptions:
+    """#56 / CB a8fd82c2: WHO FL grading is 1/2/3A/3B only — Grade 4 is
+    clinically invalid and must not appear in the dropdown.
+    """
+
+    def test_full_grade_set(self):
+        opts = ValueOptions().tumor_grades
+        assert set(opts.keys()) == {'', '10', '20', '30', '31', '32'}
+
+    def test_grade_4_is_not_offered(self):
+        """Grade 4 (code '40') was removed in PR #66 per WHO FL grading."""
+        opts = ValueOptions().tumor_grades
+        assert '40' not in opts
+        # And no '4' fallback either — the only valid grade-3 codes are the
+        # 3 / 3A / 3B subgrades (30 / 31 / 32).
+        assert '4' not in opts
+
+    def test_3a_and_3b_subgrades_are_present(self):
+        opts = ValueOptions().tumor_grades
+        assert opts['31'] == 'Grade 3A'
+        assert opts['32'] == 'Grade 3B'
+
 
 class TestPlannedTherapiesNoneOption:
     """#61 / CB 33f7525a: planned-therapies multiselect must let patients

--- a/trials/management/commands/search_trials_for_patients.py
+++ b/trials/management/commands/search_trials_for_patients.py
@@ -328,11 +328,14 @@ def _normalize_ctomop_row(row: dict) -> dict:
     if isinstance(sm, str) and ' → ' in sm:
         row['staging_modalities'] = sm.split(' → ')[0].strip()
 
-    # ── Tumor grade: CTOMOP IntegerField (1,2,3,4) → EXACT code ('10','20','30','40') ─
+    # ── Tumor grade: CTOMOP IntegerField (1,2,3) → EXACT code ('10','20','30') ─
     # Sub-grades 3A/3B (codes '31','32') cannot be derived from CTOMOP — map 3 → '30'.
+    # Grade 4 is clinically invalid for FL (WHO grades are 1/2/3A/3B only — see #56
+    # / CB a8fd82c2 and #69) so we drop it to None rather than produce an orphan
+    # '40' code that has no matching dropdown label.
     tg = row.get('tumor_grade')
     if isinstance(tg, int):
-        row['tumor_grade'] = {1: '10', 2: '20', 3: '30', 4: '40'}.get(tg, str(tg))
+        row['tumor_grade'] = {1: '10', 2: '20', 3: '30'}.get(tg)
 
     # ── Biopsy grade: CTOMOP IntegerField (1,2,3) → EXACT code ('1','2','3') ──────────
     bg = row.get('biopsy_grade')


### PR DESCRIPTION
## Summary

Closes #56, #57, #69. One actual production fix (#69) plus regression guards for two already-shipped cleanups.

## #69 — CTOMOP tumor_grade=4 orphan

`_normalize_ctomop_row` at `search_trials_for_patients.py:331-338` was mapping integer `tumor_grade=4` to string `'40'`. PR #66 had already removed `'40': 'Grade 4'` from `ValueOptions.tumor_grades` per WHO FL grading (1/2/3A/3B only — no Grade 4), so any CTOMOP-sourced FL patient with grade 4 hit an orphan code that rendered blank in the trial-detail UI.

Dropped 4 from the mapping. The new behavior:
- `tg=1/2/3` → `'10'/'20'/'30'` (unchanged)
- `tg=4` → `None` (was `'40'`)
- `tg=5/99` (any unknown int) → `None` (was `'5'/'99'` via `str(tg)` fallback)
- `tg=None` / string passthrough — unchanged

The matcher's `is_attr_blank` check turns `None` into `'unknown'` downstream, so UI label and trial-match status stay coherent.

The behavior change is FL-only in practice because `configs.py:313-321` scopes `tumor_grade` to `"disease": "FL"`. Non-FL CTOMOP patients with `tumor_grade=4` also normalize to None, but their disease branch doesn't consume the field. If `tumor_grade` ever escapes FL scoping the silent drop becomes a latent regression — flagged inline.

## #56 / #57 — regression-only

Both production fixes are already in EXACT. Tests added to `tests/services/test_value_options_dropdown_defaults.py`:

- `TestTumorGradeOptions` — `tumor_grades` excludes `'40'` and `'4'` (PR #66 / CB `a8fd82c2`)
- `TestPeripheralNeuropathyGradeOptions::test_grade_5_is_not_offered` — `peripheral_neuropathy_grades` excludes `'5'` (CB `887be4d9`)

## Tests

- Updated pre-existing `TestTumorGrade::test_int_to_code` parametrize — was `[(1,'10'), (2,'20'), (3,'30'), (4,'40')]`, now drops `(4,'40')`.
- Added `test_grade_4_normalizes_to_none` and `test_unknown_int_grade_normalizes_to_none` (tg=5, tg=99).
- Refreshed stale section docstring to reflect the new `int (1-3) → code` mapping.

## Self-review

Codex `review` clean. Fresh-context Claude verified the fix path, confirmed no downstream consumers do `if patient_info.tumor_grade == '40'`, confirmed the FL disease-scoping limits behavior change to the intended path. Minor P2 cleanups (stale comment) applied.

P3 follow-ups noted but out of scope:
- `querysets/trial.py:730` and `user_to_trial_attr_matcher.py:458` call `ValueOptions().tumor_grades()` as a method but `tumor_grades` is a `@property`. The call is unreachable via existing `isdigit()` upstream check, so it doesn't fire — but it's a pre-existing latent bug.
- `biopsy_grade` at `search_trials_for_patients.py:341-343` has the same `str(bg)` unbounded fallback pattern. Same shape as #69, different field.

## Files

- `trials/management/commands/search_trials_for_patients.py` (+5 / -2)
- `tests/management/test_normalize_ctomop_row.py` (+17 / -3)
- `tests/services/test_value_options_dropdown_defaults.py` (+29)

🤖 Generated with [Claude Code](https://claude.com/claude-code)