### PR TITLE
feat: add Trial.purpose + by_trial_purpose() + ?trialPurpose= filter (#44)

### DIFF
--- a/tests/factories.py
+++ b/tests/factories.py
@@ -11,6 +11,7 @@ from trials.models import (
     TherapyComponent,
     Trial,
     TrialPreExistingCondition,
+    TrialPurpose,
     TrialType,
     TrialTypeDiseaseConnection,
 )
@@ -31,6 +32,15 @@ class TrialTypeFactory(factory.django.DjangoModelFactory):
 
     code = factory.Sequence(lambda n: f'trial_type_code_{n}')
     title = factory.Sequence(lambda n: f'Trial Type {n}')
+
+
+class TrialPurposeFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = TrialPurpose
+        django_get_or_create = ('code',)
+
+    code = factory.Sequence(lambda n: f'trial_purpose_code_{n}')
+    title = factory.Sequence(lambda n: f'Trial Purpose {n}')
 
 
 class TrialTypeDiseaseConnectionFactory(factory.django.DjangoModelFactory):

--- a/tests/querysets/test_trial_querysets.py
+++ b/tests/querysets/test_trial_querysets.py
@@ -735,6 +735,33 @@ class TestTrialQuerySet:
         assert list(Trial.objects.by_trial_type('nonexistent').order_by('id')) == []
 
     @pytest.mark.django_db
+    def test_by_trial_purpose(self):
+        treatment = TrialPurposeFactory(code='treatment', title='Treatment')
+        prevention = TrialPurposeFactory(code='prevention', title='Prevention')
+
+        t1 = TrialFactory(purpose=treatment)
+        t2 = TrialFactory(purpose=treatment)
+        t3 = TrialFactory(purpose=prevention)
+        t4 = TrialFactory(purpose=None)
+
+        # None / empty is a no-op (returns full set)
+        assert list(Trial.objects.by_trial_purpose(None).order_by('id')) == [t1, t2, t3, t4]
+        assert list(Trial.objects.by_trial_purpose('').order_by('id')) == [t1, t2, t3, t4]
+
+        # Code-string accepted, case-insensitive (mirrors by_trial_type via eligible_for_relation)
+        assert list(Trial.objects.by_trial_purpose('treatment').order_by('id')) == [t1, t2]
+        assert list(Trial.objects.by_trial_purpose('TREATMENT').order_by('id')) == [t1, t2]
+
+        assert list(Trial.objects.by_trial_purpose('prevention').order_by('id')) == [t3]
+
+        # TrialPurpose instance is also accepted (uses .code)
+        assert list(Trial.objects.by_trial_purpose(treatment).order_by('id')) == [t1, t2]
+        assert list(Trial.objects.by_trial_purpose(prevention).order_by('id')) == [t3]
+
+        # Unknown code → empty queryset
+        assert list(Trial.objects.by_trial_purpose('nonexistent').order_by('id')) == []
+
+    @pytest.mark.django_db
     def test_by_study_type(self):
         t1 = TrialFactory(study_type='INTERVENTIONAL')
         t2 = TrialFactory(study_type='INTERVENTIONAL')

--- a/tests/services/test_study_preferences.py
+++ b/tests/services/test_study_preferences.py
@@ -1,0 +1,31 @@
+"""Tests for StudyPreferences dataclass + query-param parsing."""
+from trials.services.study_preferences import (
+    StudyPreferences,
+    study_preferences_from_query_params,
+)
+
+
+class TestStudyPreferencesParsing:
+    def test_trial_purpose_param_populated(self):
+        """`?trialPurpose=treatment` should land on `study_info.trial_purpose` (#44)."""
+        prefs = study_preferences_from_query_params({'trialPurpose': 'treatment'})
+        assert prefs.trial_purpose == 'treatment'
+
+    def test_trial_purpose_param_absent_defaults_to_none(self):
+        prefs = study_preferences_from_query_params({})
+        assert prefs.trial_purpose is None
+
+    def test_trial_purpose_empty_string_normalized_to_none(self):
+        prefs = study_preferences_from_query_params({'trialPurpose': ''})
+        assert prefs.trial_purpose is None
+
+    def test_trial_purpose_independent_from_trial_type(self):
+        prefs = study_preferences_from_query_params({
+            'trialType': 'interventional',
+            'trialPurpose': 'treatment',
+        })
+        assert prefs.trial_type == 'interventional'
+        assert prefs.trial_purpose == 'treatment'
+
+    def test_dataclass_default(self):
+        assert StudyPreferences().trial_purpose is None

--- a/tests/test_trial_taxonomy.py
+++ b/tests/test_trial_taxonomy.py
@@ -134,6 +134,21 @@ class TestSeededRows:
         )
 
     @pytest.mark.django_db
+    def test_purpose_rows_match_taxonomy_categories(self):
+        """`#44`: TrialPurpose codes are seeded from `TRIAL_TAXONOMY.keys()`.
+        If a new top-level category is added to the taxonomy, the purpose
+        migration must seed a row for it. Reverse also: if a purpose row
+        is added by a future migration, the taxonomy must have a category.
+        """
+        from trials.models import TrialPurpose
+        purpose_codes = set(TrialPurpose.objects.values_list('code', flat=True))
+        taxonomy_categories = set(TRIAL_TAXONOMY.keys())
+        missing = taxonomy_categories - purpose_codes
+        extra = purpose_codes - taxonomy_categories
+        assert not missing, f'TrialPurpose rows missing for taxonomy categories: {sorted(missing)}'
+        assert not extra, f'TrialPurpose rows without a taxonomy category: {sorted(extra)}'
+
+    @pytest.mark.django_db
     def test_mcl_does_not_have_pi3k_inhibitors(self):
         """DB-level regression for issue #42's headline assertion."""
         mcl = Disease.objects.filter(code__iexact='MCL').first()

--- a/trials/migrations/0006_trial_purpose.py
+++ b/trials/migrations/0006_trial_purpose.py
@@ -1,0 +1,73 @@
+"""Add TrialPurpose lookup + Trial.purpose FK + seed (#44).
+
+Purpose codes mirror the top-level keys of
+`trials.trial_taxonomy.TRIAL_TAXONOMY` (treatment, prevention,
+diagnostic, screening, supportive_care, health_services_research,
+basic_science, device_feasibility, other). The seed step uses
+`update_or_create` keyed on `code` so re-running refreshes titles to
+the canonical values.
+"""
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+_PURPOSE_TITLES: dict[str, str] = {
+    'treatment': 'Treatment',
+    'prevention': 'Prevention',
+    'diagnostic': 'Diagnostic',
+    'screening': 'Screening',
+    'supportive_care': 'Supportive Care',
+    'health_services_research': 'Health Services Research',
+    'basic_science': 'Basic Science',
+    'device_feasibility': 'Device Feasibility',
+    'other': 'Other',
+}
+
+
+def _seed_purposes(apps, schema_editor):
+    TrialPurpose = apps.get_model('trials', 'TrialPurpose')
+    for code, title in _PURPOSE_TITLES.items():
+        TrialPurpose.objects.update_or_create(code=code, defaults={'title': title})
+
+
+def _noop_reverse(apps, schema_editor):
+    # TrialPurpose rows are referenced by Trial.purpose (PROTECT FK).
+    # Blanket-deleting them would raise ProtectedError on any DB with
+    # existing trials whose purpose is set; the field is nullable so a
+    # cleanup migration can null out references before purging.
+    pass
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('trials', '0005_seed_trial_taxonomy'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='TrialPurpose',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('created_at', models.DateTimeField(auto_now_add=True, db_index=True)),
+                ('updated_at', models.DateTimeField(auto_now=True, db_index=True)),
+                ('code', models.TextField(db_index=True, unique=True)),
+                ('title', models.TextField(db_index=True, unique=True)),
+            ],
+            options={
+                'abstract': False,
+            },
+        ),
+        migrations.AddField(
+            model_name='trial',
+            name='purpose',
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.PROTECT,
+                related_name='trials',
+                to='trials.trialpurpose',
+            ),
+        ),
+        migrations.RunPython(_seed_purposes, _noop_reverse),
+    ]

--- a/trials/models.py
+++ b/trials/models.py
@@ -291,6 +291,7 @@ class Trial(TimeStampMixin):
     phases = models.JSONField(blank=True, default=list)
     phase_code_min = models.IntegerField(blank=True, null=True)
     trial_type = models.ForeignKey("TrialType", models.PROTECT, blank=True, null=True)
+    purpose = models.ForeignKey("TrialPurpose", models.PROTECT, blank=True, null=True, related_name='trials')
 
     # PATIENT REQUIREMENTS
     brief_summary = models.TextField(blank=True, null=True)
@@ -933,6 +934,16 @@ class TrialType(OptionsListMixin):
         related_name='disease_trial_types'
     )
 
+    def __str__(self):
+        return self.title
+
+
+class TrialPurpose(OptionsListMixin):
+    """High-level purpose of a trial (treatment / prevention / diagnostic /
+    screening / supportive_care / health_services_research / basic_science /
+    device_feasibility / other). Codes mirror the top-level keys of
+    `trials.trial_taxonomy.TRIAL_TAXONOMY`.
+    """
     def __str__(self):
         return self.title
 

--- a/trials/querysets/trial.py
+++ b/trials/querysets/trial.py
@@ -277,6 +277,7 @@ class TrialQuerySet(models.QuerySet):
         query = query.by_study_id(study_info.study_id)
         query = query.by_register(study_info.register)
         query = query.by_trial_type(study_info.trial_type)
+        query = query.by_trial_purpose(study_info.trial_purpose)
         query = query.by_study_type(study_info.study_type)
         query = query.by_validated_only(study_info.validated_only)
         if patient_info and patient_info.disease is not None and patient_info.disease != '':
@@ -336,6 +337,17 @@ class TrialQuerySet(models.QuerySet):
             traces.append({
                 'attr': 'study_info.trial_type',
                 'val': study_info.trial_type,
+                'records': new_count,
+                'dropped': count-new_count
+            })
+            count = new_count
+
+        query = query.by_trial_purpose(study_info.trial_purpose)
+        if add_traces:
+            new_count = query.count()
+            traces.append({
+                'attr': 'study_info.trial_purpose',
+                'val': study_info.trial_purpose,
                 'records': new_count,
                 'dropped': count-new_count
             })
@@ -495,6 +507,15 @@ class TrialQuerySet(models.QuerySet):
 
     def by_trial_type(self, trial_type):
         return self.eligible_for_relation('trial_type__code', trial_type)
+
+    def by_trial_purpose(self, trial_purpose):
+        """Filter by Trial.purpose. Accepts a code string or a TrialPurpose
+        instance (uses its `.code`); blank/None is a no-op.
+        """
+        if trial_purpose is None or trial_purpose == '':
+            return self
+        code = getattr(trial_purpose, 'code', trial_purpose)
+        return self.eligible_for_relation('purpose__code', code)
 
     def by_study_type(self, study_type):
         if not study_type or str(study_type).upper() in ('', 'ALL'):

--- a/trials/services/study_preferences.py
+++ b/trials/services/study_preferences.py
@@ -23,6 +23,7 @@ class StudyPreferences:
 
     # Trial classification filters
     trial_type: Optional[str] = None
+    trial_purpose: Optional[str] = None
     study_type: Optional[str] = None
 
     # Recruitment filter
@@ -76,6 +77,7 @@ def study_preferences_from_query_params(params) -> StudyPreferences:
         register=_str('register'),
         study_id=_str('studyId'),
         trial_type=_str('trialType'),
+        trial_purpose=_str('trialPurpose'),
         study_type=_str('studyType'),
         recruitment_status=_str('recruitmentStatus'),
         country=_str('country'),

--- a/trials/services/value_options.py
+++ b/trials/services/value_options.py
@@ -141,6 +141,16 @@ class ValueOptions:
             **{x.code: x.title for x in items}
         }
 
+    @cached_property
+    def trial_purposes(self):
+        from trials.models import TrialPurpose
+
+        items = TrialPurpose.objects.order_by('title')
+        return {
+            '': 'ALL',
+            **{x.code: x.title for x in items}
+        }
+
     @staticmethod
     def trial_types_by_disease_code(disease_code: str):
         """Return trial types filtered by disease code."""
@@ -842,6 +852,9 @@ class ValueOptions:
             },
             'trialType': {
                 'options': self.to_value_and_label(self.trial_types)
+            },
+            'trialPurpose': {
+                'options': self.to_value_and_label(self.trial_purposes)
             },
             'tumorGrade': {
                 'options': self.to_value_and_label(self.tumor_grades)


### PR DESCRIPTION
Closes #44.

## Summary

Adds a high-level **purpose** classification to trials so the catalog can be filtered by intent independent of trial type. Purpose codes mirror the 9 top-level categories of `trials.trial_taxonomy.TRIAL_TAXONOMY` (treatment, prevention, diagnostic, screening, supportive_care, health_services_research, basic_science, device_feasibility, other).

## Changes

**Model + migration:**
- `trials.models.TrialPurpose` — new lookup table (`OptionsListMixin`).
- `Trial.purpose` — nullable PROTECT FK with `related_name='trials'`.
- Migration `0006_trial_purpose.py` — creates the model + AddField for `Trial.purpose` + RunPython seed of 9 rows whose codes match `TRIAL_TAXONOMY.keys()` exactly. `update_or_create(code=…)` so titles refresh on rerun.

**Queryset + service:**
- `TrialQuerySet.by_trial_purpose(value)` — accepts a code string or a `TrialPurpose` instance (uses `.code`); blank/None is a no-op. Mirrors `by_trial_type` via `eligible_for_relation('purpose__code', …)` (case-insensitive).
- Wired into both branches of `filtered_trials` (simple + trace-emitting).
- `StudyPreferences.trial_purpose` + `trialPurpose` query-param parsing.
- `ValueOptions.trial_purposes` + `'trialPurpose'` form-settings entry so the frontend dropdown is populated. (Caught in self-review — the original PR plan had only the filter without the form-options endpoint, which would have left a dead param until follow-up.)

**Tests:**
- `tests/querysets/test_trial_querysets.py::test_by_trial_purpose` — None/empty no-op, case-insensitive code match, `TrialPurpose` instance pass-through, unknown code returns empty.
- `tests/services/test_study_preferences.py` — param parsing.
- `tests/test_trial_taxonomy.py::test_purpose_rows_match_taxonomy_categories` — bidirectional invariant: every taxonomy top-level category has a `TrialPurpose` row and vice versa. Locks the seed against drift in either direction.

## Notes

- **Index parity (CLAUDE.md rule):** No explicit `AddIndex` op in the migration. Django auto-indexes FKs via the field definition, so `Meta.indexes` parity is irrelevant here — mirrors how `Trial.trial_type` (line 293) is handled.
- **Backward compat:** `Trial.purpose` is nullable, no backfill needed. `by_trial_purpose(None/'')` no-ops. `StudyPreferences.trial_purpose=None` by default. Clients that never set `?trialPurpose=` see no change.
- **Migration hand-written:** local Anaconda env's `aiodns/pycares` is broken (`AttributeError: module 'pycares' has no attribute 'ares_query_a_result'`), so `makemigrations` can't run locally. Field shapes mirror Django's output for `TrialType` in `0001_initial.py:451-463` byte-for-byte. CI will run `makemigrations --check` to confirm no drift.

## Self-review

Fresh-context Claude pass — flagged the missing `value_options.py` entry (applied inline), verified migration field shapes vs `0001_initial`, verified no `related_name='trials'` collision elsewhere, confirmed wiring symmetry across both `filtered_trials` branches. Codex skipped (unreliable in this PR series).

## Test plan

- [ ] CI: `python manage.py makemigrations --check` passes (no model drift from the hand-written migration).
- [ ] CI: `test_by_trial_purpose`, `test_study_preferences.*`, `test_purpose_rows_match_taxonomy_categories` all pass.
- [ ] CI: existing queryset / view tests still pass (no regression in `filtered_trials` wiring).

🤖 Generated with [Claude Code](https://claude.com/claude-code)