### PR TITLE
fix(security): default DEBUG to false + replace unconditional CORS allow-all (#24) — DRAFT, needs deploy env confirmation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,14 @@
 SECRET_KEY=change-me
-DEBUG=true
+# Default false — uncomment for local dev / debugging (#24).
+# DEBUG=true
+# ALLOWED_HOSTS must include your prod domain when DEBUG=false; the default
+# localhost,127.0.0.1 is dev-only.
+# ALLOWED_HOSTS=app.example.com,api.example.com
+# CORS — pick one approach:
+#   CORS_ALLOWED_ORIGINS: comma-separated allowlist (preferred for staging/prod)
+#   CORS_ALLOW_ALL_ORIGINS=true: open everything (local dev only)
+CORS_ALLOWED_ORIGINS=http://localhost:3000,http://localhost:5173
+# CORS_ALLOW_ALL_ORIGINS=true
 DATABASE_NAME=exact
 DATABASE_USER=exact
 DATABASE_PASSWORD=

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -333,9 +333,11 @@ python manage.py seed_test_trials
 | Variable | Default | Description |
 |---|---|---|
 | `SECRET_KEY` | `django-insecure-…` | Django secret key — **change in production** |
-| `DEBUG` | `true` | Debug mode; set to `false` in production |
+| `DEBUG` | `false` | Debug mode; set to `true` only for local development. Pre-#24 it defaulted to `true`. |
 | `ALLOWED_HOSTS` | `localhost,127.0.0.1` | Comma-separated allowed host names |
 | `CSRF_TRUSTED_ORIGINS` | _(empty)_ | Comma-separated CSRF-trusted origins |
+| `CORS_ALLOWED_ORIGINS` | _(empty)_ | Comma-separated allowlist of browser origins — preferred for staging/prod. |
+| `CORS_ALLOW_ALL_ORIGINS` | `false` | Set to `true` for local-dev "let anything in" mode. Pre-#24 this was hardcoded `True` in settings. |
 | `DATABASE_NAME` | `exact` | PostgreSQL database name |
 | `DATABASE_USER` | `exact` | PostgreSQL user |
 | `DATABASE_PASSWORD` | _(empty)_ | PostgreSQL password |

--- a/exact/settings.py
+++ b/exact/settings.py
@@ -39,7 +39,7 @@ load_dotenv(os.path.join(BASE_DIR, _dotenv_file))
 
 SECRET_KEY = os.environ.get('SECRET_KEY', 'django-insecure-change-me-in-production')
 
-DEBUG = os.environ.get('DEBUG', 'true').lower() == 'true'
+DEBUG = os.environ.get('DEBUG', 'false').lower() == 'true'
 
 ALLOWED_HOSTS = os.environ.get('ALLOWED_HOSTS', 'localhost,127.0.0.1').split(',')
 
@@ -71,7 +71,15 @@ MIDDLEWARE = [
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 ]
 
-CORS_ALLOW_ALL_ORIGINS = True
+# CORS allowlist must be set explicitly per environment. Defaults to empty so
+# a misconfigured deploy doesn't accept browser requests from arbitrary
+# origins; local dev can opt in with `CORS_ALLOW_ALL_ORIGINS=true`.
+CORS_ALLOWED_ORIGINS = [
+    x.strip() for x in os.environ.get('CORS_ALLOWED_ORIGINS', '').split(',') if x.strip()
+]
+CORS_ALLOW_ALL_ORIGINS = (
+    os.environ.get('CORS_ALLOW_ALL_ORIGINS', 'false').lower() == 'true'
+)
 
 ROOT_URLCONF = 'exact.urls'
 

--- a/tests/test_settings_security.py
+++ b/tests/test_settings_security.py
@@ -1,0 +1,71 @@
+"""
+Smoke tests for production-safe defaults in exact/settings.py (#24).
+
+These don't reload settings (Django settings are frozen by import time)
+— they just guard against regressing the default values in the source.
+Reading the file directly avoids the need for a subprocess to test
+"what happens if DEBUG env is unset".
+"""
+import re
+from pathlib import Path
+
+
+SETTINGS_PATH = Path(__file__).resolve().parents[1] / 'exact' / 'settings.py'
+
+
+def _settings_source():
+    return SETTINGS_PATH.read_text()
+
+
+class TestDebugDefault:
+    """DEBUG must default to 'false' — pre-#24 it defaulted to 'true', which
+    exposed stack traces / SQL / settings if the env var was missing or
+    misnamed in a deploy. Catching a regression at the source-level beats
+    catching it after a permissive deploy."""
+
+    def test_debug_defaults_to_false(self):
+        source = _settings_source()
+        # Match: DEBUG = os.environ.get('DEBUG', '<default>')...
+        match = re.search(r"DEBUG\s*=\s*os\.environ\.get\(\s*['\"]DEBUG['\"]\s*,\s*['\"]([^'\"]+)['\"]", source)
+        assert match is not None, 'DEBUG env-resolution line not found in settings.py'
+        default = match.group(1).lower()
+        assert default == 'false', \
+            f"DEBUG default must be 'false' for production safety (#24); got {default!r}"
+
+
+class TestCorsAllowAllDefault:
+    """CORS_ALLOW_ALL_ORIGINS = True (unconditional) was the pre-#24 setting,
+    accepting browser requests from any origin. Replaced by an env-driven
+    allowlist; the boolean kill-switch is opt-in only."""
+
+    def test_cors_allow_all_origins_not_unconditional_true(self):
+        source = _settings_source()
+        # Reject the exact unconditional pattern. Allow env-resolved forms.
+        assert not re.search(r"^CORS_ALLOW_ALL_ORIGINS\s*=\s*True\s*$", source, re.MULTILINE), \
+            'CORS_ALLOW_ALL_ORIGINS must not be unconditionally True (#24); ' \
+            'use an env-driven opt-in instead.'
+
+    def test_cors_allow_all_origins_defaults_to_false(self):
+        source = _settings_source()
+        match = re.search(
+            r"CORS_ALLOW_ALL_ORIGINS\s*=\s*\(?\s*"
+            r"os\.environ\.get\(\s*['\"]CORS_ALLOW_ALL_ORIGINS['\"]\s*,\s*['\"]([^'\"]+)['\"]",
+            source,
+        )
+        assert match is not None, 'CORS_ALLOW_ALL_ORIGINS env-resolution line not found in settings.py'
+        default = match.group(1).lower()
+        assert default == 'false', \
+            f"CORS_ALLOW_ALL_ORIGINS default must be 'false'; got {default!r}"
+
+    def test_cors_allowed_origins_env_allowlist_is_declared(self):
+        source = _settings_source()
+        # Pre-#24 the codebase had no CORS_ALLOWED_ORIGINS at all — it relied
+        # on the unconditional allow-all switch. The fix adds an env-driven
+        # allowlist as the recommended path; assert it's present so a future
+        # refactor can't silently remove it.
+        assert 'CORS_ALLOWED_ORIGINS' in source, \
+            'CORS_ALLOWED_ORIGINS must be present in settings.py (#24).'
+        assert re.search(
+            r"CORS_ALLOWED_ORIGINS\s*=\s*\[?\s*[\s\S]*?os\.environ\.get\(\s*['\"]CORS_ALLOWED_ORIGINS['\"]",
+            source,
+        ), 'CORS_ALLOWED_ORIGINS must resolve from the env var.'


### PR DESCRIPTION
## ⚠ DRAFT — Deploy coordination required before merge

Fresh-context Claude self-review found a P0 cascade: flipping `DEBUG=false` arms Django's `ALLOWED_HOSTS` validator. The default `ALLOWED_HOSTS` in `settings.py:44` is `localhost,127.0.0.1` (dev-only).

**If the prod deploy environment doesn't already set `ALLOWED_HOSTS=<prod-domain>`, this PR causes HTTP 400 DisallowedHost on every prod request after merge.**

Same coordination question applies to `CORS_ALLOWED_ORIGINS` — prod must set the allowlist or set `CORS_ALLOW_ALL_ORIGINS=true` before this PR lands.

**Before marking ready for review**, verify the prod deploy environment has these env vars set:
- `ALLOWED_HOSTS=<comma-separated prod hosts>`
- Either `CORS_ALLOWED_ORIGINS=<comma-separated allowed frontends>` OR `CORS_ALLOW_ALL_ORIGINS=true`

---

## Summary

Closes #24. #25 (`.extra()` raw SQL replacement) was originally bundled but turned out to need a ~100-line `potential_attrs_to_check` rewrite — deferred.

## Changes

### `exact/settings.py:42`
DEBUG default flipped from `'true'` to `'false'`. Explicit `DEBUG=true` opt-in required for local debugging. Pre-#24 any deploy that missed the env var silently shipped with debug mode on, exposing stack traces, settings, and SQL.

### `exact/settings.py:74`
`CORS_ALLOW_ALL_ORIGINS = True` (unconditional) replaced with an env-driven pair:
- `CORS_ALLOWED_ORIGINS`: comma-separated allowlist (preferred for staging/prod).
- `CORS_ALLOW_ALL_ORIGINS=true`: opt-in kill switch for local dev.

Empty env → empty allowlist + no allow-all → django-cors-headers strips CORS response headers entirely (fail-closed).

### `.env.example` and `docs/setup.md`
`DEBUG` and `ALLOWED_HOSTS` commented out in `.env.example` (safe defaults now). `CORS_ALLOWED_ORIGINS` pre-filled for typical Vite/CRA ports. `docs/setup.md` env reference updated.

### `tests/test_settings_security.py` (new)
Source-level regex guards that catch regressions of the safe defaults. Django settings are frozen at import time so behavioral testing isn't viable; these tests catch a future change that flips the defaults back without a comment.

## Self-review

Fresh-context Claude flagged the `ALLOWED_HOSTS` cascade (P0) and a `.env.example:3` contradiction where the file documented one default and shipped the opposite. Both addressed; PR ships as Draft pending deploy confirmation.

Codex review not attempted (recent reliability issues).

## Files

- `exact/settings.py` (+9 / -2)
- `.env.example` (+6 / -1)
- `docs/setup.md` (+3 / -1)
- `tests/test_settings_security.py` (new, ~70 lines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)