### PR TITLE
fix: route 8 MCL custom_search attrs through filter_by_patient_info (#94)

### DIFF
--- a/tests/querysets/test_custom_search_dispatch.py
+++ b/tests/querysets/test_custom_search_dispatch.py
@@ -75,6 +75,36 @@ class TestDispatchTableExhaustive:
         therapy_keys = set(THERAPY_LINES_ATTRS_UNDERSCORED) | {'supportive_therapies'}
         assert therapy_keys.isdisjoint(_CUSTOM_SEARCH_DISPATCH.keys())
 
+    def test_every_custom_search_config_is_routable(self):
+        """Regression guard for the bug class behind #94: every config
+        marked `custom_search=True` must have a `_CUSTOM_SEARCH_DISPATCH`
+        entry (or be in the therapy-line fallback set). Without this
+        assertion, adding a new config with `custom_search=True` and no
+        dispatch entry silently crashes `filter_by_patient_info` only
+        when a patient with that attr non-blank flows through — which
+        is exactly how #94 sat latent for weeks.
+        """
+        from trials.services.patient_info.configs import (
+            USER_TO_TRIAL_ATTRS_MAPPING,
+            THERAPY_LINES_ATTRS_UNDERSCORED,
+        )
+        custom_search_keys = {
+            attr for attr, meta in USER_TO_TRIAL_ATTRS_MAPPING.items()
+            if meta.get('custom_search') is True
+        }
+        routable = (
+            set(_CUSTOM_SEARCH_DISPATCH.keys())
+            | set(THERAPY_LINES_ATTRS_UNDERSCORED)
+            | {'supportive_therapies'}
+        )
+        unroutable = custom_search_keys - routable
+        assert not unroutable, (
+            f'custom_search=True attrs with no _CUSTOM_SEARCH_DISPATCH '
+            f'entry and not in the therapy-line fallback: {sorted(unroutable)}. '
+            f'They would raise in filter_by_patient_info on any patient '
+            f'with that attr non-blank.'
+        )
+
 
 class TestCsvHelpers:
     def test_csv_splits_comma(self):

--- a/tests/querysets/test_mcl_filter_by_patient_info.py
+++ b/tests/querysets/test_mcl_filter_by_patient_info.py
@@ -1,0 +1,129 @@
+"""
+Regression test for #94 — filter_by_patient_info must not raise when an
+MCL patient has any of the 8 MCL custom_search attrs non-blank.
+
+Pre-fix, configs.py marked them with `custom_search=True` (or, for
+lesion_size_mcl, `custom_search=True` on a `min_max_value` type) but
+the queryset had no corresponding `eligible_for_*` method and the
+attrs were absent from `_CUSTOM_SEARCH_DISPATCH`. Any MCL patient
+flowing through `filter_by_patient_info` with any of them set would
+hit `raise Exception(...)` in the dispatch default branch.
+"""
+import pytest
+
+from trials.models import Trial
+from trials.services.patient_info.patient_info import PatientInfo
+from tests.factories import TrialFactory
+
+
+class TestMclFilterByPatientInfoSmoke:
+    @pytest.mark.django_db
+    def test_blank_mcl_patient_does_not_raise(self):
+        TrialFactory(disease='mantle cell lymphoma')
+        pi = PatientInfo(disease='mantle cell lymphoma')
+        # Default values are None / [] — the dispatch handlers must not
+        # raise on blanks; they should be no-ops.
+        result, _ = Trial.objects.filter_by_patient_info(pi)
+        assert result.count() >= 1
+
+    @pytest.mark.django_db
+    def test_filled_mcl_patient_does_not_raise(self):
+        TrialFactory(disease='mantle cell lymphoma')
+        pi = PatientInfo(
+            disease='mantle cell lymphoma',
+            morphologic_variant='classic',
+            lesion_size_mcl=5.0,
+            disease_behavior='indolent',
+            disease_subtype='cmcl',
+            extranodal_sites=['bone_marrow', 'gi_tract'],
+            mipi_risk='low',
+            mipi_c_risk='low',
+            bulky_disease_criteria=['bulky_lesion_5cm'],
+        )
+        # Pre-fix this would have raised
+        #   Exception('type ... is not supported for user_attr "morphologic_variant"')
+        # at the first MCL attr the loop encountered. Post-fix the
+        # dispatch routes each attr through its eligible_for_* method.
+        result, _ = Trial.objects.filter_by_patient_info(pi)
+        # Result count is a property of the underlying data; we just need
+        # the call to succeed without raising.
+        assert result.count() >= 0
+
+
+class TestMclQuerysetFilters:
+    """Each eligible_for_* method must correctly include trials that don't
+    restrict on the attr, exclude trials whose required-list is disjoint
+    from the patient value, and include trials whose required-list
+    overlaps."""
+
+    @pytest.mark.django_db
+    @pytest.mark.parametrize('method_name,trial_field,patient_value', [
+        ('eligible_for_disease_behaviors', 'disease_behaviors_required', ['indolent']),
+        ('eligible_for_disease_subtypes', 'disease_subtypes_required', ['cmcl']),
+        ('eligible_for_extranodal_sites', 'extranodal_sites_required', ['bone_marrow']),
+        ('eligible_for_mipi_risks', 'mipi_risks_required', ['low']),
+        ('eligible_for_mipi_c_risks', 'mipi_c_risks_required', ['low']),
+        ('eligible_for_bulky_disease_criteria', 'bulky_disease_criteria_required', ['bulky_lesion_5cm']),
+    ])
+    def test_required_list_overlap(self, method_name, trial_field, patient_value):
+        t_no_req = TrialFactory(disease='mantle cell lymphoma', **{trial_field: []})
+        t_matches = TrialFactory(disease='mantle cell lymphoma', **{trial_field: patient_value})
+        t_excludes = TrialFactory(
+            disease='mantle cell lymphoma',
+            **{trial_field: ['some_other_value']},
+        )
+
+        method = getattr(Trial.objects.all(), method_name)
+        result = set(method(patient_value).values_list('id', flat=True))
+
+        assert t_no_req.id in result, f'{method_name} must keep trials with empty required list'
+        assert t_matches.id in result, f'{method_name} must keep trials whose required overlaps patient'
+        assert t_excludes.id not in result, \
+            f'{method_name} must drop trials whose required is disjoint from patient'
+
+    @pytest.mark.django_db
+    def test_morphologic_variants_required_and_excluded(self):
+        # Two-list variant: required AND excluded must both be considered.
+        t_no_req = TrialFactory(
+            disease='mantle cell lymphoma',
+            morphologic_variants_required=[],
+            morphologic_variants_excluded=[],
+        )
+        t_matches = TrialFactory(
+            disease='mantle cell lymphoma',
+            morphologic_variants_required=['classic'],
+            morphologic_variants_excluded=[],
+        )
+        t_excluded = TrialFactory(
+            disease='mantle cell lymphoma',
+            morphologic_variants_required=['classic'],
+            morphologic_variants_excluded=['classic'],
+        )
+
+        result = set(
+            Trial.objects.all()
+            .eligible_for_morphologic_variants(['classic'])
+            .values_list('id', flat=True)
+        )
+        assert t_no_req.id in result
+        assert t_matches.id in result
+        assert t_excluded.id not in result
+
+    @pytest.mark.django_db
+    @pytest.mark.parametrize('method_name', [
+        'eligible_for_disease_behaviors',
+        'eligible_for_disease_subtypes',
+        'eligible_for_extranodal_sites',
+        'eligible_for_mipi_risks',
+        'eligible_for_mipi_c_risks',
+        'eligible_for_bulky_disease_criteria',
+        'eligible_for_morphologic_variants',
+    ])
+    def test_none_input_is_noop(self, method_name):
+        # The dispatch lambdas wrap empty patient values as None so the
+        # delegate (`eligible_for_required_lists` / `_and_excluded_lists`)
+        # short-circuits to `self`. Verify the wrappers honor that.
+        t = TrialFactory(disease='mantle cell lymphoma')
+        method = getattr(Trial.objects.all(), method_name)
+        result = set(method(None).values_list('id', flat=True))
+        assert t.id in result

--- a/trials/querysets/trial.py
+++ b/trials/querysets/trial.py
@@ -179,6 +179,18 @@ _CUSTOM_SEARCH_DISPATCH = {
     'tumor_burden': lambda s, v, _c: s.eligible_for_tumor_burdens(_csv_stripped(v)),
     'disease_activity': lambda s, v, _c: s.eligible_for_disease_activities(_csv_stripped(v)),
     'binet_stage': lambda s, v, _c: s.eligible_for_binet_stages(_csv_stripped(v)),
+    # MCL (#94). Single-string patient attrs are CSV-split for parity with
+    # the matcher's COMPUTED branch at user_to_trial_attr_matcher.py:592-594
+    # — without that, a `'classic,leukemic'` value would matcher-overlap as
+    # two codes but queryset-filter on the literal joined string, silently
+    # dropping every trial. Patient list attrs flow through unchanged.
+    'morphologic_variant': lambda s, v, _c: s.eligible_for_morphologic_variants(_csv_stripped(v)),
+    'disease_behavior': lambda s, v, _c: s.eligible_for_disease_behaviors(_csv_stripped(v)),
+    'disease_subtype': lambda s, v, _c: s.eligible_for_disease_subtypes(_csv_stripped(v)),
+    'mipi_risk': lambda s, v, _c: s.eligible_for_mipi_risks(_csv_stripped(v)),
+    'mipi_c_risk': lambda s, v, _c: s.eligible_for_mipi_c_risks(_csv_stripped(v)),
+    'extranodal_sites': lambda s, v, _c: s.eligible_for_extranodal_sites(v),
+    'bulky_disease_criteria': lambda s, v, _c: s.eligible_for_bulky_disease_criteria(v),
 }
 
 
@@ -1242,6 +1254,56 @@ class TrialQuerySet(models.QuerySet):
         return self.eligible_for_required_lists(
             values=binet_stages,
             required_attr_name='binet_stages_required'
+        )
+
+    # ------------------------------------------------------------------
+    # MCL filters (#94). The patient-side attrs land here as either a
+    # single string (variant / risk / behavior / subtype) or a list of
+    # strings (extranodal_sites / bulky_disease_criteria). All map to
+    # JSON-list trial columns checked via the shared list helpers above.
+    # ------------------------------------------------------------------
+
+    def eligible_for_morphologic_variants(self, values: list[str]) -> models.QuerySet:
+        return self.eligible_for_required_and_excluded_lists(
+            values=values,
+            required_attr_name='morphologic_variants_required',
+            excluded_attr_name='morphologic_variants_excluded',
+        )
+
+    def eligible_for_disease_behaviors(self, values: list[str]) -> models.QuerySet:
+        return self.eligible_for_required_lists(
+            values=values,
+            required_attr_name='disease_behaviors_required',
+        )
+
+    def eligible_for_disease_subtypes(self, values: list[str]) -> models.QuerySet:
+        return self.eligible_for_required_lists(
+            values=values,
+            required_attr_name='disease_subtypes_required',
+        )
+
+    def eligible_for_extranodal_sites(self, values: list[str]) -> models.QuerySet:
+        return self.eligible_for_required_lists(
+            values=values,
+            required_attr_name='extranodal_sites_required',
+        )
+
+    def eligible_for_mipi_risks(self, values: list[str]) -> models.QuerySet:
+        return self.eligible_for_required_lists(
+            values=values,
+            required_attr_name='mipi_risks_required',
+        )
+
+    def eligible_for_mipi_c_risks(self, values: list[str]) -> models.QuerySet:
+        return self.eligible_for_required_lists(
+            values=values,
+            required_attr_name='mipi_c_risks_required',
+        )
+
+    def eligible_for_bulky_disease_criteria(self, values: list[str]) -> models.QuerySet:
+        return self.eligible_for_required_lists(
+            values=values,
+            required_attr_name='bulky_disease_criteria_required',
         )
 
     def eligible_for_tp53_disruption(self, tp53_disruption: bool) -> models.QuerySet:

--- a/trials/services/patient_info/configs.py
+++ b/trials/services/patient_info/configs.py
@@ -507,7 +507,9 @@ USER_TO_TRIAL_ATTRS_MAPPING = {
     },
     "lesion_size_mcl": {
         "type": "min_max_value",
-        "custom_search": True,
+        # No custom_search — routed through the type-based min_max_value
+        # branch in filter_by_patient_info like every other min_max_value
+        # config (weight, patient_age, etc.). #94 fix.
         "searchable": True,
         "disease": "MCL",
         "attr_min": "lesion_size_mcl_min",


### PR DESCRIPTION
## Summary

Closes #94. Real production bug from PR #72.

PR #72 added 8 MCL patient attrs to `USER_TO_TRIAL_ATTRS_MAPPING` with `custom_search=True`. The matcher handled them via the COMPUTED branch + `uvalue_function`, but the queryset `filter_by_patient_info` has a separate routing path that needs a matching `_CUSTOM_SEARCH_DISPATCH` entry and an `eligible_for_*` queryset method. Both were missing for all 8 MCL attrs. **Any MCL patient with `morphologic_variant` / `lesion_size_mcl` / `disease_behavior` / `disease_subtype` / `extranodal_sites` / `mipi_risk` / `mipi_c_risk` / `bulky_disease_criteria` non-blank would crash the trial-matching endpoint** with `Exception('type ... is not supported for user_attr "..."')`.

Surfaced by PR #93's self-review when fresh-context Claude was verifying the dispatch refactor preserved original behavior.

## Changes

### `trials/querysets/trial.py` — 7 new `eligible_for_*` methods

Following the CLL pattern exactly — each is a thin wrapper around the shared `eligible_for_required_lists` / `eligible_for_required_and_excluded_lists` helpers:

- `eligible_for_morphologic_variants` (required + excluded — TextField patient, JSON list trial cols)
- `eligible_for_disease_behaviors` (required only)
- `eligible_for_disease_subtypes` (required only)
- `eligible_for_extranodal_sites` (required only — patient is JSONField list)
- `eligible_for_mipi_risks` (required only)
- `eligible_for_mipi_c_risks` (required only)
- `eligible_for_bulky_disease_criteria` (required only — patient is JSONField list)

### `trials/querysets/trial.py` — 7 `_CUSTOM_SEARCH_DISPATCH` entries

The 5 string-valued patient attrs go through `_csv_stripped(v)` for parity with the matcher's COMPUTED branch at `user_to_trial_attr_matcher.py:592-594`, which also CSV-splits string uvalues. **Without that symmetry**, a `'classic,leukemic'` input would matcher-overlap as two codes but queryset-filter on the literal joined string, silently dropping every trial. The 2 list-valued attrs (`extranodal_sites`, `bulky_disease_criteria`) pass through unchanged.

### `trials/services/patient_info/configs.py:508-516`

Drop `custom_search: True` from `lesion_size_mcl`. Its `type` is `min_max_value` — `custom_search` was a copy-paste mistake from the other MCL configs. Now it falls through to the type-based `min_max_value` branch (the same path `weight`, `patient_age`, etc. use).

## Tests

`tests/querysets/test_mcl_filter_by_patient_info.py` (new):
- Blank + filled MCL patient smoke tests (`filter_by_patient_info` must not raise — the regression for #94 itself).
- Per-method overlap (no_req / matches / excludes) for the 6 required-only methods.
- Required+excluded coverage for `morphologic_variants`.
- `None`-input no-op for all 7 methods.

`tests/querysets/test_custom_search_dispatch.py` (extended):
- **`test_every_custom_search_config_is_routable`** — bug-class regression test that iterates `USER_TO_TRIAL_ATTRS_MAPPING` and asserts every `custom_search=True` attr has a `_CUSTOM_SEARCH_DISPATCH` entry (or is in the therapy-line fallback). Would have caught #94 the moment PR #72 landed.

## Self-review

Fresh-context Claude pass caught a real P1 — my first draft used `[v] if v else None` to wrap single-value patient attrs as a 1-element list. But the matcher CSV-splits string values, so a `'classic,leukemic'` input would silently disagree between matcher and queryset. Switched to `_csv_stripped(v)` for symmetry.

Plus P2: misleading config comment (referenced `largest_lymph_node_size` which is `min_value`, not `min_max_value`) — fixed. Plus added the dispatch-completeness assertion Claude flagged as closing the bug class.

Codex skipped (recent reliability).

## Files

- `trials/querysets/trial.py` (+61) — 7 methods + 7 dispatch entries
- `trials/services/patient_info/configs.py` (+3 / -1) — drop `custom_search` from `lesion_size_mcl` + comment
- `tests/querysets/test_mcl_filter_by_patient_info.py` (new, ~130 lines)
- `tests/querysets/test_custom_search_dispatch.py` (+33) — bug-class regression test

🤖 Generated with [Claude Code](https://claude.com/claude-code)