### PR TITLE
perf: add DESC NULLS LAST indexes for Trial sort hot paths (#27)

### DIFF
--- a/trials/migrations/0004_trial_hot_path_indexes.py
+++ b/trials/migrations/0004_trial_hot_path_indexes.py
@@ -1,0 +1,39 @@
+"""
+Add B-tree indexes to Trial.enrollment_count and Trial.last_update_date (#27).
+
+These columns are used as ORDER BY targets at trials_views.py:156,158 (both
+`.desc(nulls_last=True)`) and last_update_date is also filtered by
+`by_date_since()` at querysets/trial.py:517. The indexes are declared with
+the same DESC NULLS LAST ordering so the planner can do an index scan
+with early termination on the LIMIT-paginated list endpoint — a plain
+ASC NULLS LAST B-tree (Django's default Index) cannot serve a DESC NULLS
+LAST query and the planner would fall back to seq scan + sort.
+
+trial_type is a ForeignKey — Django auto-indexes FKs, so no separate
+operation here.
+"""
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('trials', '0003_trial_mcl_fields'),
+    ]
+
+    operations = [
+        migrations.AddIndex(
+            model_name='trial',
+            index=models.Index(
+                models.F('enrollment_count').desc(nulls_last=True),
+                name='idx_trials_enroll_count',
+            ),
+        ),
+        migrations.AddIndex(
+            model_name='trial',
+            index=models.Index(
+                models.F('last_update_date').desc(nulls_last=True),
+                name='idx_trials_last_update',
+            ),
+        ),
+    ]

--- a/trials/models.py
+++ b/trials/models.py
@@ -6,7 +6,7 @@ from django.contrib.gis.db.models.functions import Distance
 from geopy.distance import distance as geopy_distance
 from django.contrib.postgres.indexes import GinIndex, GistIndex, Index
 from django.contrib.postgres.search import SearchVector
-from django.db.models import TextField, JSONField, Case, When, Value, IntegerField, Q
+from django.db.models import TextField, JSONField, Case, When, Value, IntegerField, F, Q
 from django.db.models.functions import Length, Lower
 from django.contrib.postgres.fields import ArrayField
 from django.contrib.gis.geos import Point
@@ -614,6 +614,20 @@ class Trial(TimeStampMixin):
             GinIndex(fields=['bulky_disease_criteria_required'], name='idx_bulky_disease_gin', opclasses=['jsonb_ops']),
             GinIndex(fields=['mipi_risks_required'], name='idx_mipi_risks_gin', opclasses=['jsonb_ops']),
             GinIndex(fields=['mipi_c_risks_required'], name='idx_mipi_c_risks_gin', opclasses=['jsonb_ops']),
+            # B-tree indexes on hot-path sort/filter columns (#27). Match the
+            # actual ORDER BY direction at trials_views.py:156,158 — a plain
+            # ASC NULLS LAST B-tree (Django default) cannot serve a
+            # `.desc(nulls_last=True)` ORDER BY, so the planner would fall
+            # back to seq scan + sort. trial_type is a ForeignKey so Django
+            # auto-indexes it.
+            Index(
+                F('enrollment_count').desc(nulls_last=True),
+                name='idx_trials_enroll_count',
+            ),
+            Index(
+                F('last_update_date').desc(nulls_last=True),
+                name='idx_trials_last_update',
+            ),
         ]
 
     def attrs_to_fill_in(self, counts):


### PR DESCRIPTION
## Summary

Closes #27. Adds two B-tree expression indexes that match the actual `ORDER BY` direction at the trials list endpoint.

## What changes

- **`trials/models.py:617-628`** — two entries in `Trial.Meta.indexes`:
  ```python
  Index(F('enrollment_count').desc(nulls_last=True), name='idx_trials_enroll_count'),
  Index(F('last_update_date').desc(nulls_last=True), name='idx_trials_last_update'),
  ```
- **`trials/migrations/0004_trial_hot_path_indexes.py`** (new) — `AddIndex` operations mirroring the Meta declarations exactly, so `manage.py makemigrations --check` reports no drift.

`trial_type` is a `ForeignKey` — Django auto-indexes FKs, so no separate declaration.

## Why DESC NULLS LAST, not the default ASC NULLS LAST

`trials_views.py:156,158` sorts with `F('last_update_date').desc(nulls_last=True)` and `F('enrollment_count').desc(nulls_last=True)`. A plain `Index(fields=[...])` builds an ASC NULLS LAST B-tree. PostgreSQL serves a DESC NULLS LAST query only via:

- forward scan of a `(... DESC NULLS LAST)` index, OR
- backward scan of a `(... ASC NULLS FIRST)` index — wrong NULLS position.

A plain ASC index wouldn't be used by the planner for the actual ORDER BY — Postgres would fall back to seq scan + sort. The pre-push self-review caught this in my first draft (I'd written `Index(fields=['enrollment_count'])`).

With the expression indexes in place, the planner can do an index scan with **early termination on the LIMIT pagination** — that's the real perf win.

## by_date_since filter

`last_update_date` is also filtered by `by_date_since()` at `querysets/trial.py:517` (`>=` predicate). `>=` is direction-agnostic — both ASC and DESC indexes serve it equally well. The DESC index continues to help this path.

## Self-review

Fresh-context Claude pass found:
- **P0**: my first draft used plain `Index(fields=[...])` which Postgres wouldn't use for the DESC NULLS LAST queries. Fixed inline with `F(...).desc(nulls_last=True)`.
- **P2**: `concurrently=True` on AddIndex would avoid the ACCESS EXCLUSIVE lock during the index build. Trials table is small (low hundreds of thousands globally), so sub-second downtime — left without CONCURRENTLY consistent with prior migrations in this repo. Worth revisiting if the table grows.
- **P2**: issue #27 also mentioned `matched_by_admin`/`favorite` "frequently-filtered booleans" — neither field exists on `Trial` (verified). Stale issue body, not a defect.

Codex review not attempted (recent reliability issues).

## Files

- `trials/models.py` (+15 / -1)
- `trials/migrations/0004_trial_hot_path_indexes.py` (new, ~40 lines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)