### PR TITLE
refactor: replace deprecated .extra() in BlankAttributeRecordsCount (#25)

### DIFF
--- a/tests/services/test_blank_attribute_records_count.py
+++ b/tests/services/test_blank_attribute_records_count.py
@@ -1,0 +1,24 @@
+"""Regression tests for BlankAttributeRecordsCount after the .extra() → aggregate() port (#25)."""
+import pytest
+
+from trials.models import Trial
+from trials.services.blank_attribute_records_count import BlankAttributeRecordsCount
+
+
+class TestBlankAttributeRecordsCount:
+    def test_none_patient_info_returns_empty(self):
+        """No patient → no candidate attrs → empty dict, no DB hit."""
+        result = BlankAttributeRecordsCount().counts(patient_info=None)
+        assert result == {}
+
+    @pytest.mark.django_db
+    def test_empty_scope_returns_empty(self, patient_info):
+        """`aggregate()` on `.none()` returns `{key: None}` for every key,
+        which the final non-None filter strips to `{}`. Pre-port this path
+        exited via `if not out: return {}` after `.extra(select=).values()`
+        — preserve the empty-dict contract.
+        """
+        result = BlankAttributeRecordsCount().counts(
+            scope=Trial.objects.none(), patient_info=patient_info
+        )
+        assert result == {}

--- a/trials/api/trials_views.py
+++ b/trials/api/trials_views.py
@@ -7,6 +7,7 @@ from rest_framework import serializers
 from trials.api.pagination import TrialsPagination
 from trials.api.trials_serializers import TrialSerializer, TrialDetailsSerializer
 from trials.models import Trial, Location, LocationTrial, PreferredCountry, State
+from trials.services.blank_attribute_records_count import BlankAttributeRecordsCount
 from trials.services.patient_info.resolve import resolve_patient_info
 from trials.services.study_preferences import study_preferences_from_query_params
 from trials.services.value_options import ValueOptions
@@ -32,28 +33,6 @@ class LocationSerializer(serializers.ModelSerializer):
         response['state'] = instance.state.title if instance.state else None
         response['country'] = instance.country.title if instance.country else None
         return response
-
-
-# ---------------------------------------------------------------------------
-# Blank-attribute counts helper (adapted from source — no user dependency)
-# ---------------------------------------------------------------------------
-
-class _BlankAttributeRecordsCount:
-    def counts(self, scope, patient_info):
-        if patient_info is None:
-            return {}
-
-        from trials.services.user_to_trial_attrs_mapper import UserToTrialAttrsMapper
-        sql_conditions = UserToTrialAttrsMapper().potential_attrs_to_check(patient_info)
-        if not sql_conditions:
-            return {}
-
-        sql_counts = {attr: f'SUM{sql_conditions[attr]}' for attr in sql_conditions}
-        out = scope.extra(select=sql_counts).values(*sql_counts.keys())
-        if not out:
-            return {}
-        out = out[0]
-        return {k: v for k, v in out.items() if v is not None}
 
 
 # ---------------------------------------------------------------------------
@@ -173,7 +152,7 @@ class TrialsViewSet(viewsets.ReadOnlyModelViewSet):
         return queryset
 
     def _trials_counts(self, queryset, patient_info):
-        return _BlankAttributeRecordsCount().counts(queryset, patient_info)
+        return BlankAttributeRecordsCount().counts(queryset, patient_info)
 
     def get_serializer_class(self):
         return self.serializer_classes.get(self.action, self.default_serializer_class)

--- a/trials/services/blank_attribute_records_count.py
+++ b/trials/services/blank_attribute_records_count.py
@@ -1,8 +1,26 @@
-from trials.models import *
+from django.db.models import BigIntegerField, Sum
+from django.db.models.expressions import RawSQL
+
+from trials.models import Trial
 from trials.services.user_to_trial_attrs_mapper import UserToTrialAttrsMapper
 
 
 class BlankAttributeRecordsCount:
+    """Count trials that are blank for each user-attribute candidate.
+
+    For every entry returned by `UserToTrialAttrsMapper.potential_attrs_to_check`,
+    sums a per-trial `(CASE WHEN <blank-condition> THEN <then> END)` expression
+    across the scope. Used to rank candidate attributes by how many trials they
+    would unlock.
+
+    The CASE-WHEN strings come from a static mapping (`USER_TO_TRIAL_ATTRS_MAPPING`)
+    so there's no user-supplied SQL on the path. Migrating from the deprecated
+    `.extra(select=…)` to `aggregate(Sum(RawSQL(…)))` (#25) — same SQL emitted,
+    same return shape; only the Django-side surface changes. The remaining
+    `.extra()` callsites in trials/querysets/trial.py:214-227 are tracked
+    separately in #97.
+    """
+
     def counts(self, scope=None, patient_info=None):
         if scope is None:
             scope = Trial.objects.all()
@@ -11,16 +29,17 @@ class BlankAttributeRecordsCount:
             return {}
 
         sql_conditions = UserToTrialAttrsMapper().potential_attrs_to_check(patient_info)
-        if sql_conditions == {}:
+        if not sql_conditions:
             return {}
 
-        sql_counts = {}
-        for attr in sql_conditions.keys():
-            sql_counts[attr] = f'SUM{sql_conditions[attr]}'
-
-        out = scope.extra(select=sql_counts).values(*sql_counts.keys())
-
-        out = out[0]
-        out = {k: v for k, v in out.items() if v is not None}
-
-        return out
+        # BigIntegerField, not IntegerField: when `counts` is passed into
+        # the mapper, the CASE-WHEN's ELSE branch uses arbitrary count
+        # values that sum across the catalog can exceed 2^31. Postgres
+        # SUM yields bigint; declaring IntegerField would silently
+        # truncate via Django's IntegerField.to_python coercion.
+        aggregations = {
+            attr: Sum(RawSQL(sql_conditions[attr], []), output_field=BigIntegerField())
+            for attr in sql_conditions
+        }
+        out = scope.aggregate(**aggregations)
+        return {k: v for k, v in out.items() if v is not None}


### PR DESCRIPTION
Closes #25. Follow-up filed as #97 for the remaining `.extra()` callsites in `trials/querysets/trial.py`.

## Summary

- Rewrites `BlankAttributeRecordsCount.counts()` to use `aggregate(Sum(RawSQL(sql, []), output_field=BigIntegerField()))` instead of `.extra(select={attr: f'SUM{sql}'}).values()[0]`. Same SQL reaches Postgres; only the Django-side surface changes.
- Deletes the duplicate private `_BlankAttributeRecordsCount` from `trials/api/trials_views.py` (was a near-copy of the service) and routes `TrialsViewSet._trials_counts` to the canonical service.
- Adds dedicated tests in `tests/services/test_blank_attribute_records_count.py` for the no-patient and empty-scope edge cases.

## Why `BigIntegerField` (not `IntegerField`)

When the caller passes a `counts` parameter, the CASE-WHEN ELSE branch emits arbitrary integer values whose `SUM` across the catalog can exceed 2^31. Postgres `SUM` yields `bigint`; an `IntegerField` output_field would silently truncate via Django's `IntegerField.to_python` coercion. Caught in fresh-context self-review.

## Scope decision

Issue #25's title is narrow (`_BlankAttributeRecordsCount.counts()`). `trials/querysets/trial.py` has 5 more `.extra()` callsites (`add_potential_attrs_count`) using `num_nonnulls()` and `extra(where=…)` — meaningfully larger, sits on the match-scoring hot path, and needs EXPLAIN ANALYZE comparison. Tracked as **#97**.

## Self-review

Fresh-context Claude pass — flagged `IntegerField` overflow (applied), confirmed SQL emission and NULL handling are equivalent. The `USER_TO_TRIAL_ATTRS_MAPPING` source for the SQL strings is a static module-level config, so the (already-zero) injection vector is unchanged. Codex review skipped (unreliable in this PR series).

## Test plan

- [ ] CI: `tests/services/test_user_to_trial_attrs_mapper.py::TestUserToTrialAttrsMapper::test_potential_attrs_for_trial` passes (existing end-to-end test that calls `BlankAttributeRecordsCount().counts(...)` with real factory data and asserts downstream ranking).
- [ ] CI: `tests/services/test_blank_attribute_records_count.py` (new, two regression tests).
- [ ] CI: `python manage.py makemigrations --check` still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)