### PR TITLE
test: loader/mapper coverage + fix 3 source typos (#30)

### DIFF
--- a/tests/services/test_attribute_names.py
+++ b/tests/services/test_attribute_names.py
@@ -1,0 +1,84 @@
+"""Unit tests for AttributeNames helpers (#30).
+
+These three staticmethods turn attribute names between snake_case,
+camelCase, and human-readable text. They power matchers, serializers,
+and the form-settings layer — drift here would cascade into per-attr
+labels and JSON keys without an obvious failure.
+"""
+import pytest
+
+from trials.services.attribute_names import ATTRIBUTE_NAME_MAPPING, AttributeNames
+
+
+class TestGetBySnakeCase:
+    @pytest.mark.parametrize('snake,camel', [
+        ('age_low_limit', 'ageMin'),
+        ('age_high_limit', 'ageMax'),
+        ('kappa_flc', 'kappaFLC'),
+        ('lambda_flc', 'lambdaFLC'),
+        ('meets_crab', 'meetsCRAB'),
+        ('meets_slim', 'meetsSLIM'),
+        ('meets_gelf', 'meetsGELF'),
+    ])
+    def test_explicit_mapping_takes_precedence(self, snake, camel):
+        assert AttributeNames.get_by_snake_case(snake) == camel
+
+    @pytest.mark.parametrize('snake,camel', [
+        ('disease', 'disease'),
+        ('treatment_refractory_status', 'treatmentRefractoryStatus'),
+        ('hr_status', 'hrStatus'),
+    ])
+    def test_falls_back_to_inflection_camelize(self, snake, camel):
+        assert AttributeNames.get_by_snake_case(snake) == camel
+
+
+class TestGetByCamelCase:
+    @pytest.mark.parametrize('camel,snake', [
+        ('ageMin', 'age_low_limit'),
+        ('ageMax', 'age_high_limit'),
+        ('kappaFLC', 'kappa_flc'),
+        ('meetsCRAB', 'meets_crab'),
+        ('meetsGELF', 'meets_gelf'),
+    ])
+    def test_explicit_mapping_takes_precedence(self, camel, snake):
+        assert AttributeNames.get_by_camel_case(camel) == snake
+
+    @pytest.mark.parametrize('camel,snake', [
+        ('disease', 'disease'),
+        ('treatmentRefractoryStatus', 'treatment_refractory_status'),
+        ('hrStatus', 'hr_status'),
+    ])
+    def test_falls_back_to_inflection_underscore(self, camel, snake):
+        assert AttributeNames.get_by_camel_case(camel) == snake
+
+    def test_explicit_mapping_round_trips_to_self(self):
+        """Every explicit map entry should round-trip:
+        snake → camel → snake should always equal snake.
+        """
+        for snake, camel in ATTRIBUTE_NAME_MAPPING.items():
+            assert AttributeNames.get_by_camel_case(camel) == snake, snake
+            assert AttributeNames.get_by_snake_case(snake) == camel, camel
+
+
+class TestHumanize:
+    @pytest.mark.parametrize('raw,expected', [
+        ('contraceptiveUse', 'Contraceptive Use'),
+        ('kappaFLC', 'Kappa FLC'),
+        ('age_minimum', 'Age Minimum'),
+        ('Lambda FLC', 'Lambda FLC'),
+        ('disease', 'Disease'),
+    ])
+    def test_humanize_title_case(self, raw, expected):
+        assert AttributeNames.humanize(raw) == expected
+
+    def test_humanize_title_false_lowercases_words(self):
+        # Acronyms are preserved even when title=False.
+        result = AttributeNames.humanize('kappaFLC', title=False)
+        assert result == 'kappa FLC'
+
+    def test_humanize_strips_trailing_id_suffix(self):
+        assert AttributeNames.humanize('therapy_id') == 'Therapy'
+
+    def test_humanize_preserves_acronym_runs(self):
+        # ECOG should survive as 'ECOG', not 'Ecog'.
+        assert AttributeNames.humanize('patientECOG') == 'Patient ECOG'

--- a/tests/services/test_concomitant_medications_mapper.py
+++ b/tests/services/test_concomitant_medications_mapper.py
@@ -1,0 +1,57 @@
+"""Structure-invariant tests for ConcomitantMedicationsMapper (#30).
+
+The mapper is the single source of truth for the concomitant-medications
+taxonomy seeded by `LoadConcomitantMedications`. Drift between the
+diseases() declaration and the per-entry `diseases` lists would silently
+seed medications under non-existent disease codes.
+"""
+from trials.services.concomitant_medications_mapper import ConcomitantMedicationsMapper
+
+
+class TestDiseases:
+    def test_diseases_returns_expected_codes(self):
+        mapper = ConcomitantMedicationsMapper()
+        assert mapper.diseases() == {
+            'MM': 'Multiple myeloma',
+            'FL': 'Follicular lymphoma',
+            'BC': 'Breast cancer',
+            'CLL': 'Chronic lymphocytic leukemia',
+        }
+
+
+class TestData:
+    def setup_method(self):
+        self.mapper = ConcomitantMedicationsMapper()
+        self.data = self.mapper.data()
+        self.known_disease_codes = set(self.mapper.diseases().keys())
+
+    def test_returns_non_empty_dict(self):
+        assert isinstance(self.data, dict)
+        assert len(self.data) > 0
+
+    def test_every_entry_has_name_and_diseases(self):
+        for code, entry in self.data.items():
+            assert 'name' in entry, code
+            assert 'diseases' in entry, code
+            assert isinstance(entry['name'], str) and entry['name'], code
+            assert isinstance(entry['diseases'], list), code
+
+    def test_entry_disease_codes_are_subset_of_declared(self):
+        """Every code in a per-entry `diseases` list must be one of the
+        codes returned by `diseases()`. Drift here would silently seed
+        medications under non-existent disease rows.
+        """
+        for code, entry in self.data.items():
+            extra = set(entry['diseases']) - self.known_disease_codes
+            assert not extra, f'{code}: unknown disease codes {sorted(extra)}'
+
+    def test_entry_keys_are_unique(self):
+        # data() returns a dict so this is structurally guaranteed,
+        # but assert anyway to flag any future merge that doesn't.
+        assert len(self.data) == len(set(self.data.keys()))
+
+    def test_known_entry_investigational_agents_present(self):
+        assert 'investigational_agents' in self.data
+        entry = self.data['investigational_agents']
+        assert entry['name'] == 'Investigational Agents'
+        assert set(entry['diseases']) == self.known_disease_codes

--- a/tests/services/test_loaders_smoke.py
+++ b/tests/services/test_loaders_smoke.py
@@ -1,0 +1,77 @@
+"""Smoke + idempotency tests for the four loaders not exercised by conftest (#30).
+
+`tests/conftest.py` runs 11 of the 15 loaders at session setup (so they
+get implicit coverage — a regression there breaks the whole test suite
+at fixture load). The four exceptions — `LoadLangOptions`,
+`LoadPreferredCountriesOptions`, `LoadScthOptions`, `LoadTnmOptions`
+— have **no** test exercise at all and are only invoked via the
+`seed_reference_data` management command in production.
+
+These tests close the gap by asserting each `load_all()`:
+1. Runs without raising.
+2. Creates at least one row in each model it targets.
+3. Is idempotent — re-running keeps the row count stable.
+"""
+import pytest
+
+from trials.models import (
+    DistantMetastasisStage,
+    Language,
+    LanguageSkillLevel,
+    NodesStage,
+    PreferredCountry,
+    StagingModality,
+    StemCellTransplant,
+    TumorStage,
+)
+from trials.services.loaders.load_lang_options import LoadLangOptions
+from trials.services.loaders.load_preferred_countries_options import LoadPreferredCountriesOptions
+from trials.services.loaders.load_scth_options import LoadScthOptions
+from trials.services.loaders.load_tnm_options import LoadTnmOptions
+
+
+# Each entry: (loader_class, [(Model, expected_min_count), ...])
+_LOADERS_UNDER_TEST = [
+    (LoadLangOptions, [(Language, 1), (LanguageSkillLevel, 1)]),
+    (LoadPreferredCountriesOptions, [(PreferredCountry, 1)]),
+    (LoadScthOptions, [(StemCellTransplant, 1)]),
+    (LoadTnmOptions, [
+        (TumorStage, 1),
+        (NodesStage, 1),
+        (DistantMetastasisStage, 1),
+        (StagingModality, 1),
+    ]),
+]
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize('loader_cls,model_expectations', _LOADERS_UNDER_TEST)
+def test_load_all_runs_and_populates(loader_cls, model_expectations):
+    loader_cls().load_all()
+    for model, min_count in model_expectations:
+        assert model.objects.count() >= min_count, (
+            f'{loader_cls.__name__} did not populate {model.__name__} '
+            f'(expected ≥ {min_count})'
+        )
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize('loader_cls,model_expectations', _LOADERS_UNDER_TEST)
+def test_load_all_is_idempotent(loader_cls, model_expectations):
+    """Re-running `load_all()` must not duplicate rows. Each loader uses
+    `update_or_create` keyed on `code`, so a second run should leave the
+    count unchanged — silent duplication would corrupt downstream
+    eligibility lookups that join on these reference tables.
+    """
+    loader_cls().load_all()
+    counts_after_first_run = {
+        model: model.objects.count() for model, _ in model_expectations
+    }
+
+    loader_cls().load_all()
+    for model, _ in model_expectations:
+        assert model.objects.count() == counts_after_first_run[model], (
+            f'{loader_cls.__name__} created duplicates in '
+            f'{model.__name__} on re-run '
+            f'({counts_after_first_run[model]} → {model.objects.count()})'
+        )

--- a/tests/services/test_markers_mapper.py
+++ b/tests/services/test_markers_mapper.py
@@ -1,0 +1,50 @@
+"""Structure-invariant tests for MarkersMapper (#30).
+
+The mapper feeds `LoadMarkers` which seeds the `Marker` model used by
+the matcher's cytogenicMarkers / molecularMarkers eligibility checks.
+"""
+from trials.services.markers_mapper import MarkersMapper
+
+
+class TestCategories:
+    def test_categories_returns_expected_pair(self):
+        # Two categories — cytogenic and molecular — feed the
+        # `MARKER_CATEGORIES` config and the disease-aware option lists
+        # (`_CYTOGENIC_DISEASES` / `_MOLECULAR_DISEASES` in #63).
+        assert MarkersMapper().categories() == {
+            'cytogenic': 'Cytogenic Markers',
+            'molecular': 'Molecular Markers',
+        }
+
+
+class TestData:
+    def setup_method(self):
+        self.mapper = MarkersMapper()
+        self.data = self.mapper.data()
+        self.known_category_titles = set(self.mapper.categories().values())
+
+    def test_returns_non_empty_dict(self):
+        assert isinstance(self.data, dict)
+        assert len(self.data) > 0
+
+    def test_every_entry_has_name_and_categories(self):
+        for code, entry in self.data.items():
+            assert 'name' in entry, code
+            assert 'categories' in entry, code
+            assert isinstance(entry['name'], str) and entry['name'], code
+            assert isinstance(entry['categories'], list) and entry['categories'], code
+
+    def test_entry_category_titles_are_subset_of_declared(self):
+        """Every category title in a per-entry `categories` list must be
+        one of the titles in `categories()`. Drift would silently seed
+        markers under non-existent category rows.
+        """
+        for code, entry in self.data.items():
+            extra = set(entry['categories']) - self.known_category_titles
+            assert not extra, f'{code}: unknown category titles {sorted(extra)}'
+
+    def test_known_entry_del17p13_present(self):
+        # Spot-check: del(17p13) is the headline TP53-deletion marker.
+        assert 'del17p13' in self.data
+        entry = self.data['del17p13']
+        assert 'Cytogenic Markers' in entry['categories']

--- a/tests/services/test_therapies_mapper.py
+++ b/tests/services/test_therapies_mapper.py
@@ -1,0 +1,71 @@
+"""Structure-invariant tests for TherapiesMapper (#30).
+
+The mapper is 1500 lines of static therapy regimens — exhaustively
+testing every entry would just duplicate the data. These tests assert
+the shape contract that `LoadTherapies` and the disease-aware therapy
+line getters depend on.
+"""
+import pytest
+
+from trials.services.therapies_mapper import TherapiesMapper
+
+
+class TestData:
+    def setup_method(self):
+        self.mapper = TherapiesMapper()
+        self.data = self.mapper.data()
+
+    def test_returns_non_empty_dict(self):
+        assert isinstance(self.data, dict)
+        assert len(self.data) > 0
+
+    def test_every_entry_has_required_keys(self):
+        """Only `name` and `drugs` are universal. `short_name` is set on
+        regimen entries but absent on simple-drug entries
+        (e.g. `selinexor`, `asct`); `drugs` may be empty for entries
+        that represent procedures or observation rather than drug
+        regimens (e.g. `asct`, `ww`, `ifrt`).
+        """
+        for code, entry in self.data.items():
+            assert 'name' in entry, code
+            assert 'drugs' in entry, code
+            assert isinstance(entry['name'], str) and entry['name'], code
+            assert isinstance(entry['drugs'], list), code
+            if 'short_name' in entry:
+                assert isinstance(entry['short_name'], str) and entry['short_name'], code
+
+    def test_drug_lists_contain_strings(self):
+        for code, entry in self.data.items():
+            for drug in entry['drugs']:
+                assert isinstance(drug, str) and drug, f'{code}: empty/non-str drug {drug!r}'
+
+    def test_codes_are_unique(self):
+        assert len(self.data) == len(set(self.data.keys()))
+
+    @pytest.mark.parametrize('code', ['vrd', 'dara_vrd', 'dara_rd'])
+    def test_known_mm_regimen_present(self, code):
+        # Spot-check: VRd and Dara-VRd variants are headline MM regimens.
+        assert code in self.data
+
+
+class TestDiseaseKeyedLineGetters:
+    """The mapper exposes disease-keyed methods (e.g. `first_line_mm`)
+    that return therapy lists for use by `LoadTherapies`. Smoke-test
+    that the documented methods exist, return iterables of strings, and
+    each entry resolves to a `data()` code.
+    """
+
+    @pytest.mark.parametrize('method_name', [
+        'first_line_mm', 'first_line_fl', 'first_line_bc',
+        'second_line_mm', 'second_line_fl', 'second_line_bc',
+        'later_therapy_mm', 'later_therapy_fl', 'later_therapy_bc',
+    ])
+    def test_returns_iterable_of_known_codes(self, method_name):
+        mapper = TherapiesMapper()
+        codes = getattr(mapper, method_name)()
+        assert codes, f'{method_name} returned empty'
+        known = set(mapper.data().keys())
+        unknown = [c for c in codes if c not in known]
+        assert not unknown, (
+            f'{method_name} returns codes not in data(): {unknown}'
+        )

--- a/trials/services/therapies_mapper.py
+++ b/trials/services/therapies_mapper.py
@@ -1360,7 +1360,7 @@ class TherapiesMapper:
     def later_therapy_fl(self):
         return [
             "axicabtagene_ciloleucel", "tisagenlecleucel", "polatuzumab_vedotin", "idelalisib",
-            "copanlisib", "duvelisib", "tazemetostat", "l_r", "br", "obinutuzumab", "agsct",
+            "copanlisib", "duvelisib", "tazemetostat", "lr", "br", "obinutuzumab", "agsct",
             "radiotherapy", "clinical_trials"
         ]
 
@@ -1369,10 +1369,10 @@ class TherapiesMapper:
             "fulvestrant", "exemestane_everolimus", "alpelisib_fulvestrant", "capivasertib_fulvestrant",
             "elacestrant", "tamoxifen", "megestrol_acetate", "capecitabine", "eribulin", "vinorelbine",
             "gemcitabine", "paclitaxel", "docetaxel", "trastuzumab_deruxtecan", "tucatinib_trastuzumab_capecitabine",
-            "lapatinib", "neratinib", "margetuximab_chemotherapy", "trastuzumab_emtansine", "sacituzumab_govitecan",
+            "lapatinib", "neratinib", "margetuximab", "trastuzumab_emtansine", "sacituzumab_govitecan",
             "sacituzumab_govitecan", "atezolizumab_nab_paclitaxel", "pembrolizumab_chemotherapy", "olaparib",
             "talazoparib", "carboplatin", "cisplatin", "eribulin", "capecitabine", "gemcitabine", "vinorelbine",
-            "olaparib", "talazoparib", "alpelisib", "capivasertib", "larotrectinib", "entrectinib", "immune_checkpoint_inhibitor",
+            "olaparib", "talazoparib", "alpelisib", "capivasertib", "larotrectinib", "entrectinib", "immune_checkpoint_inhibitors",
         ]
 
     def supportive_all(self):


### PR DESCRIPTION
Closes #30. Adds the zero-coverage test surface for `trials/services/loaders/` (the four not invoked by conftest) and the four mapper services. Includes 3 source typo fixes for orphan therapy codes the new tests caught.

## New test files

| File | What |
|------|------|
| `tests/services/test_attribute_names.py` | Unit tests + round-trip invariant on `ATTRIBUTE_NAME_MAPPING`. Acronym preservation (`Kappa FLC`, `Patient ECOG`) and edge paths (`_id` suffix stripping, `title=False`) covered. |
| `tests/services/test_concomitant_medications_mapper.py` | Asserts every entry's `diseases` list is a subset of `diseases()` — drift would silently seed medications under non-existent disease rows. |
| `tests/services/test_markers_mapper.py` | Same shape contract for `categories` ↔ `data` entries. |
| `tests/services/test_therapies_mapper.py` | Shape contract on 166 `data()` entries (relaxed after self-review: `short_name` is optional for non-regimen entries like `selinexor`/`asct`; `drugs` can be empty for procedure entries like `asct`/`ww`/`ifrt`); plus parametrised assertion that all 9 disease-keyed line getters resolve to known codes. |
| `tests/services/test_loaders_smoke.py` | Parametrised smoke + idempotency for the 4 loaders not invoked by conftest (`LoadLangOptions`, `LoadPreferredCountriesOptions`, `LoadScthOptions`, `LoadTnmOptions`). |

## Source fixes — orphan therapy codes caught by the new tests

The `test_returns_iterable_of_known_codes` test surfaced three real typos:

- `later_therapy_fl` → `'l_r'` (typo for `'lr'`)
- `later_therapy_bc` → `'margetuximab_chemotherapy'` (typo for `'margetuximab'`)
- `later_therapy_bc` → `'immune_checkpoint_inhibitor'` (typo for `'immune_checkpoint_inhibitors'` — plural)

Each pointed at a regimen not in the `data()` catalog, so `LoadTherapies` silently dropped them when seeding the BC/FL later-line therapy lists. Without coverage these would have stayed broken indefinitely. Fixed in the same PR since they're a direct product of adding the tests.

## Self-review

Fresh-context Claude pass — flagged the shape over-spec on `test_every_entry_has_required_keys` (150 of 166 entries lack `short_name`; 32 have empty `drugs`) and the 3 source typos. Shape test relaxed; typos fixed. Runtime-verified all assertions pass via standalone Python smoke. Codex skipped (unreliable in this PR series).

## Test plan

- [ ] CI: all 5 new test files pass.
- [ ] CI: existing test suite still passes (`LoadTherapies` now successfully seeds 3 more codes — should be silently good).
- [ ] CI: `python manage.py makemigrations --check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)