### PR TITLE
fix: honor locationtrial_set prefetch in Trial location/distance helpers (#26)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ scripts/*.zip
 trials/management/commands/evaluate_ethalon_live.py
 tests/management/test_evaluate_ethalon_live.py
 scripts/evaluator/evaluate_live.sh
+republish_latest.sh

--- a/tests/models/test_locationtrial_prefetch.py
+++ b/tests/models/test_locationtrial_prefetch.py
@@ -1,0 +1,185 @@
+"""
+Regression test for #26 — sorted_locations_by_distance must honor the
+locationtrial_set prefetch declared in TrialsViewSet.get_queryset, instead
+of issuing a fresh `self.locationtrial_set.select_related('location')`
+query per trial.
+
+The serializer (`TrialSerializer.to_representation`) calls this method on
+every trial in the page. Pre-fix, that meant N additional queries per
+page (one per Trial). Post-fix, the prefetched cache is reused and the
+query count stays flat regardless of page size.
+"""
+import pytest
+from django.db.models import Prefetch
+
+from trials.models import LocationTrial, Trial
+from tests.factories import LocationFactory, TrialFactory
+
+
+def _build_n_trials_with_locations(n):
+    loc_a = LocationFactory(title=f'loc_a_{n}')
+    loc_b = LocationFactory(title=f'loc_b_{n}')
+    trials = []
+    for i in range(n):
+        trial = TrialFactory()
+        LocationTrial.objects.create(trial=trial, location=loc_a, recruitment_status='RECRUITING')
+        LocationTrial.objects.create(trial=trial, location=loc_b, recruitment_status='RECRUITING')
+        trials.append(trial)
+    return trials
+
+
+def _list_qs():
+    """Mirror the prefetch TrialsViewSet.get_queryset uses for /trials/."""
+    return Trial.objects.prefetch_related(
+        Prefetch(
+            'locationtrial_set',
+            queryset=LocationTrial.objects.select_related('location'),
+        )
+    )
+
+
+class TestLocationTrialPrefetch:
+    @pytest.mark.django_db
+    def test_sorted_locations_uses_prefetch_when_available(self, django_assert_num_queries):
+        """With the list-endpoint prefetch in place, calling
+        sorted_locations_by_distance per Trial must issue zero
+        additional queries.
+        """
+        _build_n_trials_with_locations(3)
+
+        # Materialise the prefetched queryset — 1 query for trials, 1 for
+        # locationtrial_set, 1 for the joined location rows.
+        trials = list(_list_qs())
+        assert len(trials) == 3
+
+        # The hot path: serialise each Trial's location list. Pre-fix this
+        # was N additional queries (one per trial); post-fix it's zero.
+        with django_assert_num_queries(0):
+            for trial in trials:
+                locations = trial.sorted_locations_by_distance(None)
+                # Touch .location to make sure it's resolved without a
+                # fresh query (select_related is part of the prefetch).
+                assert all(lt.location is not None for lt in locations)
+
+    @pytest.mark.django_db
+    def test_query_count_constant_across_page_sizes(self, django_assert_num_queries):
+        """Pre-fix: query count grew linearly with page size (N+constant).
+        Post-fix: same constant query count regardless of page size."""
+        # Small page
+        _build_n_trials_with_locations(2)
+        trials_small = list(_list_qs())
+        with django_assert_num_queries(0):
+            for trial in trials_small:
+                trial.sorted_locations_by_distance(None)
+
+        # Larger page — still zero extra queries after the prefetch
+        # materialisation above.
+        _build_n_trials_with_locations(5)
+        trials_large = list(_list_qs())
+        with django_assert_num_queries(0):
+            for trial in trials_large:
+                trial.sorted_locations_by_distance(None)
+
+    @pytest.mark.django_db
+    def test_fallback_path_still_works_without_prefetch(self):
+        """Callers that don't prefetch (e.g. ad-hoc model-method use
+        outside the list endpoint) must keep getting correct results
+        via the original QuerySet path."""
+        trials = _build_n_trials_with_locations(1)
+        trial = Trial.objects.get(pk=trials[0].pk)  # NOT prefetched
+
+        locations = trial.sorted_locations_by_distance(None)
+        # Two LocationTrial rows seeded above.
+        assert len(list(locations)) == 2
+
+    @pytest.mark.django_db
+    def test_recruitment_status_filter_applies_in_python_when_prefetched(self):
+        """Filter must work the same whether we're using the prefetched
+        cache (Python filter) or the fallback (DB filter)."""
+        loc = LocationFactory(title='filterloc')
+        trial = TrialFactory()
+        LocationTrial.objects.create(trial=trial, location=loc, recruitment_status='RECRUITING')
+        LocationTrial.objects.create(trial=trial, location=loc, recruitment_status='COMPLETED')
+
+        # Prefetched path
+        trial_prefetched = _list_qs().get(pk=trial.pk)
+        result = trial_prefetched.sorted_locations_by_distance(None, recruitment_status='RECRUITING')
+        assert all(lt.recruitment_status == 'RECRUITING' for lt in result)
+        assert len(list(result)) == 1
+
+        # Fallback path
+        trial_plain = Trial.objects.get(pk=trial.pk)
+        result_plain = trial_plain.sorted_locations_by_distance(None, recruitment_status='RECRUITING')
+        assert all(lt.recruitment_status == 'RECRUITING' for lt in result_plain)
+        assert len(list(result_plain)) == 1
+
+    @pytest.mark.django_db
+    def test_closest_location_wins_with_geo_point(self):
+        """The novel with-geo branch (Python distance sort via geopy):
+        closest location must be returned, and missing-geo LocationTrials
+        must sort last regardless of how the prefetched cache happened
+        to be ordered.
+        """
+        from django.contrib.gis.geos import Point as GeoPoint
+
+        # Patient is in Boston (~42.36 N, ~-71.06 E).
+        boston = GeoPoint(-71.0589, 42.3601, srid=4326)
+        # Three locations: one near Boston, one in San Francisco, one with
+        # no geo at all. (PointField stores x=lon, y=lat.)
+        near = LocationFactory(title='cambridge', city='cambridge')
+        far = LocationFactory(title='sf', city='sf')
+        no_geo = LocationFactory(title='no_geo', city='unknown')
+        near.geo_point = GeoPoint(-71.1097, 42.3736, srid=4326)
+        near.save()
+        far.geo_point = GeoPoint(-122.4194, 37.7749, srid=4326)
+        far.save()
+        # no_geo.geo_point left None
+
+        trial = TrialFactory()
+        LocationTrial.objects.create(trial=trial, location=no_geo, recruitment_status='RECRUITING')
+        LocationTrial.objects.create(trial=trial, location=far, recruitment_status='RECRUITING')
+        LocationTrial.objects.create(trial=trial, location=near, recruitment_status='RECRUITING')
+
+        # Prefetched path
+        trial_prefetched = _list_qs().get(pk=trial.pk)
+        result = trial_prefetched.sorted_locations_by_distance(boston)
+        assert len(result) == 1
+        assert result[0].location.title == 'cambridge'
+
+        # Fallback path (no prefetch) must return the same closest pick.
+        trial_plain = Trial.objects.get(pk=trial.pk)
+        result_plain = trial_plain.sorted_locations_by_distance(boston)
+        assert len(result_plain) == 1
+        assert result_plain[0].location.title == 'cambridge'
+
+    @pytest.mark.django_db
+    def test_get_distance_obj_uses_prefetch_cache(self, django_assert_num_queries):
+        """Companion fix for the actual production N+1: TrialSerializer
+        falls through to instance.get_distance() when distance isn't DB-
+        annotated, which calls get_distance_obj. Before the fix that
+        method's .filter(recruitment_status__in=...) clone issued a fresh
+        query per Trial.
+        """
+        from django.contrib.gis.geos import Point as GeoPoint
+
+        loc = LocationFactory(title='loc_for_distance', city='boston')
+        loc.geo_point = GeoPoint(-71.0589, 42.3601, srid=4326)
+        loc.save()
+        # 3 trials, each with one RECRUITING LocationTrial
+        trials = []
+        for _ in range(3):
+            t = TrialFactory()
+            LocationTrial.objects.create(trial=t, location=loc, recruitment_status='RECRUITING')
+            trials.append(t)
+
+        # Patient with geo
+        class _Stub:
+            geo_point = GeoPoint(-71.1097, 42.3736, srid=4326)
+        pi = _Stub()
+
+        # Prefetched + with recruitment_status filter (the previously
+        # broken path).
+        trials_pf = list(_list_qs())
+        with django_assert_num_queries(0):
+            for t in trials_pf:
+                t.get_distance_obj(pi, recruitment_status='RECRUITING')

--- a/tests/models/test_locationtrial_prefetch.py
+++ b/tests/models/test_locationtrial_prefetch.py
@@ -96,10 +96,13 @@ class TestLocationTrialPrefetch:
     def test_recruitment_status_filter_applies_in_python_when_prefetched(self):
         """Filter must work the same whether we're using the prefetched
         cache (Python filter) or the fallback (DB filter)."""
-        loc = LocationFactory(title='filterloc')
+        # Need two distinct locations: (trial, location) is uniquely
+        # constrained on LocationTrial.
+        loc_a = LocationFactory(title='filterloc_a')
+        loc_b = LocationFactory(title='filterloc_b')
         trial = TrialFactory()
-        LocationTrial.objects.create(trial=trial, location=loc, recruitment_status='RECRUITING')
-        LocationTrial.objects.create(trial=trial, location=loc, recruitment_status='COMPLETED')
+        LocationTrial.objects.create(trial=trial, location=loc_a, recruitment_status='RECRUITING')
+        LocationTrial.objects.create(trial=trial, location=loc_b, recruitment_status='COMPLETED')
 
         # Prefetched path
         trial_prefetched = _list_qs().get(pk=trial.pk)

--- a/trials/models.py
+++ b/trials/models.py
@@ -633,30 +633,54 @@ class Trial(TimeStampMixin):
         return [self.locations_name[0]] if len(self.locations_name) > 0 else []
 
     def get_distance_obj(self, pi, recruitment_status=None):
+        """Closest distance from patient to any LocationTrial of this Trial.
+
+        Materializes locationtrial_set as a Python list and filters in
+        Python so the TrialsViewSet prefetch (`Prefetch('locationtrial_set',
+        select_related('location'))`) is honored. The previous version
+        cloned the queryset via `.filter(recruitment_status__in=...)`
+        which issued a fresh DB query per Trial — the production N+1
+        flagged in #26.
+        """
         from trials.querysets.trial import get_recruitment_status_filter_values
 
         if hasattr(self, 'distance') and self.distance:
             return self.distance
 
-        if hasattr(self, 'locationtrial_set') and self.locationtrial_set.exists():
-            status_values = get_recruitment_status_filter_values(recruitment_status)
-            location_trials = self.locationtrial_set.all()
-            if status_values is not None:
-                location_trials = location_trials.filter(recruitment_status__in=status_values)
+        if not hasattr(self, 'locationtrial_set'):
+            return None
+        # `.all()` honors a `Prefetch` cache when one was declared;
+        # `list(...)` then materializes once, after which subsequent
+        # filtering happens in Python without further DB hits.
+        location_trials = list(self.locationtrial_set.all())
+        if not location_trials:
+            return None
 
-            for lt in location_trials:
-                if hasattr(lt, 'distance'):
-                    return lt.distance
+        status_values = get_recruitment_status_filter_values(recruitment_status)
+        if status_values is not None:
+            location_trials = [
+                lt for lt in location_trials
+                if lt.recruitment_status in status_values
+            ]
 
-            min_distance = None
-            for lt in location_trials:
-                if lt.location and lt.location.geo_point and pi.geo_point:
-                    p1 = Point(lt.location.geo_point.y, lt.location.geo_point.x, srid=4326)
-                    p2 = Point(pi.geo_point.y, pi.geo_point.x, srid=4326)
-                    dist = geopy_distance(p1, p2)
-                    if min_distance is None or dist < min_distance:
-                        min_distance = dist
-            return min_distance
+        for lt in location_trials:
+            if hasattr(lt, 'distance'):
+                return lt.distance
+
+        if pi is None or pi.geo_point is None:
+            return None
+
+        # Hoist the patient Point out of the loop (was rebuilt per
+        # LocationTrial in the prior version).
+        pi_point = Point(pi.geo_point.y, pi.geo_point.x, srid=4326)
+        min_distance = None
+        for lt in location_trials:
+            if lt.location and lt.location.geo_point:
+                p1 = Point(lt.location.geo_point.y, lt.location.geo_point.x, srid=4326)
+                dist = geopy_distance(p1, pi_point)
+                if min_distance is None or dist < min_distance:
+                    min_distance = dist
+        return min_distance
 
     def get_distance_penalty(self, pi, recruitment_status=None):
         if not pi or not pi.geo_point:
@@ -687,8 +711,53 @@ class Trial(TimeStampMixin):
         )
 
     def sorted_locations_by_distance(self, user_geo_point, recruitment_status=None):
+        """Return LocationTrial rows ordered by distance from user_geo_point.
+
+        Honors a `locationtrial_set` prefetch when present (TrialsViewSet
+        prefetches with `select_related('location')` for the list endpoint
+        — see #26), filtering and sorting in Python so the prefetched
+        cache isn't bypassed by a fresh `.select_related(...)` call.
+        Falls back to the QuerySet path for callers that didn't prefetch,
+        keeping the original DB-annotated `distance` ordering for those.
+
+        When user_geo_point is None: returns all matching LocationTrial
+        rows. When set: returns a single-element list with the closest one,
+        matching the prior contract.
+        """
         from trials.querysets.trial import get_recruitment_status_filter_values
         status_values = get_recruitment_status_filter_values(recruitment_status)
+
+        cached = (
+            self._prefetched_objects_cache.get('locationtrial_set')
+            if hasattr(self, '_prefetched_objects_cache') else None
+        )
+        if cached is not None:
+            location_trials = list(cached)
+            if status_values is not None:
+                location_trials = [
+                    lt for lt in location_trials
+                    if lt.recruitment_status in status_values
+                ]
+            if not user_geo_point:
+                return location_trials
+
+            # Hoist the patient Point so it's built once, not per LT.
+            user_point = Point(user_geo_point.y, user_geo_point.x, srid=4326)
+
+            def _distance_key(lt):
+                # Sort LocationTrials with missing geo last (matches the
+                # DB-side null_distance_flag ordering in the fallback).
+                # `lt.pk` is the stable tie-breaker so the prefetched and
+                # fallback paths can't drift apart when all-null inputs
+                # tie at (1, 0.0).
+                if not lt.location or not lt.location.geo_point:
+                    return (1, 0.0, lt.pk)
+                lt_point = Point(lt.location.geo_point.y, lt.location.geo_point.x, srid=4326)
+                return (0, geopy_distance(lt_point, user_point).km, lt.pk)
+            location_trials.sort(key=_distance_key)
+            return [location_trials[0]] if location_trials else location_trials
+
+        # Fallback: no prefetch cached — issue a DB query like before.
         location_trials = self.locationtrial_set.select_related('location')
         if status_values is not None:
             location_trials = location_trials.filter(recruitment_status__in=status_values)


### PR DESCRIPTION
## Summary

Closes #26 (and finally — for real, not just declaring the prefetch).

`TrialsViewSet.get_queryset` had been declaring `Prefetch('locationtrial_set', select_related('location'))` for the list endpoint since the rename PR, but **two** model methods the serializer calls per row were bypassing the cache:

| Method | What it did | Result |
|---|---|---|
| `sorted_locations_by_distance` (`models.py:689`) | `self.locationtrial_set.select_related('location')` — a fresh QuerySet | 1 query per Trial (or 1 + Distance annotate for geo path) |
| `get_distance_obj` (`models.py:635`) | `.all()` honored the prefetch but the follow-up `.filter(recruitment_status__in=...)` cloned the QuerySet | 1 query per Trial when recruitment_status filter was set (the default list contract) |

Both methods now materialize `self.locationtrial_set` as a Python list (which honors a `Prefetch` cache when one was declared) and filter / sort in Python.

## Fix details

- **`sorted_locations_by_distance`**: prefetched + with `user_geo_point` uses `geopy.distance` in Python instead of the DB-side `Distance` annotation. Stable `lt.pk` tie-breaker so prefetched and fallback paths agree on all-null inputs. Patient `Point` hoisted out of the per-LT closure.
- **`get_distance_obj`**: `list(self.locationtrial_set.all())` once, then Python filter. Patient `Point` hoisted out of the loop (was being rebuilt per LT in the prior version).
- **Fallback paths preserved**: when the prefetch isn't in scope (trial-detail rendering, ad-hoc model use), behavior is unchanged — DB-side `Distance` annotation + `order_by` for `sorted_locations_by_distance`; one query for `get_distance_obj`.

## Tests

`tests/models/test_locationtrial_prefetch.py` (new):
- `test_sorted_locations_uses_prefetch_when_available` — `django_assert_num_queries(0)` over prefetched trials.
- `test_query_count_constant_across_page_sizes` — N=2 then N=5, both with 0 extra queries.
- `test_fallback_path_still_works_without_prefetch`.
- `test_recruitment_status_filter_applies_in_python_when_prefetched`.
- `test_closest_location_wins_with_geo_point` — Boston patient + Cambridge / SF / no-geo locations → Cambridge wins on both paths.
- `test_get_distance_obj_uses_prefetch_cache` — `django_assert_num_queries(0)` proving the actual production hot path is fixed.

## Self-review

Fresh-context Claude pass caught two real issues:

1. **P0**: my first draft only fixed `sorted_locations_by_distance`. The serializer's distance-rendering branch falls through to `get_distance_obj` (since the list queryset doesn't annotate `distance`), and THAT method's `.filter()` clone was the actual production N+1 hot path. Fixed inline.
2. **P1**: novel with-geo sort branch had zero test coverage. Added `test_closest_location_wins_with_geo_point` cross-checking both paths against the same Boston/Cambridge/SF setup.

Plus stable-PK tie-breaker for the `(1, 0.0)` ties Claude flagged (P1-4), and patient `Point` hoisted out of the sort closure (P1-3).

Codex review not attempted this round — hung in previous sessions.

## Bonus

Adds `republish_latest.sh` (a local helper that kept getting accidentally staged) to `.gitignore` so future PRs in this branch don't have to keep unstaging it.

## Files

- `trials/models.py` (+88 / -19) — both methods rewritten
- `tests/models/test_locationtrial_prefetch.py` (new, ~185 lines)
- `tests/models/__init__.py` (new, empty)
- `.gitignore` (+1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)