### PR TITLE
refactor: consolidate BC receptor parent-code maps into single module (#45)

### DIFF
--- a/tests/services/test_receptor_hierarchy.py
+++ b/tests/services/test_receptor_hierarchy.py
@@ -1,0 +1,82 @@
+"""Unit tests for the consolidated receptor parent-code expansion module.
+
+The end-to-end behaviour (BC trial matching against ER/PR/HR hierarchy)
+is covered by `tests/querysets/test_trial_querysets.py::test_estrogen_receptor_status_hierarchy`
+and the matcher's hierarchy tests at
+`tests/services/test_user_to_trial_attr_matcher.py`. This file locks in
+the helper signatures so a future drift between SQL-filter and
+match-status display layers (which both consume this module) is caught
+at the unit level too.
+"""
+import pytest
+
+from trials.services.receptor_hierarchy import expand_uvalue, expand_values
+
+
+class TestExpandValues:
+    """SQL-filter layer: append parent code to list of patient values."""
+
+    def test_child_value_gets_parent_appended(self):
+        assert expand_values(['er_plus_with_hi_exp'], 'er') == [
+            'er_plus_with_hi_exp', 'er_plus',
+        ]
+
+    def test_parent_only_passes_through(self):
+        assert expand_values(['er_plus'], 'er') == ['er_plus']
+
+    def test_unknown_code_passes_through(self):
+        assert expand_values(['er_minus'], 'er') == ['er_minus']
+
+    def test_empty_list_returns_empty(self):
+        assert expand_values([], 'er') == []
+
+    def test_order_preserved(self):
+        result = expand_values(['er_minus', 'er_plus_with_hi_exp'], 'er')
+        assert result == ['er_minus', 'er_plus_with_hi_exp', 'er_plus']
+
+    def test_parent_not_duplicated_when_already_present(self):
+        result = expand_values(['er_plus_with_hi_exp', 'er_plus'], 'er')
+        assert result == ['er_plus_with_hi_exp', 'er_plus']
+
+    def test_input_list_not_mutated(self):
+        values = ['er_plus_with_hi_exp']
+        expand_values(values, 'er')
+        assert values == ['er_plus_with_hi_exp']
+
+    @pytest.mark.parametrize('kind,child,parent', [
+        ('er', 'er_plus_with_hi_exp', 'er_plus'),
+        ('er', 'er_plus_with_low_exp', 'er_plus'),
+        ('pr', 'pr_plus_with_hi_exp', 'pr_plus'),
+        ('pr', 'pr_plus_with_low_exp', 'pr_plus'),
+        ('hr', 'hr_plus_with_hi_exp', 'hr_plus'),
+        ('hr', 'hr_plus_with_low_exp', 'hr_plus'),
+    ])
+    def test_all_known_hierarchies(self, kind, child, parent):
+        assert expand_values([child], kind) == [child, parent]
+
+
+class TestExpandUvalue:
+    """Matcher uvalue layer: comma-join code with parent for CSV-split overlap."""
+
+    @pytest.mark.parametrize('kind,child,parent', [
+        ('er', 'er_plus_with_hi_exp', 'er_plus'),
+        ('er', 'er_plus_with_low_exp', 'er_plus'),
+        ('pr', 'pr_plus_with_hi_exp', 'pr_plus'),
+        ('pr', 'pr_plus_with_low_exp', 'pr_plus'),
+        ('hr', 'hr_plus_with_hi_exp', 'hr_plus'),
+        ('hr', 'hr_plus_with_low_exp', 'hr_plus'),
+    ])
+    def test_child_value_produces_csv(self, kind, child, parent):
+        assert expand_uvalue(child, kind) == f'{child},{parent}'
+
+    def test_parent_only_passes_through_unchanged(self):
+        assert expand_uvalue('er_plus', 'er') == 'er_plus'
+
+    def test_unknown_code_passes_through_unchanged(self):
+        assert expand_uvalue('er_minus', 'er') == 'er_minus'
+
+    def test_none_passes_through(self):
+        assert expand_uvalue(None, 'er') is None
+
+    def test_empty_string_passes_through(self):
+        assert expand_uvalue('', 'er') == ''

--- a/trials/querysets/trial.py
+++ b/trials/querysets/trial.py
@@ -23,6 +23,7 @@ from trials.services.patient_info.configs import (
     ATTR_MAPPING_TYPE_COMPUTED, SCT_HISTORY_EXCLUDED_MAPPING,
     sct_value_is_none,
 )
+from trials.services.receptor_hierarchy import expand_values as expand_receptor_values
 from trials.services.patient_info.genetic_mutations import GeneticMutations
 from trials.services.patient_info.patient_info_flipi_score import PatientInfoFlipyScore
 from trials.services.trial_details.configs import PHASE_CODE_MAPPING
@@ -1133,33 +1134,19 @@ class TrialQuerySet(models.QuerySet):
             required_attr_name='languages_skills_required'
         )
 
-    # ── Receptor status parent-code expansion ─────────────────────────────────
-    # Trials may store a generic parent code (e.g. "er_plus") while the patient
-    # carries a specific child code (e.g. "er_plus_with_hi_exp") after CTOMOP
-    # normalization.  Including the parent in the filter ensures trials that
-    # accepted the generic code still match.
-    _ER_PARENTS = {'er_plus_with_hi_exp': 'er_plus', 'er_plus_with_low_exp': 'er_plus'}
-    _PR_PARENTS = {'pr_plus_with_hi_exp': 'pr_plus', 'pr_plus_with_low_exp': 'pr_plus'}
-    _HR_PARENTS = {'hr_plus_with_hi_exp': 'hr_plus', 'hr_plus_with_low_exp': 'hr_plus'}
-
-    @staticmethod
-    def _expand_receptor_codes(values: list[str], parent_map: dict) -> list[str]:
-        expanded = list(values)
-        for v in values:
-            parent = parent_map.get(v)
-            if parent and parent not in expanded:
-                expanded.append(parent)
-        return expanded
+    # Receptor parent-code expansion lives in trials.services.receptor_hierarchy
+    # — shared with the matcher's uvalue_function lambdas so SQL filtering and
+    # match-status display stay in sync.
 
     def eligible_for_estrogen_receptor_statuses(self, estrogen_receptor_statuses: list[str]) -> models.QuerySet:
         return self.eligible_for_required_lists(
-            values=self._expand_receptor_codes(estrogen_receptor_statuses, self._ER_PARENTS),
+            values=expand_receptor_values(estrogen_receptor_statuses, 'er'),
             required_attr_name='estrogen_receptor_statuses_required'
         )
 
     def eligible_for_progesterone_receptor_statuses(self, progesterone_receptor_statuses: list[str]) -> models.QuerySet:
         return self.eligible_for_required_lists(
-            values=self._expand_receptor_codes(progesterone_receptor_statuses, self._PR_PARENTS),
+            values=expand_receptor_values(progesterone_receptor_statuses, 'pr'),
             required_attr_name='progesterone_receptor_statuses_required'
         )
 
@@ -1177,7 +1164,7 @@ class TrialQuerySet(models.QuerySet):
 
     def eligible_for_hr_statuses(self, hr_statuses: list[str]) -> models.QuerySet:
         return self.eligible_for_required_lists(
-            values=self._expand_receptor_codes(hr_statuses, self._HR_PARENTS),
+            values=expand_receptor_values(hr_statuses, 'hr'),
             required_attr_name='hr_statuses_required'
         )
 

--- a/trials/services/patient_info/configs.py
+++ b/trials/services/patient_info/configs.py
@@ -8,6 +8,7 @@ from trials.services.patient_info.convertors.bilirubin_convertor import Bilirubi
 from trials.services.patient_info.convertors.scr_uln_calculator import ScrUlnCalculator
 from trials.services.patient_info.convertors.serum_calcium_convertor import SerumCalciumConvertor
 from trials.services.patient_info.convertors.serum_creatinine_convertor import SerumCreatinineConvertor
+from trials.services.receptor_hierarchy import expand_uvalue as _receptor_uvalue
 
 THERAPY_LINES_ATTRS = ["firstLineTherapy", "secondLineTherapy", "laterTherapy", "laterTherapies"]
 THERAPY_LINES_ATTRS_UNDERSCORED = ["first_line_therapy", "second_line_therapy", "later_therapy", "later_therapies"]
@@ -17,20 +18,6 @@ THERAPIES_ATTRS_UNDERSCORED = ["therapies_required", "therapies_excluded", "ther
 TRIAL_GENETIC_MUTATIONS_ATTRS_UNDERSCORED = ["mutation_genes_required", "mutation_variants_required", "mutation_origins_required", "mutation_interpretations_required"]
 
 ATTR_MAPPING_TYPE_COMPUTED = "computed"
-
-# Receptor status hierarchy: subtypes must also match generic parent codes.
-# E.g. a patient with er_plus_with_hi_exp is also er_plus.
-_ER_PARENT_CODES = {'er_plus_with_hi_exp': 'er_plus', 'er_plus_with_low_exp': 'er_plus'}
-_PR_PARENT_CODES = {'pr_plus_with_hi_exp': 'pr_plus', 'pr_plus_with_low_exp': 'pr_plus'}
-_HR_PARENT_CODES = {'hr_plus_with_hi_exp': 'hr_plus', 'hr_plus_with_low_exp': 'hr_plus'}
-
-
-def _receptor_uvalue(code, parent_map):
-    """Return code plus its generic parent (comma-joined) so the matcher can overlap against either."""
-    if not code:
-        return code
-    parent = parent_map.get(code)
-    return f"{code},{parent}" if parent else code
 
 # "priorSCT": "prior SCT",
 # "priorAutologousSCT": "prior autologous SCT",
@@ -636,7 +623,7 @@ USER_TO_TRIAL_ATTRS_MAPPING = {
         "attr": ["estrogen_receptor_statuses_required"],
         "uvalue_function": {
             "estrogen_receptor_statuses_required":
-                lambda patient_info: _receptor_uvalue(patient_info.estrogen_receptor_status, _ER_PARENT_CODES),
+                lambda patient_info: _receptor_uvalue(patient_info.estrogen_receptor_status, 'er'),
         }
     },
     "progesterone_receptor_status": {
@@ -646,7 +633,7 @@ USER_TO_TRIAL_ATTRS_MAPPING = {
         "attr": ["progesterone_receptor_statuses_required"],
         "uvalue_function": {
             "progesterone_receptor_statuses_required":
-                lambda patient_info: _receptor_uvalue(patient_info.progesterone_receptor_status, _PR_PARENT_CODES),
+                lambda patient_info: _receptor_uvalue(patient_info.progesterone_receptor_status, 'pr'),
         }
     },
     "her2_status": {
@@ -676,7 +663,7 @@ USER_TO_TRIAL_ATTRS_MAPPING = {
         "attr": ["hr_statuses_required"],
         "uvalue_function": {
             "hr_statuses_required":
-                lambda patient_info: _receptor_uvalue(patient_info.hr_status, _HR_PARENT_CODES),
+                lambda patient_info: _receptor_uvalue(patient_info.hr_status, 'hr'),
         }
     },
     "tnbc_status": {

--- a/trials/services/receptor_hierarchy.py
+++ b/trials/services/receptor_hierarchy.py
@@ -1,0 +1,60 @@
+"""Shared parent-code expansion for BC receptor statuses.
+
+Patient receptor codes have a 2-level hierarchy: specific subtypes
+(`*_with_hi_exp`, `*_with_low_exp`) imply the generic parent
+(`er_plus`, `pr_plus`, `hr_plus`). A trial that requires the parent
+code must match patients carrying any subtype.
+
+Consumed at two layers — both must include the parent so the SQL
+filter and the per-trial match-status display agree:
+
+- SQL filter (`trials/querysets/trial.py`'s `eligible_for_*_statuses`)
+  uses `expand_values()` to append the parent to the values list before
+  the IN-overlap check.
+- Match-status display (`USER_TO_TRIAL_ATTRS_MAPPING.*.uvalue_function`
+  in `trials/services/patient_info/configs.py`) uses `expand_uvalue()`
+  to comma-join the patient's code with its parent so the matcher's
+  CSV-split overlap picks up either.
+
+Previously each layer had its own copy of the parent map; editing one
+without the other silently desynced search results from match badges.
+This module is the single source of truth.
+"""
+from typing import Literal
+
+ReceptorType = Literal['er', 'pr', 'hr']
+
+_PARENT_CODES_BY_TYPE: dict[ReceptorType, dict[str, str]] = {
+    'er': {'er_plus_with_hi_exp': 'er_plus', 'er_plus_with_low_exp': 'er_plus'},
+    'pr': {'pr_plus_with_hi_exp': 'pr_plus', 'pr_plus_with_low_exp': 'pr_plus'},
+    'hr': {'hr_plus_with_hi_exp': 'hr_plus', 'hr_plus_with_low_exp': 'hr_plus'},
+}
+
+
+def expand_values(values: list[str], kind: ReceptorType) -> list[str]:
+    """Append the parent code for every child in `values`. Order preserved.
+
+    Used by the SQL-filter layer. Returns a new list; `values` is unmodified.
+    """
+    parent_map = _PARENT_CODES_BY_TYPE[kind]
+    expanded = list(values)
+    for v in values:
+        parent = parent_map.get(v)
+        if parent and parent not in expanded:
+            expanded.append(parent)
+    return expanded
+
+
+def expand_uvalue(code: str | None, kind: ReceptorType) -> str | None:
+    """Comma-join `code` with its parent (if any) for matcher consumption.
+
+    Used by `uvalue_function` lambdas in the matcher pipeline; the
+    matcher splits the returned string by comma so a CSV of
+    `"child,parent"` overlaps against either trial requirement.
+    Returns `code` unchanged when it has no parent mapping. Falsy
+    inputs (None, empty string) pass through.
+    """
+    if not code:
+        return code
+    parent = _PARENT_CODES_BY_TYPE[kind].get(code)
+    return f"{code},{parent}" if parent else code


### PR DESCRIPTION
Closes #45 — with a scope correction (see "Issue framing" below).

## Summary

Consolidates the ER/PR/HR receptor parent-code expansion logic into a single shared module `trials/services/receptor_hierarchy.py`. Previously two copies of identical map data lived in different layers with different helpers:

- `trials/querysets/trial.py:1141-1182` — `_ER_PARENTS`/`_PR_PARENTS`/`_HR_PARENTS` + `_expand_receptor_codes` (list-append form, SQL-filter layer).
- `trials/services/patient_info/configs.py:21-33` — `_ER_PARENT_CODES`/`_PR_PARENT_CODES`/`_HR_PARENT_CODES` + `_receptor_uvalue` (CSV-string form, matcher's match-status display).

After this PR, both layers consume `_PARENT_CODES_BY_TYPE` from the shared module via `expand_values(values, kind)` and `expand_uvalue(code, kind)`. The two call shapes are preserved — only the underlying source is unified.

## Why this matters

The two copies were trivially desyncable. Editing one without the other would silently mismatch search results (queryset-level filter) and the per-trial "matched/not matched" badge (matcher uvalue path), which are presented side-by-side in the UI. The single source closes that drift surface.

## Issue framing — heads-up

Issue #45 originally asked to *remove* the parent-code expansion as "upstream has been simplified out". Verification showed the child codes are alive and load-bearing in EXACT:

- Child codes (`er_plus_with_hi_exp`/`_low_exp`, PR + HR equivalents) are emitted by the CTOMOP normalizer (`trials/management/commands/search_trials_for_patients.py:110-117`).
- Seeded as form options in `trials/services/loaders/load_bc_options.py:41-87`.
- Consumed to derive `hr_status` in `trials/services/patient_info/{patient_info_attributes.py:352-358,normalize.py:157-163}`.
- Asserted by explicit hierarchy tests at `tests/querysets/test_trial_querysets.py::test_estrogen_receptor_status_hierarchy` and `:test_progesterone_receptor_status_hierarchy`, plus the matcher's parallel tests at `tests/services/test_user_to_trial_attr_matcher.py:125+`.

Removing the expansion would have broken these. Reframed the work as DRY consolidation, which is a strict subset of the issue's "remove duplication" intent.

## Test plan

- [ ] CI: existing hierarchy regression tests pass (queryset + matcher).
- [ ] CI: new `tests/services/test_receptor_hierarchy.py` (parametrised over ER/PR/HR, covers passthrough, dedup, input non-mutation).
- [ ] CI: `python manage.py makemigrations --check` passes (no model touches).

## Self-review

Fresh-context Claude pass — verified map byte-equality, helper semantic byte-equality, no import cycle, no copy-paste typo across the three lambda call sites in `configs.py`, existing tests unchanged. Two nits applied inline (typed `expand_uvalue` signature + parametrised the uvalue test across all three kinds). Codex skipped (unreliable in this PR series).

🤖 Generated with [Claude Code](https://claude.com/claude-code)