### PR TITLE
chore: code-health cleanup (#32 + #34 + #35)

### DIFF
--- a/tests/views/test_explain_param.py
+++ b/tests/views/test_explain_param.py
@@ -2,14 +2,14 @@
 Tests for the ?explain=true query parameter.
 
 The flag is threaded through two layers:
-  1. TrailsViewSet.get_serializer_context() sets context['explain'] = True/False
+  1. TrialsViewSet.get_serializer_context() sets context['explain'] = True/False
   2. TrialSerializer.to_representation() reads it and populates matchReasons
      (non-null list) or leaves it null.
 """
 import pytest
 from unittest.mock import patch, MagicMock
 
-from trials.api.trials_views import TrailsViewSet
+from trials.api.trials_views import TrialsViewSet
 from trials.api.trials_serializers import TrialSerializer
 from tests.factories import TrialFactory
 from trials.services.patient_info.patient_info import PatientInfo
@@ -19,8 +19,8 @@ from trials.services.patient_info.patient_info import PatientInfo
 # View layer: get_serializer_context sets the flag correctly
 # ---------------------------------------------------------------------------
 
-def _make_view(query_params: dict) -> TrailsViewSet:
-    view = TrailsViewSet()
+def _make_view(query_params: dict) -> TrialsViewSet:
+    view = TrialsViewSet()
     view.action = 'list'
     view.format_kwarg = None
     mock_request = MagicMock()
@@ -38,7 +38,7 @@ class TestExplainContext:
         with patch.object(view, '_resolve_patient_info', return_value=None), \
              patch.object(view, '_resolve_study_preferences') as mock_prefs:
             mock_prefs.return_value = MagicMock(distance_units='km', recruitment_status=None)
-            with patch('trials.api.trials_views.TrailsViewSet.get_serializer_context',
+            with patch('trials.api.trials_views.TrialsViewSet.get_serializer_context',
                        wraps=view.get_serializer_context):
                 return view.get_serializer_context()
 

--- a/tests/views/test_trials_goodness_weights.py
+++ b/tests/views/test_trials_goodness_weights.py
@@ -9,12 +9,12 @@ directly with a controlled mock queryset to capture the actual kwargs.
 import pytest
 from unittest.mock import patch, MagicMock, call
 
-from trials.api.trials_views import TrailsViewSet
+from trials.api.trials_views import TrialsViewSet
 
 
-def _make_view(query_params: dict, action: str = 'list') -> TrailsViewSet:
-    """Return a TrailsViewSet instance with a mock request."""
-    view = TrailsViewSet()
+def _make_view(query_params: dict, action: str = 'list') -> TrialsViewSet:
+    """Return a TrialsViewSet instance with a mock request."""
+    view = TrialsViewSet()
     view.action = action
     view.format_kwarg = None
 

--- a/trials/api/graph_view.py
+++ b/trials/api/graph_view.py
@@ -8,7 +8,7 @@ from rest_framework.response import Response
 
 from trials.api.graph_serializers import GraphTrialNodeSerializer
 from trials.api.patient_info_serializers import PatientInfoSerializer
-from trials.api.trials_views import TrailsViewSet
+from trials.api.trials_views import TrialsViewSet
 from trials.services.attribute_names import AttributeNames
 from trials.services.patient_info.resolve import resolve_patient_info
 from trials.services.trial_details.trial_templates import TrialTemplates
@@ -57,9 +57,9 @@ class GraphPatientInfoSerializer(PatientInfoSerializer):
         return data
 
 
-class TrialsGraphViewSet(TrailsViewSet):
+class TrialsGraphViewSet(TrialsViewSet):
     """
-    Reuses TrailsViewSet queryset logic to build a graph-oriented response.
+    Reuses TrialsViewSet queryset logic to build a graph-oriented response.
     """
     http_method_names = ["get"]
 

--- a/trials/api/trials_views.py
+++ b/trials/api/trials_views.py
@@ -6,7 +6,7 @@ from rest_framework import serializers
 
 from trials.api.pagination import TrialsPagination
 from trials.api.trials_serializers import TrialSerializer, TrialDetailsSerializer
-from trials.models import Trial, Location, PreferredCountry, State
+from trials.models import Trial, Location, LocationTrial, PreferredCountry, State
 from trials.services.patient_info.resolve import resolve_patient_info
 from trials.services.study_preferences import study_preferences_from_query_params
 from trials.services.value_options import ValueOptions
@@ -60,7 +60,7 @@ class _BlankAttributeRecordsCount:
 # Trials ViewSet
 # ---------------------------------------------------------------------------
 
-class TrailsViewSet(viewsets.ReadOnlyModelViewSet):
+class TrialsViewSet(viewsets.ReadOnlyModelViewSet):
     permission_classes = [permissions.IsAuthenticated]
     default_serializer_class = TrialDetailsSerializer
     serializer_classes = {
@@ -167,7 +167,7 @@ class TrailsViewSet(viewsets.ReadOnlyModelViewSet):
         if self.action in ['list', 'search']:
             queryset = queryset.prefetch_related(
                 Prefetch('locationtrial_set',
-                         queryset=__import__('trials.models', fromlist=['LocationTrial']).LocationTrial.objects.select_related('location'))
+                         queryset=LocationTrial.objects.select_related('location'))
             )
 
         return queryset

--- a/trials/querysets/trial.py
+++ b/trials/querysets/trial.py
@@ -325,7 +325,6 @@ class TrialQuerySet(models.QuerySet):
                 'records': new_count,
                 'dropped': count-new_count
             })
-            # count = new_count
 
         return query, traces
 
@@ -619,7 +618,10 @@ class TrialQuerySet(models.QuerySet):
         max_burden = Value(20.0, output_field=FloatField())
         max_risk = Value(20.0, output_field=FloatField())
 
-        # score = (0.50×Benefit + 0.25(1-PB) + 0.15(1-Risk) + 0.10(1-DistancePenalty)) × 100 + 0.5
+        # score = (Wb×Benefit/20 + Wpb×(1−PB/20) + Wr×(1−Risk/20) + Wd×(1−DistancePenalty)) × 100 / ΣW + 0.5
+        # Wb / Wpb / Wr / Wd are the caller-supplied benefit / patient-burden /
+        # risk / distance weights (default 25/25/25/25 — equal). +0.5 is a
+        # rounding nudge before the IntegerField cast.
         score_expr = ExpressionWrapper(
             (
                     benefit_weight * Coalesce(F('benefit_score'), Value(0.0)) / max_benefit +
@@ -632,7 +634,6 @@ class TrialQuerySet(models.QuerySet):
 
         return self.annotate(
             goodness_score=score_expr,
-            # distance_expr=distance_expr
         )
 
     def eligible_for_min_max_value(self, attr_min_name, attr_max_name, value, skip_blank=True):
@@ -1204,13 +1205,6 @@ class TrialQuerySet(models.QuerySet):
             trial_attr_name = trial_attr_meta["attr"]
             if "disease" in trial_attr_meta and (patient_info_attr.disease_code is None or patient_info_attr.disease_code not in trial_attr_meta["disease"]):
                 continue
-
-            # if "search_conditions" in trial_attr_meta:
-            #     # check for skip the filter
-            #     conditions_value = getattr(patient_info, trial_attr_meta["search_conditions"]["attr_name"])
-            #     if conditions_value == trial_attr_meta["search_conditions"]["attr_value"]:
-            #         if trial_attr_meta["search_conditions"]["action"] == "skip":
-            #             continue
 
             if "custom_search" in trial_attr_meta and trial_attr_meta["custom_search"] is True:
                 if user_attr == "stage":

--- a/trials/services/trial_details/configs.py
+++ b/trials/services/trial_details/configs.py
@@ -324,8 +324,8 @@ ATTR_GROUP_MAPPING = {
     'isValidated': 'ignore',
     'isLabeled': 'ignore',
 
-    'matchScore': ['general'],  # TODO: add to `general` on another level
-    'disease': ['general', 'disease'],  # TODO: add to `general` on another level
+    'matchScore': ['general'],
+    'disease': ['general', 'disease'],
 
     # == Disease group ==
     # + Patient Age

--- a/trials/services/user_to_trial_attr_matcher.py
+++ b/trials/services/user_to_trial_attr_matcher.py
@@ -566,7 +566,9 @@ class UserToTrialAttrMatcher:
                 matching_results = []
 
                 def get_matching_result(tr_attr_name, uvalue_func):
-                    # TODO: it's a bit hackish, but should be OK as long as we follow internal naming convention
+                    # Naming convention: trial attrs ending in `_excluded` are
+                    # restriction lists (patient must NOT be in them); anything
+                    # else (typically `_required`) is the inclusion list.
                     is_exclude = '_excluded' in trial_subattr_name
 
                     tr_attr_value = getattr(self.trial, tr_attr_name)

--- a/trials/urls.py
+++ b/trials/urls.py
@@ -5,7 +5,7 @@ from rest_framework import permissions
 from rest_framework.routers import DefaultRouter
 
 from trials.api.graph_view import TrialsGraphViewSet
-from trials.api.trials_views import TrailsViewSet, CountriesViewSet, LocationsViewSet, FormSettingsViewSet
+from trials.api.trials_views import TrialsViewSet, CountriesViewSet, LocationsViewSet, FormSettingsViewSet
 
 schema_view = get_schema_view(
     openapi.Info(
@@ -20,7 +20,7 @@ schema_view = get_schema_view(
 app_name = 'trials'
 
 router = DefaultRouter()
-router.register(r'trials', TrailsViewSet, basename='trials-v1')
+router.register(r'trials', TrialsViewSet, basename='trials-v1')
 router.register(r'trials-graph', TrialsGraphViewSet, basename='trials-graph-v1')
 router.register(r'countries', CountriesViewSet, basename='countries-v1')
 router.register(r'locations', LocationsViewSet, basename='locations-v1')


### PR DESCRIPTION
## Summary

Closes #32, #34, #35. Three cleanup items bundled.

## #32 — Rename TrailsViewSet → TrialsViewSet

Typo fix. 15 references across 5 files (`trials_views.py`, `urls.py`, `graph_view.py`, 2 test files). DRF router basename (`trials-v1`) is unaffected so `reverse()` callers don't break.

## #34 — Replace `__import__()` with static import

`trials_views.py:170` was using `__import__('trials.models', fromlist=['LocationTrial'])` to obscure the dependency. Lifted to a module-level static import. Verified no circular: `trials/models.py` has no reverse dependency on `trials/api/`.

## #35 — TODOs and dead code

- `user_to_trial_attr_matcher.py:569` — converted "TODO: it's a bit hackish" to an explanatory comment naming the `_excluded` naming convention. The check IS load-bearing (drives `is_exclude` branching downstream) so documenting beats leaving a self-deprecating TODO.
- `trial_details/configs.py:327-328` — removed two aspirational TODOs about adding to "general on another level". No structural "another level" concept exists in the file.
- `trial.py:328` — removed dead `# count = new_count`.
- `trial.py:635` — removed dead `# distance_expr=distance_expr` commented kwarg.
- `trial.py:1206-1211` — removed 6 lines of commented-out `search_conditions` logic. Repo-wide grep for `search_conditions` returned zero hits — it was a never-implemented stub.
- `trial.py:621` — rewrote the goodness-score formula docstring. Old comment showed weights `(0.50/0.25/0.15/0.10)` that don't match the `with_goodness_score_optimized` defaults `(25/25/25/25)`. New version describes the structure with caller-supplied weights and the `+0.5` rounding nudge.

## Out of scope

- `trial.py:589` still has a function-local `from trials.models import LocationTrial` inside the geo-point branch. Late import is load-bearing there (non-geo callers skip the GIS import cost). Left alone.
- `test_trials_goodness_weights.py:55` mocks `Trial` but not the newly module-level `LocationTrial`. Test currently relies on a `try/except: pass` to swallow whatever blows up — pre-existing, not regressed by this PR.

## Self-review

Fresh-context Claude verified: rename is complete (zero stragglers in `.py`/`.html`/`.json`/`.md`/`.yml`/`.yaml`); static import safe (no circular path); each deletion verified non-load-bearing (`search_conditions` never referenced anywhere, `count` not used after the removed line, etc.). One P2 caught: original PR claimed the formula docstring was useful documentation but Claude correctly identified it as stale — rewrote it inline.

Codex review hung at the start of the run (process at 0.0% CPU for 30+ min, no output) so it was killed without producing findings. Risk is bounded — the cleanups are mechanical and fresh Claude's review was thorough.

## Files

- `trials/api/trials_views.py` (-3 / +3) — rename + static import + use
- `trials/api/graph_view.py` (-3 / +3) — rename references
- `trials/urls.py` (-2 / +2) — rename references
- `trials/services/user_to_trial_attr_matcher.py` (-1 / +3) — comment swap
- `trials/services/trial_details/configs.py` (-2 / +2) — drop TODOs
- `trials/querysets/trial.py` (-9 / +4) — dead code + docstring rewrite
- `tests/views/test_explain_param.py` (-5 / +5) — rename
- `tests/views/test_trials_goodness_weights.py` (-4 / +4) — rename

🤖 Generated with [Claude Code](https://claude.com/claude-code)