### PR TITLE
fix: reject ?limit=N requests outside [1, max_page_size] with 400 (#33)

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -375,7 +375,9 @@ All list endpoints return a standard paginated envelope:
 }
 ```
 
-Default page size is 200. Override with `?page_size=<n>`.
+Default page size is 20. Override with `?limit=<n>` up to a maximum of 200.
+Requests with `limit` < 1, > 200, non-integer, or empty return
+`400 Bad Request` with details under the `limit` key (#33).
 
 ---
 

--- a/tests/api/test_pagination.py
+++ b/tests/api/test_pagination.py
@@ -1,0 +1,67 @@
+"""
+Tests for TrialsPagination.get_page_size — page-size validation (#33).
+
+DRF's default `PageNumberPagination` silently clamps `?limit=N` requests
+to `max_page_size`, hiding abuse and shipping fewer results than the caller
+asked for. Our override returns 400 ValidationError instead so resource
+exhaustion attempts are explicit.
+"""
+import pytest
+from rest_framework.exceptions import ValidationError
+from rest_framework.request import Request
+from rest_framework.test import APIRequestFactory
+
+from trials.api.pagination import TrialsPagination
+
+
+def _request(**params):
+    # Wrap the WSGIRequest in a DRF Request so request.query_params resolves
+    # the same way it does inside a view's dispatch() — production code path.
+    return Request(APIRequestFactory().get('/trials/', params))
+
+
+class TestPageSizeValidation:
+    def test_no_limit_returns_default_page_size(self):
+        assert TrialsPagination().get_page_size(_request()) == 20
+
+    def test_valid_limit_returned_as_is(self):
+        assert TrialsPagination().get_page_size(_request(limit='50')) == 50
+
+    def test_limit_equal_to_max_is_accepted(self):
+        assert TrialsPagination().get_page_size(_request(limit='200')) == 200
+
+    def test_limit_above_max_raises_validation_error(self):
+        with pytest.raises(ValidationError) as exc_info:
+            TrialsPagination().get_page_size(_request(limit='1000'))
+        # Error payload must surface the requested value and the cap so
+        # API consumers can correct their request.
+        detail = str(exc_info.value.detail['limit'][0])
+        assert '1000' in detail
+        assert '200' in detail
+
+    def test_limit_zero_raises_validation_error(self):
+        with pytest.raises(ValidationError) as exc_info:
+            TrialsPagination().get_page_size(_request(limit='0'))
+        assert '>=' in str(exc_info.value.detail['limit'][0])
+
+    def test_negative_limit_raises_validation_error(self):
+        with pytest.raises(ValidationError):
+            TrialsPagination().get_page_size(_request(limit='-5'))
+
+    def test_non_integer_limit_raises_validation_error(self):
+        with pytest.raises(ValidationError) as exc_info:
+            TrialsPagination().get_page_size(_request(limit='abc'))
+        assert 'integer' in str(exc_info.value.detail['limit'][0])
+
+    def test_empty_string_limit_raises_validation_error(self):
+        # ?limit= (no value) → '' → ValueError on int() → 400
+        with pytest.raises(ValidationError):
+            TrialsPagination().get_page_size(_request(limit=''))
+
+    def test_unbounded_input_not_reflected_in_error_body(self):
+        # Defensive: large garbage should produce a fixed-size error, not
+        # echo the entire input back (request-bloat amplifier).
+        garbage = 'x' * 10000
+        with pytest.raises(ValidationError) as exc_info:
+            TrialsPagination().get_page_size(_request(limit=garbage))
+        assert garbage not in str(exc_info.value.detail['limit'][0])

--- a/trials/api/pagination.py
+++ b/trials/api/pagination.py
@@ -1,4 +1,5 @@
 import math
+from rest_framework.exceptions import ValidationError
 from rest_framework.pagination import PageNumberPagination
 from rest_framework.response import Response
 
@@ -8,6 +9,42 @@ class TrialsPagination(PageNumberPagination):
     page_size_query_param = 'limit'
     max_page_size = 200
     page_query_param = 'page'
+
+    def get_page_size(self, request):
+        """Reject `?limit=N` requests where N > max_page_size with 400 (#33).
+
+        DRF's default behavior silently clamps the value to max_page_size,
+        which both hides abuse (a client asking for 10000 rows looks fine
+        in logs) and gives the caller fewer results than they requested
+        without telling them.
+        """
+        if not self.page_size_query_param:
+            return self.page_size
+
+        raw = request.query_params.get(self.page_size_query_param)
+        if raw is None:
+            return self.page_size
+
+        try:
+            requested = int(raw)
+        except (TypeError, ValueError):
+            # Don't echo unbounded user input back in the error body — a
+            # 1MB ?limit=<garbage> would otherwise reflect into the 400
+            # response.
+            raise ValidationError({
+                self.page_size_query_param: ['must be a positive integer']
+            })
+        if requested < 1:
+            raise ValidationError({
+                self.page_size_query_param: [f'must be >= 1, got {requested}']
+            })
+        if requested > self.max_page_size:
+            raise ValidationError({
+                self.page_size_query_param: [
+                    f'{requested} exceeds maximum allowed value {self.max_page_size}'
+                ]
+            })
+        return requested
 
     def get_paginated_response(self, data, extra_keys: dict = None):
         total_items = self.page.paginator.count


### PR DESCRIPTION
## Summary

Closes #33. Receptor-status cleanup (#45) was originally bundled but deferred — see "Out of scope" below.

## #33

`TrialsPagination` inherited DRF's `PageNumberPagination.get_page_size`, which silently clamps `?limit=N` for any N > `max_page_size` (200) back to the cap. Downsides:

- **Hides abuse.** A client asking for 10000 rows looks fine in access logs even though the server is evaluating "give me everything" intent.
- **Caller confusion.** Response shape is the same as a normal page — caller gets fewer rows than asked for with no signal.

Override `get_page_size` to validate explicitly:
- Missing `limit` → default 20 (DRF parent semantics preserved)
- Non-integer / `< 1` / `> max_page_size` → `ValidationError` → DRF default handler renders as `400 Bad Request` with `{limit: [message]}`

Error messages are fixed-size — no echoing back unbounded user input so a 1MB `?limit=<garbage>` doesn't amplify into a 1MB error response.

## Docs

`docs/api.md:378` was already wrong about the default (claimed `200`, actual `20`) and the param name (claimed `page_size`, actual `limit`). Fixed both and documented the new 400 behavior.

## Tests

`tests/api/test_pagination.py` (new) covers:
- Default fallback (no `limit` → 20)
- Valid values (50)
- Boundary (200 accepted, 1000 rejected)
- `0` rejected, `-5` rejected
- Non-integer (`'abc'`) rejected
- Empty string (`''`) rejected
- Unbounded input non-reflection (10000-char garbage doesn't appear in error body)

Uses `Request(WSGIRequest)` wrapping so `request.query_params` resolves the same way it does inside a real view's `dispatch()`.

## Self-review

Fresh-context Claude pass caught two P0s in my first draft:
- `APIRequestFactory().get(...)` returns a Django `WSGIRequest`, which lacks `.query_params` (DRF-Request-only attribute). All tests would have errored with `AttributeError`. Fixed by wrapping with `Request(...)`.
- `ValidationError({'limit': 'msg'})` produces `e.detail['limit']` as a single `ErrorDetail` string, not a list — so `e.detail['limit'][0]` would have returned the first character. Fixed by wrapping each message in a list (matches `serializer.is_valid()` shape, consistent with the rest of the API).

Also surfaced a P1 docs gap (already-wrong line) and the unbounded-input echo P2 — both addressed inline.

Codex review was attempted earlier in this session but the process hung at 0.0% CPU for 30+ min with no output and had to be killed. Risk is bounded — the change is small, tests cover all branches, and fresh Claude was thorough.

## Out of scope — #45 deferred

The original plan bundled #45 (remove receptor-status parent-code expansion). Investigation showed removing the `_ER_PARENT_CODES` / `_PR_PARENT_CODES` / `_HR_PARENT_CODES` maps and the `_receptor_uvalue` helper would break two existing tests (`test_estrogen_receptor_status_hierarchy`, `test_progesterone_receptor_status_hierarchy`) that explicitly assert the hierarchy contract: a patient with `er_plus_with_hi_exp` matches a trial requiring `er_plus`. That's a real matching-contract change requiring trial-data assumptions to be made explicit. Deferred to its own PR.

## Files

- `trials/api/pagination.py` (+37) — `get_page_size` override
- `tests/api/test_pagination.py` (new, ~70 lines)
- `tests/api/__init__.py` (new, empty — matches convention)
- `docs/api.md` (+3 / -1) — fix default + document new 400 behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)