### PR TITLE
refactor: replace deprecated .extra() in add_potential_attrs_count (#97)

### DIFF
--- a/tests/querysets/test_potential_attrs_count.py
+++ b/tests/querysets/test_potential_attrs_count.py
@@ -1,0 +1,82 @@
+"""Tests for TrialQuerySet.add_potential_attrs_count / with_potential_attrs_count
+after the .extra() → annotate(RawSQL) port (#97).
+
+Pre-port the method used `.extra(select={...})` for the three annotations
+and `.extra(where=[...])` for the `eligible`/`potential` filters. Post-port
+it uses `annotate(RawSQL(...))` and `filter(potential_attrs_count={0|__gt:0})`
+referencing the annotation. SQL emitted is functionally identical; this
+test locks the surface so a future regression in the annotation names or
+filter semantics shows up at unit level rather than via downstream
+serializer flakiness.
+"""
+import pytest
+
+from trials.models import Trial
+from trials.services.patient_info.patient_info import PatientInfo
+from tests.factories import TrialFactory
+
+
+class TestAddPotentialAttrsCount:
+    @pytest.mark.django_db
+    def test_annotations_attached_with_empty_patient_info(self):
+        """The patient_info=None branch passes attributes=[] through
+        `add_potential_attrs_count`, so the annotations must still attach
+        even when the CASE-WHEN list is degenerate. Each annotated value
+        comes from `num_nonnulls(NULL) = 0`.
+        """
+        TrialFactory()
+        qs = Trial.objects.all().with_potential_attrs_count(patient_info=None)
+        trial = qs.first()
+        assert hasattr(trial, 'potential_attrs_count')
+        assert hasattr(trial, 'match_score')
+        assert hasattr(trial, 'potential_profit_avg')
+        # `num_nonnulls(NULL)` is 0; integer division 0*100 / 0 → SQL error
+        # in some engines, but Postgres returns NULL when divisor is 0
+        # via the `num_nonnulls` path. Either way the value should be
+        # int-or-None — not crash.
+        assert trial.potential_attrs_count in (0, None)
+
+    @pytest.mark.django_db
+    def test_search_type_eligible_filters_to_zero(self):
+        """search_type='eligible' must keep only trials where
+        potential_attrs_count == 0. With patient_info=None the candidate
+        list is empty, so every trial trivially scores 0 → all pass.
+        """
+        TrialFactory()
+        TrialFactory()
+        qs = Trial.objects.all().with_potential_attrs_count(
+            patient_info=None, search_type='eligible'
+        )
+        assert qs.count() == 2
+
+    @pytest.mark.django_db
+    def test_search_type_potential_filters_to_positive(self):
+        """search_type='potential' must keep only trials where
+        potential_attrs_count > 0. With patient_info=None every trial
+        scores 0, so none pass — this asserts the filter is wired the
+        right direction (no off-by-one or inverted comparison).
+        """
+        TrialFactory()
+        TrialFactory()
+        qs = Trial.objects.all().with_potential_attrs_count(
+            patient_info=None, search_type='potential'
+        )
+        assert qs.count() == 0
+
+    @pytest.mark.django_db
+    def test_match_score_accessible_with_real_patient_info(self):
+        """End-to-end with a real PatientInfo: the matcher pipeline produces
+        a non-empty candidate list, so the annotations are emitted from
+        non-trivial SQL. Just smoke-test that the annotation lookup works.
+        """
+        TrialFactory(disease='multiple myeloma')
+        pi = PatientInfo(disease='multiple myeloma')
+        qs = Trial.objects.all().with_potential_attrs_count(patient_info=pi)
+        trial = qs.first()
+        # match_score is a non-negative integer (0..100) computed by
+        # `num_nonnulls(filled) * 100 / num_nonnulls(all)`. The actual
+        # value depends on the matcher's bookkeeping for this patient;
+        # we only care that the attribute is reachable and well-typed.
+        assert hasattr(trial, 'match_score')
+        ms = trial.match_score
+        assert ms is None or isinstance(ms, int)

--- a/trials/querysets/trial.py
+++ b/trials/querysets/trial.py
@@ -10,7 +10,7 @@ from django.db import models
 from django.db.models import Case, Count, Q, When, Exists, OuterRef, Value, QuerySet, Min, Subquery
 from django.db.models.functions import Coalesce, Least
 from django.contrib.gis.geos import Point
-from django.db.models import F, FloatField, ExpressionWrapper, IntegerField
+from django.db.models import BigIntegerField, F, FloatField, ExpressionWrapper, IntegerField, RawSQL
 
 from django.utils import timezone
 
@@ -205,6 +205,18 @@ class TrialQuerySet(models.QuerySet):
     # UserTrial removed — no favorites/participation tracking in standalone app
 
     def add_potential_attrs_count(self, attributes, search_type=None, counts=None, filled_attributes=None):
+        """Annotate trials with potential_attrs_count, match_score, and
+        potential_profit_avg from `num_nonnulls()` of the candidate CASE
+        expressions.
+
+        The fragments in `attributes` / `filled_attributes` come from
+        `UserToTrialAttrsMapper.potential_attrs_to_check` — values are
+        SQL CASE-WHEN strings built from the static
+        `USER_TO_TRIAL_ATTRS_MAPPING` (no user-supplied SQL). Migrating
+        from the deprecated `.extra(select=…)/extra(where=…)` to
+        `annotate(RawSQL(…))` + filter-on-annotation (#97) — same SQL
+        emitted, same return shape.
+        """
         if filled_attributes is None:
             filled_attributes = []
 
@@ -212,20 +224,39 @@ class TrialQuerySet(models.QuerySet):
         filled_attrs = ','.join(filled_attributes + ['NULL'])
         all_attrs = ','.join(attributes + filled_attributes + ['NULL'])
 
-        query = self.extra(select={'potential_attrs_count': f'num_nonnulls({attrs})'})
-
-        # (filled / filled + potential) * 100
-        match_score_sql = f'num_nonnulls({filled_attrs}) * 100 / num_nonnulls({all_attrs})'
-        query = query.extra(select={'match_score': match_score_sql})
+        # (filled / filled + potential) * 100 — integer division, capped at 100.
+        # NULLIF guards against div-by-zero on the `patient_info=None` path
+        # where `all_attrs` collapses to just `'NULL'` and num_nonnulls = 0
+        # (latent crash in the pre-port `.extra()` form too — closed here
+        # since the new test surface exercises that path).
+        match_score_sql = (
+            f'num_nonnulls({filled_attrs}) * 100 / '
+            f'NULLIF(num_nonnulls({all_attrs}), 0)'
+        )
 
         sql_conditions = UserToTrialAttrsMapper().potential_attrs_to_check(patient_info=None, counts=counts)
-        sql_conditions = ' + '.join([*sql_conditions.values(), '0'])
-        query = query.extra(select={'potential_profit_avg': f'({sql_conditions}) / NULLIF(num_nonnulls({attrs}), 0)'})
+        sql_conditions_sum = ' + '.join([*sql_conditions.values(), '0'])
+
+        # BigIntegerField on potential_profit_avg: the numerator sums
+        # arbitrary counts across the catalog and can exceed 2^31 in the
+        # large-counts case (same rationale as #25 / PR #98).
+        query = self.annotate(
+            potential_attrs_count=RawSQL(
+                f'num_nonnulls({attrs})', [], output_field=IntegerField()
+            ),
+            match_score=RawSQL(
+                match_score_sql, [], output_field=IntegerField()
+            ),
+            potential_profit_avg=RawSQL(
+                f'({sql_conditions_sum}) / NULLIF(num_nonnulls({attrs}), 0)',
+                [], output_field=BigIntegerField(),
+            ),
+        )
 
         if search_type == 'eligible':
-            query = query.extra(where=[f'num_nonnulls({attrs}) = 0'])
+            query = query.filter(potential_attrs_count=0)
         elif search_type == 'potential':
-            query = query.extra(where=[f'num_nonnulls({attrs}) > 0'])
+            query = query.filter(potential_attrs_count__gt=0)
         return query
 
     def filtered_trials(self, search_options, study_info, patient_info, add_traces=False, search_type=None):

--- a/trials/querysets/trial.py
+++ b/trials/querysets/trial.py
@@ -8,9 +8,10 @@ from django.contrib.postgres.search import SearchVector, SearchQuery
 
 from django.db import models
 from django.db.models import Case, Count, Q, When, Exists, OuterRef, Value, QuerySet, Min, Subquery
+from django.db.models.expressions import RawSQL
 from django.db.models.functions import Coalesce, Least
 from django.contrib.gis.geos import Point
-from django.db.models import BigIntegerField, F, FloatField, ExpressionWrapper, IntegerField, RawSQL
+from django.db.models import BigIntegerField, F, FloatField, ExpressionWrapper, IntegerField
 
 from django.utils import timezone
 


### PR DESCRIPTION
Closes #97 — the follow-up filed by PR #98 for the remaining `.extra()` callsites.

## Summary

Migrates 3 select-extras + 2 where-extras in `TrialQuerySet.add_potential_attrs_count` to native ORM (`annotate(RawSQL(...))` + `filter` on the annotation). Same SQL reaches Postgres; only the Django-side surface changes.

## Annotation output_field choices

- `potential_attrs_count` — `IntegerField`. Value is `num_nonnulls(CASE..., NULL)` over a fixed-length list ≤ ~100. Fits.
- `match_score` — `IntegerField`. Integer-divided percentage in 0..100. Fits.
- `potential_profit_avg` — `BigIntegerField`. Numerator sums arbitrary `count` values from the mapper; across the catalog the sum can exceed 2^31 in the large-counts case — same rationale as #25 / PR #98.

## Latent crash closed inline

Self-review caught a latent `division_by_zero` on the `patient_info=None` search path: the SQL was `num_nonnulls(NULL) * 100 / num_nonnulls(NULL)` = `0 / 0`, which raises in Postgres. The same bug exists in the pre-port `.extra()` form but no existing test exercises it, so it sat latent in main. Wrapped the divisor with `NULLIF(num_nonnulls(all_attrs), 0)`. NULL flows correctly through the downstream consumers:

- `F('match_score').desc(nulls_last=True)` in `trials/api/trials_views.py:141` — handles NULL.
- `getattr(instance, 'match_score', None)` in `trials/api/trials_serializers.py:54,60,181` — already returns None on missing.

## Security

The `RawSQL` strings still come from `UserToTrialAttrsMapper.potential_attrs_to_check`, which is built from the static `USER_TO_TRIAL_ATTRS_MAPPING` config (no user input on the path). Injection surface is identical to the original `.extra(select=…)` — zero in practice.

## Test plan

- [ ] CI: new `tests/querysets/test_potential_attrs_count.py` (4 cases — empty-list path, eligible/potential filter direction, real-patient smoke).
- [ ] CI: existing matcher / queryset / serializer tests pass (no regression on `match_score` sort or `matchScore` API field).
- [ ] CI: `python manage.py makemigrations --check` still passes.

## Self-review

Fresh-context Claude pass — verified emitted-SQL equivalence (`RawSQL.as_sql` returns `(<sql>)`, filter on annotation re-emits expression inline → same WHERE clause), verified `F('match_score').desc(nulls_last=True)` resolves through the annotation registry, verified `output_field` sizing. The reviewer's HIGH finding (latent div-by-zero) was applied inline as `NULLIF`. Codex skipped (unreliable in this PR series).

## What this completes

Combined with PR #98 (#25), `trials/services/blank_attribute_records_count.py` and `trials/querysets/trial.py` now have zero `.extra()` calls. The whole repo's only remaining mention is in docstring text. The deprecation deadline (Django will remove `.extra()` in a future release) no longer threatens these hot paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)