### PR TITLE
chore: add type hints to matcher / resolver / view-helper entry points (#31)

### DIFF
--- a/trials/api/trials_views.py
+++ b/trials/api/trials_views.py
@@ -1,4 +1,6 @@
-from django.db.models import F, Prefetch
+from typing import TYPE_CHECKING, Optional
+
+from django.db.models import F, Prefetch, QuerySet
 from rest_framework import viewsets, filters, permissions, status
 from rest_framework.decorators import action
 from rest_framework.response import Response
@@ -9,8 +11,11 @@ from trials.api.trials_serializers import TrialSerializer, TrialDetailsSerialize
 from trials.models import Trial, Location, LocationTrial, PreferredCountry, State
 from trials.services.blank_attribute_records_count import BlankAttributeRecordsCount
 from trials.services.patient_info.resolve import resolve_patient_info
-from trials.services.study_preferences import study_preferences_from_query_params
+from trials.services.study_preferences import StudyPreferences, study_preferences_from_query_params
 from trials.services.value_options import ValueOptions
+
+if TYPE_CHECKING:
+    from trials.services.patient_info.patient_info import PatientInfo
 
 
 # ---------------------------------------------------------------------------
@@ -51,13 +56,13 @@ class TrialsViewSet(viewsets.ReadOnlyModelViewSet):
     search_fields = ['brief_title', 'official_title']
     pagination_class = TrialsPagination
 
-    def _resolve_patient_info(self):
+    def _resolve_patient_info(self) -> Optional['PatientInfo']:
         try:
             return resolve_patient_info(self.request)
         except Exception:
             return None
 
-    def _resolve_study_preferences(self):
+    def _resolve_study_preferences(self) -> StudyPreferences:
         return study_preferences_from_query_params(self.request.query_params)
 
     def get_queryset(self, patient_info=None):
@@ -151,7 +156,7 @@ class TrialsViewSet(viewsets.ReadOnlyModelViewSet):
 
         return queryset
 
-    def _trials_counts(self, queryset, patient_info):
+    def _trials_counts(self, queryset: QuerySet, patient_info: Optional['PatientInfo']) -> dict[str, int]:
         return BlankAttributeRecordsCount().counts(queryset, patient_info)
 
     def get_serializer_class(self):

--- a/trials/services/patient_info/resolve.py
+++ b/trials/services/patient_info/resolve.py
@@ -35,13 +35,17 @@ import ast
 import datetime as dt
 import json
 from decimal import Decimal, InvalidOperation
+from typing import TYPE_CHECKING, Any, Optional
 
 from django.db.models import DateField, DateTimeField, DecimalField, FloatField, IntegerField, JSONField
 
 from trials.services.patient_info.normalize import normalize_patient_info
 
+if TYPE_CHECKING:
+    from trials.services.patient_info.patient_info import PatientInfo
 
-def resolve_patient_info(request):
+
+def resolve_patient_info(request) -> Optional['PatientInfo']:
     """
     Build an in-memory PatientInfo instance from the request.
 
@@ -62,7 +66,7 @@ def resolve_patient_info(request):
     return None
 
 
-def _get_body_field(request, name):
+def _get_body_field(request, name: str) -> Any:
     """Read a field from request.data, tolerating None or non-dict bodies."""
     data = getattr(request, 'data', None)
     if not isinstance(data, dict):
@@ -70,8 +74,14 @@ def _get_body_field(request, name):
     return data.get(name)
 
 
-def _extract_person_id(request):
-    """Return person_id from query params first, then body. None if absent."""
+def _extract_person_id(request) -> Optional[Any]:
+    """Return person_id from query params first, then body. None if absent.
+
+    The return is `Any` (not `str`) because the body path can carry a JSON
+    integer (e.g. `{"person_id": 9003}`) while the query-string path always
+    yields `str`. `CtomopClient.fetch_patient` coerces both to int before
+    constructing the URL.
+    """
     query_params = getattr(request, 'query_params', None)
     if query_params:
         pid = query_params.get('person_id') or query_params.get('personId')
@@ -82,7 +92,7 @@ def _extract_person_id(request):
     return body_pid or None
 
 
-def _resolve_from_ctomop(person_id):
+def _resolve_from_ctomop(person_id: Any) -> Optional['PatientInfo']:
     """Fetch the CTOMOP row and adapt it to a PatientInfo. None on any error."""
     from trials.services.patient_info.ctomop_adapter import (
         build_patient_info_from_ctomop_row,
@@ -95,7 +105,7 @@ def _resolve_from_ctomop(person_id):
     return build_patient_info_from_ctomop_row(row)
 
 
-def _build_in_memory(data: dict):
+def _build_in_memory(data: dict) -> 'PatientInfo':
     """Build an unsaved PatientInfo from a dict, compute derived fields."""
     from trials.services.patient_info.patient_info import PatientInfo
     from trials.models import PreExistingConditionCategory

--- a/trials/services/user_to_trial_attr_matcher.py
+++ b/trials/services/user_to_trial_attr_matcher.py
@@ -1,7 +1,20 @@
 import itertools
 import datetime as dt
 from dataclasses import dataclass
-from typing import Any
+from typing import TYPE_CHECKING, Any, Literal, Optional
+
+if TYPE_CHECKING:
+    from trials.models import Trial
+    from trials.services.patient_info.patient_info import PatientInfo
+
+# Per-attribute match outcomes. `attr_match_status` always returns one of
+# these three literal strings (it raises on unsupported config types
+# rather than returning a fourth tag). `min_max_match` is the exception:
+# it returns `None` when neither bound is set, signalling "no constraint".
+AttrMatchStatus = Literal['matched', 'not_matched', 'unknown']
+
+# Aggregate per-trial outcomes (`trial_match_status` returns one).
+TrialMatchStatus = Literal['eligible', 'potential', 'not_eligible']
 
 from trials.enums import PriorTherapyLines
 from trials.services.patient_info.configs import (
@@ -73,7 +86,18 @@ _TYPE_HANDLERS = {
 }
 
 
-def min_max_match(min_val, max_val, value, value_is_blank):
+def min_max_match(
+    min_val: Optional[Any],
+    max_val: Optional[Any],
+    value: Any,
+    value_is_blank: bool,
+) -> Optional[AttrMatchStatus]:
+    """Return `None` when both bounds are absent (no constraint), otherwise
+    the standard per-attr match outcome. `min_val`/`max_val`/`value` are
+    annotated `Any` because callers pass mixed numeric types (ints, floats,
+    Decimals) plus date/datetime objects depending on the attr — uniform
+    comparison via `<` / `>` is the only contract.
+    """
     if min_val is None and max_val is None:
         return None
     elif value_is_blank:
@@ -87,14 +111,14 @@ def min_max_match(min_val, max_val, value, value_is_blank):
 
 
 class UserToTrialAttrMatcher:
-    def __init__(self, trial, patient_info):
+    def __init__(self, trial: 'Trial', patient_info: 'PatientInfo') -> None:
         self.trial = trial
         self.patient_info = patient_info
         self.mapping = USER_TO_TRIAL_ATTRS_MAPPING
         self.patient_info_attr = PatientInfoAttributes(patient_info)
-        self.disease_code = self.get_disease_code_from_trial(trial)
+        self.disease_code: Optional[str] = self.get_disease_code_from_trial(trial)
 
-    def get_disease_code_from_trial(self, trial):
+    def get_disease_code_from_trial(self, trial: 'Trial') -> Optional[str]:
         disease = str(trial.disease).lower()
         if disease == 'multiple myeloma':
             return 'MM'
@@ -108,7 +132,7 @@ class UserToTrialAttrMatcher:
             return 'MCL'
         return None
 
-    def trial_match_status(self):
+    def trial_match_status(self) -> TrialMatchStatus:
         out = {}
         for attr, trial_attr_meta in self.mapping.items():
             if "disease" in trial_attr_meta and (
@@ -125,7 +149,7 @@ class UserToTrialAttrMatcher:
         else:
             return 'eligible'
 
-    def trial_match_score(self):
+    def trial_match_score(self) -> int:
         eligible_count = 0
         all_count = 0
 
@@ -146,7 +170,7 @@ class UserToTrialAttrMatcher:
             return 0
         return int(float(eligible_count) * 100 / float(all_count))
 
-    def is_patient_info_attr_blank(self, patient_info_attr):
+    def is_patient_info_attr_blank(self, patient_info_attr: str) -> bool:
         return self.patient_info_attr.is_attr_blank(patient_info_attr)
 
     def therapy_related_things_mismatch_status(self):
@@ -249,7 +273,7 @@ class UserToTrialAttrMatcher:
 
         return out
 
-    def attr_match_status(self, patient_info_attr):
+    def attr_match_status(self, patient_info_attr: str) -> AttrMatchStatus:
         """Match a single patient attribute against the corresponding trial
         attribute(s) and return one of `'matched'`, `'not_matched'`,
         `'unknown'`.


### PR DESCRIPTION
Closes #31 (annotations half). Adds explicit type hints to core service entry points where `Optional` flows were previously implicit. Behaviour is unchanged — the diff is signature/docstring/import-only.

## What's annotated

**`trials/services/user_to_trial_attr_matcher.py`** — two `Literal` aliases at module top (`AttrMatchStatus`, `TrialMatchStatus`) + `min_max_match`, `UserToTrialAttrMatcher.__init__`, `get_disease_code_from_trial`, `trial_match_status`, `trial_match_score`, `is_patient_info_attr_blank`, `attr_match_status`.

**`trials/services/patient_info/resolve.py`** — `resolve_patient_info`, `_get_body_field`, `_extract_person_id`, `_resolve_from_ctomop`, `_build_in_memory`.

**`trials/api/trials_views.py`** — `_resolve_patient_info`, `_resolve_study_preferences`, `_trials_counts(queryset: QuerySet, patient_info: Optional[PatientInfo]) -> dict[str, int]`. The `dict[str, int]` tightening was caught in fresh-context self-review (`BlankAttributeRecordsCount.counts()` filters non-None values after the BigIntegerField Sum introduced in #25 / PR #98).

`Trial` and `PatientInfo` are forward-string-referenced under `TYPE_CHECKING` to avoid runtime import / cycle risk. `StudyPreferences` lives in a leaf module so the direct import is safe.

## Deliberately out of scope

Issue #31 also suggests adding a lightweight `mypy` config. **Skipped for this PR** — mypy is a meaningful new CI pipeline that needs separate buy-in. Annotations land first; mypy gating is a follow-up if you want it.

## Self-review

Fresh-context Claude pass — verified every `return` in `min_max_match`, `attr_match_status` handlers, `trial_match_status`, and `_match_computed_attr` resolves to the declared literal set (no stray empty strings or alternate tags); verified all `'Trial'`/`'PatientInfo'` forward refs are correctly quoted; verified `Optional[Any]` in `_extract_person_id` is semantically meaningful (collapses to `Any` for mypy but documents the json-int-vs-str body/query divergence); verified no module-load cycle. One tighten-able item (`dict` → `dict[str, int]`) applied inline. Codex skipped (unreliable in this PR series).

## Test plan

- [ ] CI: existing matcher / resolve / view tests pass (annotations are runtime no-ops).
- [ ] CI: `python manage.py makemigrations --check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)