### PR TITLE
chore(security): harden .gitignore against secret/credential leaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,28 @@ trials/management/commands/load_trials_from_cancerbot.py
 # Local environment variables (never commit)
 .env
 .env.test
+.env.*
+!.env.example
 env/
+
+# Secrets / credentials — NEVER commit (this repo is PUBLIC)
+serviceAccountKeys/
+*serviceAccount*.json
+*-firebase-adminsdk-*.json
+*-sa-key.json
+*sa-key.json
+firebase-sa-key.json
+*.pem
+*.key
+
+# Terraform — tfstate/tfvars store secrets in plaintext; never commit
+*.tfvars
+*.tfvars.json
+!*.tfvars.example
+*.tfstate
+*.tfstate.*
+.terraform/
+.terraform.lock.hcl
 
 # IDE
 .idea/

--- a/README.md
+++ b/README.md
@@ -70,3 +70,22 @@ python manage.py runserver
 
 See [docs/setup.md](docs/setup.md) for full instructions including database
 setup, environment variables, and test configuration.
+
+## Configuration & secrets
+
+EXACT is a **public** repository. All runtime configuration is supplied through
+environment variables — never commit secret values to git.
+
+- **Local dev:** copy `.env.example` to `.env` and fill in values. Everything
+  matching `.env*` (except `.env.example`) is git-ignored.
+- **Secrets never enter git.** `.gitignore` blocks `.env*`, Terraform state and
+  vars (`*.tfvars`, `*.tfstate*`, `.terraform/`), service-account JSON
+  (`*serviceAccount*.json`, `*-firebase-adminsdk-*.json`, `*-sa-key.json`,
+  `firebase-sa-key.json`), and private keys (`*.pem`, `*.key`).
+- **Production/staging:** secrets such as `SECRET_KEY`, database credentials,
+  `TRIALS_DATABASE_URL`, and `CTOMOP_SERVICE_TOKEN` come from the host
+  platform's secret store (e.g. GCP Secret Manager) and are injected as
+  environment variables at runtime — never from files in this repo.
+- **When CI deployment is added**, it should authenticate to the cloud
+  *keyless* (GitHub OIDC / Workload Identity Federation). Do not store a
+  long-lived service-account JSON key in the repo or in CI.


### PR DESCRIPTION
## Summary
- This repo is **public**. Its `.gitignore` had no protection against committing Terraform state/vars or service-account/private-key files.
- Adds ignore rules for `*.tfvars`, `*.tfstate*`, `.terraform/`, plus `*serviceAccount*.json`, `*-firebase-adminsdk-*.json`, `*-sa-key.json`, `firebase-sa-key.json`, `*.pem`, `*.key`. Broadens `.env.*` with a `!.env.example` allow.
- Motivated by a security audit of the public GCP/deploy surface (Claude + codex). The audit found **nothing sensitive committed today** — this is purely preventative so a future stray secret file can't be added.

## Test plan
- [x] `git check-ignore` confirms `terraform.tfvars`, `terraform.tfstate(.backup)`, `firebase-sa-key.json`, `serviceAccount.json`, `key.pem`, `.terraform/` are now ignored.
- [x] Confirmed `.env.example` / `terraform.tfvars.example` / `manage.py` remain tracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)