### PR TITLE
fix: disease-aware patient-facing option lists (#63, CB #4330 port)

### DIFF
--- a/tests/services/test_value_options_disease_aware_lists.py
+++ b/tests/services/test_value_options_disease_aware_lists.py
@@ -1,0 +1,131 @@
+"""Tests for the per-disease option-list helpers (#63 / CB #4330).
+
+Extends the existing `_by_disease_code` pattern (trial_types, therapy_outcomes)
+to eight clinically disease-specific lists:
+
+- FLIPI + GELF                 → FL only
+- Binet + Richter + diseaseActivity → CLL only
+- tumorBurden                  → FL, CLL, MCL (GELF / iwCLL / bulky-disease)
+- cytogenicMarkers + molecularMarkers → all hematological (MM/FL/CLL/MCL)
+
+Off-disease patients receive an empty option set (or `{'': '...'}` if the
+source list has the '' Unknown sentinel — preserved so the form still
+renders a valid blank).
+"""
+import pytest
+
+from trials.services.value_options import ValueOptions
+
+
+class TestDiseaseAwareOptionLists:
+    @pytest.mark.django_db
+    def test_flipi_scores_only_for_fl(self):
+        v = ValueOptions()
+        full = set(v.flipi_scores.keys())
+        assert full  # sanity
+
+        assert set(v.flipi_scores_by_disease_code('FL').keys()) == full
+        for off_disease in ('MM', 'BC', 'CLL', 'MCL'):
+            # flipi_scores has '' = Unknown sentinel; off-disease preserves it.
+            keys = set(v.flipi_scores_by_disease_code(off_disease).keys())
+            assert keys == ({''} if '' in full else set()), off_disease
+
+    @pytest.mark.django_db
+    def test_gelf_criteria_only_for_fl(self):
+        v = ValueOptions()
+        full = set(v.gelf_criteria_statuses.keys())
+        assert full
+
+        assert set(v.gelf_criteria_statuses_by_disease_code('FL').keys()) == full
+        for off_disease in ('MM', 'BC', 'CLL', 'MCL'):
+            keys = set(v.gelf_criteria_statuses_by_disease_code(off_disease).keys())
+            assert keys == ({''} if '' in full else set()), off_disease
+
+    @pytest.mark.django_db
+    def test_cytogenic_markers_for_hematological_malignancies(self):
+        # MM (del(17p13), t(4;14), 1q21amp...), CLL (del(17p), del(11q),
+        # trisomy 12), FL (BCL2/BCL6), MCL (t(11;14)). BC uses ER/PR/HER2.
+        v = ValueOptions()
+        full = set(v.cytogenic_markers.keys())
+        assert full
+
+        for on_disease in ('MM', 'FL', 'CLL', 'MCL'):
+            assert set(v.cytogenic_markers_by_disease_code(on_disease).keys()) == full, on_disease
+        bc_keys = set(v.cytogenic_markers_by_disease_code('BC').keys())
+        assert bc_keys == ({''} if '' in full else set())
+
+    @pytest.mark.django_db
+    def test_molecular_markers_for_hematological_malignancies(self):
+        # MM (TP53, KRAS/NRAS/BRAF), FL (BCL2/EZH2/KMT2D/CREBBP), CLL
+        # (TP53/NOTCH1/SF3B1/ATM), MCL (TP53/NOTCH1/CCND1).
+        v = ValueOptions()
+        full = set(v.molecular_markers.keys())
+        assert full
+
+        for on_disease in ('MM', 'FL', 'CLL', 'MCL'):
+            assert set(v.molecular_markers_by_disease_code(on_disease).keys()) == full, on_disease
+        bc_keys = set(v.molecular_markers_by_disease_code('BC').keys())
+        assert bc_keys == ({''} if '' in full else set())
+
+    @pytest.mark.django_db
+    def test_binet_stages_only_for_cll(self):
+        v = ValueOptions()
+        full = set(v.binet_stages.keys())
+        assert full
+
+        assert set(v.binet_stages_by_disease_code('CLL').keys()) == full
+        for off_disease in ('MM', 'FL', 'BC', 'MCL'):
+            keys = set(v.binet_stages_by_disease_code(off_disease).keys())
+            assert keys == ({''} if '' in full else set()), off_disease
+
+    @pytest.mark.django_db
+    def test_richter_transformations_only_for_cll(self):
+        v = ValueOptions()
+        full = set(v.richter_transformations.keys())
+        assert full
+
+        assert set(v.richter_transformations_by_disease_code('CLL').keys()) == full
+        for off_disease in ('MM', 'FL', 'BC', 'MCL'):
+            keys = set(v.richter_transformations_by_disease_code(off_disease).keys())
+            assert keys == ({''} if '' in full else set()), off_disease
+
+    @pytest.mark.django_db
+    def test_tumor_burdens_for_lymphomas_and_cll(self):
+        # GELF criteria → FL; iwCLL burden → CLL; bulky-disease criteria → MCL.
+        v = ValueOptions()
+        full = set(v.tumor_burdens.keys())
+        assert full
+
+        for on_disease in ('FL', 'CLL', 'MCL'):
+            assert set(v.tumor_burdens_by_disease_code(on_disease).keys()) == full, on_disease
+        for off_disease in ('MM', 'BC'):
+            keys = set(v.tumor_burdens_by_disease_code(off_disease).keys())
+            assert keys == ({''} if '' in full else set()), off_disease
+
+    @pytest.mark.django_db
+    def test_disease_activities_only_for_cll(self):
+        v = ValueOptions()
+        full = set(v.disease_activities.keys())
+        assert full
+
+        assert set(v.disease_activities_by_disease_code('CLL').keys()) == full
+        for off_disease in ('MM', 'FL', 'BC', 'MCL'):
+            keys = set(v.disease_activities_by_disease_code(off_disease).keys())
+            assert keys == ({''} if '' in full else set()), off_disease
+
+    @pytest.mark.django_db
+    def test_disease_code_is_case_insensitive(self):
+        v = ValueOptions()
+        assert v.flipi_scores_by_disease_code('fl') == v.flipi_scores_by_disease_code('FL')
+        assert v.cytogenic_markers_by_disease_code('mm') == v.cytogenic_markers_by_disease_code('MM')
+
+    @pytest.mark.django_db
+    def test_all_options_exposes_per_disease_keys(self):
+        all_opts = ValueOptions().all_options()
+        for base in ('flipiScore', 'cytogenicMarkers', 'molecularMarkers',
+                     'gelfCriteriaStatus', 'binetStages', 'richterTransformations',
+                     'tumorBurdens', 'diseaseActivities'):
+            for suffix in ('Mm', 'Fl', 'Bc', 'Cll', 'Mcl'):
+                key = f'{base}{suffix}'
+                assert key in all_opts, key
+                assert 'options' in all_opts[key], key

--- a/tests/views/test_form_settings_disease_aware_lists.py
+++ b/tests/views/test_form_settings_disease_aware_lists.py
@@ -1,0 +1,120 @@
+"""Tests for /form-settings/ disease-aware overrides on the 8 lists (#63).
+
+The view applies per-disease subsets for FLIPI / GELF / cytogenic /
+molecular / Binet / Richter / tumorBurden / diseaseActivity when
+`?disease=` is set. Without these overrides, a BC patient hitting
+/form-settings/?disease=BC would still see the union FLIPI / GELF /
+Binet / Richter / tumorBurden / diseaseActivity dropdowns even though
+those are clinically meaningless for BC.
+"""
+import pytest
+from unittest.mock import MagicMock
+
+from trials.api.trials_views import FormSettingsViewSet
+from trials.services.value_options import ValueOptions
+
+
+def _form_settings_response(disease_param):
+    """Drive FormSettingsViewSet.list with a query-param request, bypass auth."""
+    view = FormSettingsViewSet()
+    mock_request = MagicMock()
+    mock_request.query_params = {'disease': disease_param} if disease_param else {}
+    return view.list(mock_request).data
+
+
+def _values(data, key):
+    return {opt['value'] for opt in data[key]['options']}
+
+
+@pytest.mark.django_db
+class TestFormSettingsDiseaseAwareLists:
+    def test_no_disease_param_returns_union_for_all_lists(self):
+        data = _form_settings_response('')
+        v = ValueOptions()
+        # Union lists pass through unchanged when no disease is specified.
+        assert _values(data, 'flipiScore') == set(v.flipi_scores.keys())
+        assert _values(data, 'binetStages') == set(v.binet_stages.keys())
+        assert _values(data, 'tumorBurdens') == set(v.tumor_burdens.keys())
+
+    def test_bc_drops_flipi_gelf_binet_richter_activity(self):
+        data = _form_settings_response('BC')
+        v = ValueOptions()
+        # BC patients see only the '' sentinel for each list (or nothing).
+        for key, source in [
+            ('flipiScore', v.flipi_scores),
+            ('gelfCriteriaStatus', v.gelf_criteria_statuses),
+            ('binetStages', v.binet_stages),
+            ('richterTransformations', v.richter_transformations),
+            ('tumorBurdens', v.tumor_burdens),
+            ('diseaseActivities', v.disease_activities),
+        ]:
+            actual = _values(data, key)
+            expected = {''} if '' in source else set()
+            assert actual == expected, key
+        # Cytogenic / molecular are EMPTY for BC (BC uses ER/PR/HER2 + HRD).
+        for key, source in [
+            ('cytogenicMarkers', v.cytogenic_markers),
+            ('molecularMarkers', v.molecular_markers),
+        ]:
+            actual = _values(data, key)
+            expected = {''} if '' in source else set()
+            assert actual == expected, key
+
+    def test_fl_keeps_flipi_gelf_tumorburden(self):
+        data = _form_settings_response('FL')
+        v = ValueOptions()
+        assert _values(data, 'flipiScore') == set(v.flipi_scores.keys())
+        assert _values(data, 'gelfCriteriaStatus') == set(v.gelf_criteria_statuses.keys())
+        assert _values(data, 'tumorBurdens') == set(v.tumor_burdens.keys())
+        # FL is a hematological malignancy → cytogenic / molecular full.
+        assert _values(data, 'cytogenicMarkers') == set(v.cytogenic_markers.keys())
+        assert _values(data, 'molecularMarkers') == set(v.molecular_markers.keys())
+        # FL drops CLL-specific Binet / Richter / diseaseActivity.
+        assert _values(data, 'binetStages') == ({''} if '' in v.binet_stages else set())
+
+    def test_cll_keeps_binet_richter_tumorburden_activity(self):
+        data = _form_settings_response('CLL')
+        v = ValueOptions()
+        assert _values(data, 'binetStages') == set(v.binet_stages.keys())
+        assert _values(data, 'richterTransformations') == set(v.richter_transformations.keys())
+        assert _values(data, 'tumorBurdens') == set(v.tumor_burdens.keys())
+        assert _values(data, 'diseaseActivities') == set(v.disease_activities.keys())
+        assert _values(data, 'cytogenicMarkers') == set(v.cytogenic_markers.keys())
+        assert _values(data, 'molecularMarkers') == set(v.molecular_markers.keys())
+        # CLL drops FL-specific FLIPI / GELF.
+        assert _values(data, 'flipiScore') == ({''} if '' in v.flipi_scores else set())
+
+    def test_mcl_keeps_tumorburden_cytogenic_molecular(self):
+        data = _form_settings_response('MCL')
+        v = ValueOptions()
+        assert _values(data, 'tumorBurdens') == set(v.tumor_burdens.keys())
+        assert _values(data, 'cytogenicMarkers') == set(v.cytogenic_markers.keys())
+        assert _values(data, 'molecularMarkers') == set(v.molecular_markers.keys())
+        # MCL drops CLL-specific Binet / Richter / diseaseActivity.
+        assert _values(data, 'binetStages') == ({''} if '' in v.binet_stages else set())
+
+    def test_mm_keeps_cytogenic_molecular(self):
+        data = _form_settings_response('MM')
+        v = ValueOptions()
+        assert _values(data, 'cytogenicMarkers') == set(v.cytogenic_markers.keys())
+        assert _values(data, 'molecularMarkers') == set(v.molecular_markers.keys())
+        # MM drops FL-specific FLIPI / GELF + CLL-specific lists.
+        assert _values(data, 'flipiScore') == ({''} if '' in v.flipi_scores else set())
+        assert _values(data, 'binetStages') == ({''} if '' in v.binet_stages else set())
+
+    def test_trial_attributes_still_reads_union(self):
+        """Trial-side `*Required`/`*Excluded` aliases must keep showing the
+        full union so trials can require any marker independent of the
+        current patient's disease. `TrialAttributes.__init__` builds its
+        own fresh `ValueOptions().all_options()` (see trial_attributes.py:39),
+        so the view-level mutations above don't leak into trial detail
+        rendering. Confirm by asserting the union keys still resolve to
+        the full set when read directly off a fresh ValueOptions instance.
+        """
+        v = ValueOptions()
+        opts = v.all_options()
+        # Source-of-truth: the bare union keys are still present in
+        # all_options() and still expose the full union — only the
+        # view's per-request `out` dict is mutated for `?disease=`.
+        assert {o['value'] for o in opts['cytogenicMarkers']['options']} == set(v.cytogenic_markers.keys())
+        assert {o['value'] for o in opts['binetStages']['options']} == set(v.binet_stages.keys())

--- a/trials/api/trials_views.py
+++ b/trials/api/trials_views.py
@@ -253,15 +253,37 @@ class FormSettingsViewSet(viewsets.ViewSet):
     def list(self, request, *args, **kwargs):
         disease_param = request.query_params.get('disease', '')
         disease_code = self._normalize_disease_code(disease_param)
-        out = ValueOptions().all_options()
+        value_options = ValueOptions()
+        out = value_options.all_options()
         if disease_code:
             trial_types = ValueOptions.trial_types_by_disease_code(disease_code)
             out['trialType'] = {'options': ValueOptions.to_value_and_label(trial_types)}
             # Disease-aware treatment outcomes (#60 / #70 / CB #4137).
             # Without this override callers reading the union `therapyOutcome`
             # would still see IMWG-specific sCR / VGPR / MRD for BC patients.
-            outcomes = ValueOptions().therapy_outcomes_by_disease_code(disease_code)
+            outcomes = value_options.therapy_outcomes_by_disease_code(disease_code)
             out['therapyOutcome'] = {'options': ValueOptions.to_value_and_label(outcomes)}
+            # Per #63 / CB #4330: eight clinically disease-specific lists
+            # were historically exposed as a single union to every patient.
+            # Override each patient-facing union key with its per-disease
+            # subset — key names match what `all_options()` already exposes
+            # to the frontend (4 singular + 4 plural — preserved as-is for
+            # back-compat). Trial-side `*Required` / `*Excluded` aliases
+            # stay at the union (set by `trial_attributes.py` from a fresh
+            # `ValueOptions().all_options()`), so trials can still require
+            # any marker independent of the current patient's disease.
+            disease_aware_overrides = {
+                'flipiScore': value_options.flipi_scores_by_disease_code,
+                'cytogenicMarkers': value_options.cytogenic_markers_by_disease_code,
+                'molecularMarkers': value_options.molecular_markers_by_disease_code,
+                'gelfCriteriaStatus': value_options.gelf_criteria_statuses_by_disease_code,
+                'binetStages': value_options.binet_stages_by_disease_code,
+                'richterTransformations': value_options.richter_transformations_by_disease_code,
+                'tumorBurdens': value_options.tumor_burdens_by_disease_code,
+                'diseaseActivities': value_options.disease_activities_by_disease_code,
+            }
+            for key, getter in disease_aware_overrides.items():
+                out[key] = {'options': ValueOptions.to_value_and_label(getter(disease_code))}
         return Response(out)
 
     def _normalize_disease_code(self, disease_param: str) -> str:

--- a/trials/services/value_options.py
+++ b/trials/services/value_options.py
@@ -13,7 +13,13 @@ def ordered_dict(data):
 
 class ValueOptions:
     def cache_key(self):
-        return 'ValueOptions.all_options'
+        # v2: bumped on #63 — `all_options()` gained 40 new per-disease
+        # keys (flipiScore{Mm|Fl|Bc|Cll|Mcl}, cytogenicMarkers{…}, …).
+        # Without the bump, a deploy hitting a populated Redis cache
+        # would serve the pre-#63 shape (missing those 40 keys), letting
+        # the cached blob drift from fresh `all_options()` output until
+        # the 1h TTL expires.
+        return 'ValueOptions.all_options.v2'
 
     @staticmethod
     def to_value_and_label(data):
@@ -424,6 +430,63 @@ class ValueOptions:
             'MCL': recist_outcomes,
         }
         return per_disease.get((disease_code or '').upper(), self.therapy_outcomes)
+
+    # ── Per-disease option-list scoping (#63 / CB #4330) ────────────────
+    # Eight clinically disease-specific lists were historically exposed as
+    # a single union to every patient. Each `*_by_disease_code` helper
+    # returns the disease-applicable subset (the full list when the
+    # patient's disease is in the applicable set, an empty/blank-only
+    # dict otherwise). The "" / "Unknown" sentinel is preserved on the
+    # off-disease path when the source list has one, so the form still
+    # renders a valid blank option.
+    #
+    # Clinical scoping (verified during CB independent review, polish
+    # commit dbcc1a7f): cytogenic and molecular markers apply across all
+    # hematological malignancies — not just MM. Tumor burden applies to
+    # FL via GELF criteria + CLL via iwCLL burden + MCL via bulky-disease.
+    # BC stays correctly excluded (uses ER/PR/HER2 + HRD instead).
+
+    _FLIPI_DISEASES = {'FL'}
+    _CYTOGENIC_DISEASES = {'MM', 'FL', 'CLL', 'MCL'}
+    _MOLECULAR_DISEASES = {'MM', 'FL', 'CLL', 'MCL'}
+    _GELF_DISEASES = {'FL'}
+    _BINET_DISEASES = {'CLL'}
+    _RICHTER_DISEASES = {'CLL'}
+    _TUMOR_BURDEN_DISEASES = {'FL', 'CLL', 'MCL'}
+    _DISEASE_ACTIVITY_DISEASES = {'CLL'}
+
+    @staticmethod
+    def _scoped_options(full_options, disease_code, applicable_diseases):
+        """Return `full_options` when disease matches; an empty/blank-only
+        dict otherwise. Preserves the "" → "Unknown" sentinel if present
+        so the form still renders a valid blank option."""
+        if (disease_code or '').upper() in applicable_diseases:
+            return full_options
+        return {'': full_options['']} if '' in full_options else {}
+
+    def flipi_scores_by_disease_code(self, disease_code):
+        return self._scoped_options(self.flipi_scores, disease_code, self._FLIPI_DISEASES)
+
+    def cytogenic_markers_by_disease_code(self, disease_code):
+        return self._scoped_options(self.cytogenic_markers, disease_code, self._CYTOGENIC_DISEASES)
+
+    def molecular_markers_by_disease_code(self, disease_code):
+        return self._scoped_options(self.molecular_markers, disease_code, self._MOLECULAR_DISEASES)
+
+    def gelf_criteria_statuses_by_disease_code(self, disease_code):
+        return self._scoped_options(self.gelf_criteria_statuses, disease_code, self._GELF_DISEASES)
+
+    def binet_stages_by_disease_code(self, disease_code):
+        return self._scoped_options(self.binet_stages, disease_code, self._BINET_DISEASES)
+
+    def richter_transformations_by_disease_code(self, disease_code):
+        return self._scoped_options(self.richter_transformations, disease_code, self._RICHTER_DISEASES)
+
+    def tumor_burdens_by_disease_code(self, disease_code):
+        return self._scoped_options(self.tumor_burdens, disease_code, self._TUMOR_BURDEN_DISEASES)
+
+    def disease_activities_by_disease_code(self, disease_code):
+        return self._scoped_options(self.disease_activities, disease_code, self._DISEASE_ACTIVITY_DISEASES)
 
     @property
     def ethnicities(self):
@@ -862,6 +925,22 @@ class ValueOptions:
             'flipiScore': {
                 'options': self.to_value_and_label(self.flipi_scores)
             },
+            # Per-disease FLIPI enum (#63). FL-only clinically.
+            'flipiScoreMm': {
+                'options': self.to_value_and_label(self.flipi_scores_by_disease_code('MM'))
+            },
+            'flipiScoreFl': {
+                'options': self.to_value_and_label(self.flipi_scores_by_disease_code('FL'))
+            },
+            'flipiScoreBc': {
+                'options': self.to_value_and_label(self.flipi_scores_by_disease_code('BC'))
+            },
+            'flipiScoreCll': {
+                'options': self.to_value_and_label(self.flipi_scores_by_disease_code('CLL'))
+            },
+            'flipiScoreMcl': {
+                'options': self.to_value_and_label(self.flipi_scores_by_disease_code('MCL'))
+            },
             'priorTherapy': {
                 'options': self.to_value_and_label(self.prior_therapies)
             },
@@ -915,11 +994,59 @@ class ValueOptions:
             'cytogenicMarkers': {
                 'options': self.to_value_and_label(self.cytogenic_markers)
             },
+            # Per-disease cytogenic markers (#63). Hematological-only.
+            'cytogenicMarkersMm': {
+                'options': self.to_value_and_label(self.cytogenic_markers_by_disease_code('MM'))
+            },
+            'cytogenicMarkersFl': {
+                'options': self.to_value_and_label(self.cytogenic_markers_by_disease_code('FL'))
+            },
+            'cytogenicMarkersBc': {
+                'options': self.to_value_and_label(self.cytogenic_markers_by_disease_code('BC'))
+            },
+            'cytogenicMarkersCll': {
+                'options': self.to_value_and_label(self.cytogenic_markers_by_disease_code('CLL'))
+            },
+            'cytogenicMarkersMcl': {
+                'options': self.to_value_and_label(self.cytogenic_markers_by_disease_code('MCL'))
+            },
             'molecularMarkers': {
                 'options': self.to_value_and_label(self.molecular_markers)
             },
+            # Per-disease molecular markers (#63). Hematological-only.
+            'molecularMarkersMm': {
+                'options': self.to_value_and_label(self.molecular_markers_by_disease_code('MM'))
+            },
+            'molecularMarkersFl': {
+                'options': self.to_value_and_label(self.molecular_markers_by_disease_code('FL'))
+            },
+            'molecularMarkersBc': {
+                'options': self.to_value_and_label(self.molecular_markers_by_disease_code('BC'))
+            },
+            'molecularMarkersCll': {
+                'options': self.to_value_and_label(self.molecular_markers_by_disease_code('CLL'))
+            },
+            'molecularMarkersMcl': {
+                'options': self.to_value_and_label(self.molecular_markers_by_disease_code('MCL'))
+            },
             'gelfCriteriaStatus': {
                 'options': self.to_value_and_label(self.gelf_criteria_statuses)
+            },
+            # Per-disease GELF criteria (#63). FL-only clinically.
+            'gelfCriteriaStatusMm': {
+                'options': self.to_value_and_label(self.gelf_criteria_statuses_by_disease_code('MM'))
+            },
+            'gelfCriteriaStatusFl': {
+                'options': self.to_value_and_label(self.gelf_criteria_statuses_by_disease_code('FL'))
+            },
+            'gelfCriteriaStatusBc': {
+                'options': self.to_value_and_label(self.gelf_criteria_statuses_by_disease_code('BC'))
+            },
+            'gelfCriteriaStatusCll': {
+                'options': self.to_value_and_label(self.gelf_criteria_statuses_by_disease_code('CLL'))
+            },
+            'gelfCriteriaStatusMcl': {
+                'options': self.to_value_and_label(self.gelf_criteria_statuses_by_disease_code('MCL'))
             },
             'progression': {
                 'options': self.to_value_and_label(self.progressions)
@@ -1158,17 +1285,81 @@ class ValueOptions:
             'binetStages': {
                 'options': self.to_value_and_label(self.binet_stages)
             },
+            # Per-disease Binet stages (#63). CLL-only clinically.
+            'binetStagesMm': {
+                'options': self.to_value_and_label(self.binet_stages_by_disease_code('MM'))
+            },
+            'binetStagesFl': {
+                'options': self.to_value_and_label(self.binet_stages_by_disease_code('FL'))
+            },
+            'binetStagesBc': {
+                'options': self.to_value_and_label(self.binet_stages_by_disease_code('BC'))
+            },
+            'binetStagesCll': {
+                'options': self.to_value_and_label(self.binet_stages_by_disease_code('CLL'))
+            },
+            'binetStagesMcl': {
+                'options': self.to_value_and_label(self.binet_stages_by_disease_code('MCL'))
+            },
             'proteinExpressions': {
                 'options': self.to_value_and_label(self.protein_expressions)
             },
             'richterTransformations': {
                 'options': self.to_value_and_label(self.richter_transformations)
             },
+            # Per-disease Richter transformations (#63). CLL-only clinically.
+            'richterTransformationsMm': {
+                'options': self.to_value_and_label(self.richter_transformations_by_disease_code('MM'))
+            },
+            'richterTransformationsFl': {
+                'options': self.to_value_and_label(self.richter_transformations_by_disease_code('FL'))
+            },
+            'richterTransformationsBc': {
+                'options': self.to_value_and_label(self.richter_transformations_by_disease_code('BC'))
+            },
+            'richterTransformationsCll': {
+                'options': self.to_value_and_label(self.richter_transformations_by_disease_code('CLL'))
+            },
+            'richterTransformationsMcl': {
+                'options': self.to_value_and_label(self.richter_transformations_by_disease_code('MCL'))
+            },
             'tumorBurdens': {
                 'options': self.to_value_and_label(self.tumor_burdens)
             },
+            # Per-disease tumor burdens (#63). FL/CLL/MCL clinically.
+            'tumorBurdensMm': {
+                'options': self.to_value_and_label(self.tumor_burdens_by_disease_code('MM'))
+            },
+            'tumorBurdensFl': {
+                'options': self.to_value_and_label(self.tumor_burdens_by_disease_code('FL'))
+            },
+            'tumorBurdensBc': {
+                'options': self.to_value_and_label(self.tumor_burdens_by_disease_code('BC'))
+            },
+            'tumorBurdensCll': {
+                'options': self.to_value_and_label(self.tumor_burdens_by_disease_code('CLL'))
+            },
+            'tumorBurdensMcl': {
+                'options': self.to_value_and_label(self.tumor_burdens_by_disease_code('MCL'))
+            },
             'diseaseActivities': {
                 'options': self.to_value_and_label(self.disease_activities)
+            },
+            # Per-disease disease activities (#63). CLL-only clinically.
+            'diseaseActivitiesMm': {
+                'options': self.to_value_and_label(self.disease_activities_by_disease_code('MM'))
+            },
+            'diseaseActivitiesFl': {
+                'options': self.to_value_and_label(self.disease_activities_by_disease_code('FL'))
+            },
+            'diseaseActivitiesBc': {
+                'options': self.to_value_and_label(self.disease_activities_by_disease_code('BC'))
+            },
+            'diseaseActivitiesCll': {
+                'options': self.to_value_and_label(self.disease_activities_by_disease_code('CLL'))
+            },
+            'diseaseActivitiesMcl': {
+                'options': self.to_value_and_label(self.disease_activities_by_disease_code('MCL'))
             },
             'diseaseBehaviorsMcl': {
                 'options': self.to_value_and_label(self.disease_behaviors_mcl)


### PR DESCRIPTION
Closes #63. Ports CB's `_by_disease_code` pattern from #4330 (initial `ddd5a1e9` + polish `dbcc1a7f`).

## Summary

Eight clinically disease-specific dropdowns were historically exposed as a single union to every patient, surfacing clinically meaningless options (FLIPI shown to BC patients, Binet to MM, etc.). This PR scopes each to its applicable diseases at the `/form-settings/?disease=` boundary.

**Clinical scoping** (final state after the polish commit — broader than the initial port):

| List | Applicable diseases |
|------|---------------------|
| FLIPI, GELF | FL |
| Binet, Richter, diseaseActivity | CLL |
| tumorBurden | FL, CLL, MCL |
| cytogenicMarkers, molecularMarkers | MM, FL, CLL, MCL |

BC stays correctly excluded from all eight (uses ER/PR/HER2/HRD instead).

## Changes

**`trials/services/value_options.py`:**
- 8 disease-set constants + `_scoped_options` staticmethod preserving the `''` Unknown sentinel on the off-disease path.
- 8 `*_by_disease_code(disease_code)` methods mirroring the existing `therapy_outcomes_by_disease_code` shape.
- 40 new `all_options()` entries (8 lists × 5 disease codes).
- `cache_key()` bumped to `v2` so a populated Redis cache doesn't serve the pre-#63 shape after deploy.

**`trials/api/trials_views.py` (`FormSettingsViewSet.list`):**
- When `?disease=` is set, the 8 patient-facing union keys are overridden with their per-disease subset. Key names match what `all_options()` already exposes (4 singular + 4 plural — preserved as-is for frontend back-compat).
- Trial-side `*Required`/`*Excluded` aliases stay at the union — `TrialAttributes.__init__` builds its own fresh `ValueOptions().all_options()` (`trial_attributes.py:39`), so the view's per-request mutation never leaks into trial detail rendering.

## Why view-level, not patient_info_details

EXACT has no `patient_info_details` layer (CB's aliasing site). `FormSettingsViewSet` is the only patient-facing form-settings endpoint, so it's the correct EXACT analog of CB's aliasing. Verified by grep — no consumer reads singular `binetStage`/`richterTransformation`/etc. as a patient-facing key.

## Tests

- `tests/services/test_value_options_disease_aware_lists.py` (10 cases) — one per list, plus case-insensitivity + `all_options()` exposure.
- `tests/views/test_form_settings_disease_aware_lists.py` (7 cases) — drives `FormSettingsViewSet` end-to-end for each disease + a regression guard that fresh `all_options()` still has the union under the bare key (trial-side isolation).

## Self-review

Fresh-context Claude pass — verified disease sets match CB `dbcc1a7f` byte-for-byte, `_scoped_options` semantics byte-equivalent, no singular-key consumer exists in EXACT tree (plural-key choice safe), trial-side isolation holds via fresh ValueOptions, cache_key rationale clarified, duplicated comment block deduped, redundant `ValueOptions()` instance removed, and the misnamed `test_trial_side_aliases_remain_at_union` reframed as a fresh-instance regression guard. Codex skipped (unreliable in this PR series).

## Test plan

- [ ] CI: new disease-aware service + view tests pass.
- [ ] CI: existing `test_value_options_dropdown_defaults.py`, `test_value_options_mcl.py`, `test_form_settings_therapy_outcome.py` still pass (no-disease path is unchanged).
- [ ] CI: matcher / queryset / form-settings tests still pass (no regression in trial-side aliases or default behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)