### PR TITLE
refactor: extract disease_attr_applies helper (#43)

### DIFF
--- a/tests/services/test_disease_attr_applies.py
+++ b/tests/services/test_disease_attr_applies.py
@@ -1,0 +1,87 @@
+"""
+Unit tests for disease_attr_applies (#43).
+
+The helper replaces five inline `disease_code in trial_attr_meta["disease"]`
+checks where the operator was string-vs-list-polymorphic. With a list, `in`
+checks membership (good). With a string, `in` does substring matching
+(bad — `'M' in 'MM'` is True), so a future disease code like 'M' would
+have silently matched 'MM' / 'MCL' restrictions. The call sites:
+matcher.trial_match_status / trial_match_score, queryset
+filter_by_patient_info, user_to_trial_attrs_mapper.potential_attrs_to_check,
+trial_details.trial_attributes get_user_details, and
+trial_match_explainer.explain.
+"""
+from trials.services.utils import disease_attr_applies
+
+
+class TestDiseaseAttrApplies:
+    # --- string restriction --------------------------------------------------
+
+    def test_string_exact_match(self):
+        assert disease_attr_applies('MM', 'MM') is True
+
+    def test_string_non_match(self):
+        assert disease_attr_applies('MM', 'CLL') is False
+
+    def test_string_substring_does_not_match(self):
+        # Pre-#43 inline check: `'M' in 'MM'` is True (substring). The helper
+        # must treat string restrictions as exact equality, not substring.
+        assert disease_attr_applies('MM', 'M') is False
+
+    def test_string_substring_reversed(self):
+        # And the opposite direction: a longer patient code should not match
+        # a shorter trial code.
+        assert disease_attr_applies('M', 'MM') is False
+
+    def test_string_case_sensitive(self):
+        # Disease codes are upper-case canonical (MM/FL/BC/CLL/MCL). The
+        # helper does a strict equality check — no lowercasing.
+        assert disease_attr_applies('MM', 'mm') is False
+
+    # --- list restriction ----------------------------------------------------
+
+    def test_list_member_matches(self):
+        assert disease_attr_applies(['MM', 'CLL'], 'MM') is True
+        assert disease_attr_applies(['MM', 'CLL'], 'CLL') is True
+
+    def test_list_non_member(self):
+        assert disease_attr_applies(['MM', 'CLL'], 'BC') is False
+
+    def test_empty_list_matches_nothing(self):
+        assert disease_attr_applies([], 'MM') is False
+
+    def test_list_substring_of_member_does_not_match(self):
+        # `'C' in ['CLL']` is False (list membership ignores substrings).
+        # Sanity-check the polymorphism didn't reintroduce substring behavior.
+        assert disease_attr_applies(['CLL'], 'C') is False
+
+    # --- list-like containers ------------------------------------------------
+
+    def test_tuple_restriction(self):
+        # Tuples are also accepted (configs sometimes use tuples for
+        # immutability; the helper should treat them the same as lists).
+        assert disease_attr_applies(('MM', 'CLL'), 'MM') is True
+        assert disease_attr_applies(('MM', 'CLL'), 'BC') is False
+
+    def test_set_restriction(self):
+        assert disease_attr_applies({'MM', 'CLL'}, 'MM') is True
+        assert disease_attr_applies({'MM', 'CLL'}, 'BC') is False
+
+
+class TestRealConfigShapes:
+    """Spot-check against the actual `USER_TO_TRIAL_ATTRS_MAPPING` shapes
+    so a config refactor (e.g. switching a list to a tuple, or vice
+    versa) doesn't silently break the helper's contract.
+    """
+
+    def test_mm_only_restriction(self):
+        # configs.py:272 — "disease": "MM"
+        assert disease_attr_applies('MM', 'MM') is True
+        assert disease_attr_applies('MM', 'FL') is False
+
+    def test_mm_or_cll_restriction(self):
+        # configs.py:257 — "disease": ["MM", "CLL"]
+        assert disease_attr_applies(['MM', 'CLL'], 'MM') is True
+        assert disease_attr_applies(['MM', 'CLL'], 'CLL') is True
+        assert disease_attr_applies(['MM', 'CLL'], 'MCL') is False
+        assert disease_attr_applies(['MM', 'CLL'], 'BC') is False

--- a/trials/querysets/trial.py
+++ b/trials/querysets/trial.py
@@ -27,6 +27,7 @@ from trials.services.patient_info.genetic_mutations import GeneticMutations
 from trials.services.patient_info.patient_info_flipi_score import PatientInfoFlipyScore
 from trials.services.trial_details.configs import PHASE_CODE_MAPPING
 from trials.services.user_to_trial_attrs_mapper import UserToTrialAttrsMapper
+from trials.services.utils import disease_attr_applies
 
 
 if TYPE_CHECKING:
@@ -1203,7 +1204,10 @@ class TrialQuerySet(models.QuerySet):
 
             # do the search now
             trial_attr_name = trial_attr_meta["attr"]
-            if "disease" in trial_attr_meta and (patient_info_attr.disease_code is None or patient_info_attr.disease_code not in trial_attr_meta["disease"]):
+            if "disease" in trial_attr_meta and (
+                patient_info_attr.disease_code is None
+                or not disease_attr_applies(trial_attr_meta["disease"], patient_info_attr.disease_code)
+            ):
                 continue
 
             if "custom_search" in trial_attr_meta and trial_attr_meta["custom_search"] is True:

--- a/trials/services/trial_details/trial_attributes.py
+++ b/trials/services/trial_details/trial_attributes.py
@@ -11,6 +11,7 @@ from trials.services.patient_info.configs import THERAPY_LINES_ATTRS_UNDERSCORED
 from trials.services.trial_details.configs import *
 from trials.services.therapies_mapper import *
 from trials.services.user_to_trial_attrs_mapper import *
+from trials.services.utils import disease_attr_applies
 from trials.services.value_options import ValueOptions
 
 
@@ -780,7 +781,10 @@ class TrialAttributes:
             subform_details = subform_attrs[user_attr] if user_attr in subform_attrs else None
             ureadonly = ('is_computed_value' in trial_attr_meta and trial_attr_meta['is_computed_value'] is True) or subform_details is not None
 
-            if "disease" in trial_attr_meta and (self._patient_info_attr.disease_code is None or self._patient_info_attr.disease_code not in trial_attr_meta["disease"]):
+            if "disease" in trial_attr_meta and (
+                self._patient_info_attr.disease_code is None
+                or not disease_attr_applies(trial_attr_meta["disease"], self._patient_info_attr.disease_code)
+            ):
                 continue
 
             if trial_attr_meta["type"] == "min_value":

--- a/trials/services/trial_match_explainer.py
+++ b/trials/services/trial_match_explainer.py
@@ -1,6 +1,7 @@
 from trials.services.patient_info.configs import USER_TO_TRIAL_ATTRS_MAPPING
 from trials.services.patient_info.patient_info_attributes import PatientInfoAttributes
 from trials.services.user_to_trial_attr_matcher import UserToTrialAttrMatcher
+from trials.services.utils import disease_attr_applies
 
 _STATUS_ORDER = {'not_matched': 0, 'unknown': 1, 'matched': 2}
 
@@ -63,17 +64,13 @@ class TrialMatchExplainer:
         results = []
 
         for attr, meta in USER_TO_TRIAL_ATTRS_MAPPING.items():
-            # Skip attrs not relevant to this trial's disease
+            # Skip attrs not relevant to this trial's disease.
             disease_restriction = meta.get('disease')
             if disease_restriction is not None:
                 if self._matcher.disease_code is None:
                     continue
-                if isinstance(disease_restriction, list):
-                    if self._matcher.disease_code not in disease_restriction:
-                        continue
-                else:
-                    if self._matcher.disease_code != disease_restriction:
-                        continue
+                if not disease_attr_applies(disease_restriction, self._matcher.disease_code):
+                    continue
 
             status = self._matcher.attr_match_status(attr)
             patient_value = self._pi_attrs.get_value(attr)

--- a/trials/services/user_to_trial_attr_matcher.py
+++ b/trials/services/user_to_trial_attr_matcher.py
@@ -11,7 +11,7 @@ from trials.services.patient_info.configs import (
 from trials.services.patient_info.genetic_mutations import GeneticMutations
 from trials.services.patient_info.patient_info_attributes import PatientInfoAttributes
 from trials.services.patient_info.patient_info_flipi_score import PatientInfoFlipyScore
-from trials.services.utils import get_overlap
+from trials.services.utils import disease_attr_applies, get_overlap
 
 
 def min_max_match(min_val, max_val, value, value_is_blank):
@@ -52,7 +52,10 @@ class UserToTrialAttrMatcher:
     def trial_match_status(self):
         out = {}
         for attr, trial_attr_meta in self.mapping.items():
-            if "disease" in trial_attr_meta and (self.disease_code is None or self.disease_code not in trial_attr_meta["disease"]):
+            if "disease" in trial_attr_meta and (
+                self.disease_code is None
+                or not disease_attr_applies(trial_attr_meta["disease"], self.disease_code)
+            ):
                 continue
             out[attr] = self.attr_match_status(attr)
 
@@ -68,7 +71,10 @@ class UserToTrialAttrMatcher:
         all_count = 0
 
         for attr, trial_attr_meta in self.mapping.items():
-            if "disease" in trial_attr_meta and (self.disease_code is None or self.disease_code not in trial_attr_meta["disease"]):
+            if "disease" in trial_attr_meta and (
+                self.disease_code is None
+                or not disease_attr_applies(trial_attr_meta["disease"], self.disease_code)
+            ):
                 continue
             status = self.attr_match_status(attr)
             all_count = all_count + 1

--- a/trials/services/user_to_trial_attrs_mapper.py
+++ b/trials/services/user_to_trial_attrs_mapper.py
@@ -5,6 +5,7 @@ from django.db.models import Q
 from trials.services.attribute_names import AttributeNames
 from trials.services.patient_info.configs import USER_TO_TRIAL_ATTRS_MAPPING, TRIAL_ATTRS_JSON_AS_A_LIST
 from trials.services.patient_info.patient_info_attributes import PatientInfoAttributes
+from trials.services.utils import disease_attr_applies
 
 
 class UserToTrialAttrsMapper:
@@ -135,7 +136,10 @@ class UserToTrialAttrsMapper:
             is_under_user_control = 'under_user_control' in trial_attr_meta and trial_attr_meta['under_user_control'] is True
 
             if patient_info:
-                if "disease" in trial_attr_meta and (service.disease_code is None or service.disease_code not in trial_attr_meta["disease"]):
+                if "disease" in trial_attr_meta and (
+                    service.disease_code is None
+                    or not disease_attr_applies(trial_attr_meta["disease"], service.disease_code)
+                ):
                     continue
 
                 is_blank = service.is_attr_blank(user_attr)

--- a/trials/services/utils.py
+++ b/trials/services/utils.py
@@ -1,6 +1,23 @@
 from glom import glom
 
 
+def disease_attr_applies(attr_disease, patient_disease) -> bool:
+    """True if a mapping entry's `disease` restriction includes the patient.
+
+    `attr_disease` is the `disease` value from a `USER_TO_TRIAL_ATTRS_MAPPING`
+    entry — a single disease code (str) or a collection of codes. Replaces
+    the inline `disease_code in trial_attr_meta["disease"]` checks at the
+    matcher, queryset, mapper, trial-detail, and explainer call sites (#43),
+    which silently substring-match when `attr_disease` is a string
+    (`'M' in 'MM'` is True), so adding a new disease code that's a
+    substring of an existing one would have caused subtle cross-disease
+    pollution.
+    """
+    if isinstance(attr_disease, (list, tuple, set)):
+        return patient_disease in attr_disease
+    return attr_disease == patient_disease
+
+
 def glom_or_none(data, key):
     try:
         return glom(data, key)


### PR DESCRIPTION
## Summary

Closes #43. Refactor 5 inline disease-applicability checks into a single helper, removing a substring-match brittleness that would have bitten when someone adds a future disease code that's a substring of an existing one.

## The brittleness

The matcher repeatedly did:
```python
if "disease" in trial_attr_meta and (disease_code is None or disease_code not in trial_attr_meta["disease"]):
    continue
```

`trial_attr_meta["disease"]` is either a single string (`"MM"`) or a list (`["MM", "CLL"]`). With a string, the inline `not in` does **substring matching** — `'M' in 'MM'` is True. The current MM/FL/BC/CLL/MCL code set happens to have no substring relationships, so behavior is preserved on real configs, but adding a hypothetical `'M'` or `'CL'` code would have silently matched parent restrictions.

## The fix

Single helper in `trials/services/utils.py`:
```python
def disease_attr_applies(attr_disease, patient_disease) -> bool:
    if isinstance(attr_disease, (list, tuple, set)):
        return patient_disease in attr_disease
    return attr_disease == patient_disease
```

Applied at **five** call sites:
- `user_to_trial_attr_matcher.trial_match_status` / `trial_match_score`
- `querysets/trial.py` `filter_by_patient_info`
- `user_to_trial_attrs_mapper.potential_attrs_to_check` (also gates the blank-attribute records-count SQL)
- `trial_details/trial_attributes.get_user_details`
- `trial_match_explainer.explain` (was a verbose 7-line hand-rolled `isinstance / list / else` block → 1 call)

## Self-review

Fresh-context Claude found **three call sites I'd missed** in the first draft (mapper, trial_attributes, trial_match_explainer). The original PR description claimed three call sites; the actual count is five. Fixed inline.

Also flagged P2: putting the helper in `user_to_trial_attr_matcher.py` forced four other modules to import from the matcher module — but the helper has nothing to do with the matcher class. Moved to `trials/services/utils.py` alongside `glom_or_none` / `get_overlap`.

Also dropped tautological smoke tests Claude flagged (asserted `result in ('eligible', 'potential', 'not_eligible')` — those are the only return values, so the test passed for any implementation including a stub).

Codex review not attempted (recent reliability issues).

## Tests

- String exact match / non-match.
- Substring brittleness in both directions (the regression guard).
- Case sensitivity (codes are canonical upper-case; helper is strict equality).
- List / tuple / set membership.
- Empty list matches nothing.
- Spot-checks against real `configs.py` shapes (`"MM"` string, `["MM","CLL"]` list).

## Files

- `trials/services/utils.py` (+17) — new helper
- `trials/services/user_to_trial_attr_matcher.py` (+8 / -4) — import + 2 call sites
- `trials/querysets/trial.py` (+5 / -1) — import + 1 call site
- `trials/services/user_to_trial_attrs_mapper.py` (+5 / -1)
- `trials/services/trial_details/trial_attributes.py` (+5 / -1)
- `trials/services/trial_match_explainer.py` (+3 / -8) — 7 lines collapsed to 1
- `tests/services/test_disease_attr_applies.py` (new, ~90 lines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)