### PR TITLE
feat(frontend): scaffold federation remote exact_remote + toolchain (#103)

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -1,0 +1,41 @@
+name: frontend
+
+on:
+  push:
+    branches: [dev, main]
+    paths:
+      - "frontend/**"
+      - ".github/workflows/frontend.yml"
+  pull_request:
+    paths:
+      - "frontend/**"
+      - ".github/workflows/frontend.yml"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: frontend/package-lock.json
+      - name: Install
+        # Scaffold ships without a lockfile — fall back to `npm install`
+        # on first run; subsequent PRs that touch package.json should
+        # commit the resulting `frontend/package-lock.json`.
+        run: |
+          if [ -f package-lock.json ]; then
+            npm ci
+          else
+            npm install
+          fi
+      - name: Typecheck
+        run: npm run typecheck
+      - name: Build remote
+        run: npm run build

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -23,12 +23,12 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "20"
-          cache: "npm"
-          cache-dependency-path: frontend/package-lock.json
       - name: Install
         # Scaffold ships without a lockfile — fall back to `npm install`
         # on first run; subsequent PRs that touch package.json should
-        # commit the resulting `frontend/package-lock.json`.
+        # commit the resulting `frontend/package-lock.json` and add
+        # `cache: "npm"` + `cache-dependency-path: frontend/package-lock.json`
+        # to the setup-node step above.
         run: |
           if [ -f package-lock.json ]; then
             npm ci

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,0 +1,7 @@
+node_modules/
+dist/
+*.tsbuildinfo
+.vite-remote/
+.vite/
+.env.local
+.env.*.local

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,50 @@
+# EXACT frontend (`exact_remote`)
+
+Federated React 19 remote that ships the `TrialMatches` component. Toolchain mirrors SoC / ctomop / hk-labs so a host can mount EXACT alongside the other org remotes with one React tree + one TanStack QueryClient.
+
+This package was scaffolded in #103 (part of #101). The real component lands in #104.
+
+## Scripts
+
+| Script | What |
+|--------|------|
+| `npm run dev` | SPA harness for iterating on the component in isolation. Serves `index.html` at http://localhost:5178/. Proxies `/api/*` → Django on :8000. |
+| `npm run dev:remote` | Federation dev server. Serves `dev-harness.html` at http://localhost:5177/ and exposes the remote at `/remoteEntry.js`. Adds CTOMOP proxies (`/ctomop-local`, `/ctomop-staging`) with Set-Cookie rewriting. |
+| `npm run build` | Production federation build. Output: `dist/remote/remoteEntry.js` + exposed modules. |
+| `npm run build:spa` | Production SPA build. Output: `dist/`. Use this if you want to deploy the harness as a static site. |
+| `npm run typecheck` | `tsc -b`. CI gates this. |
+
+## Exposed modules
+
+```ts
+// In the host:
+import("exact_remote/TrialMatches").then(({ TrialMatches }) => { /* … */ });
+import("exact_remote/types").then(({ /* TrialMatchesProps, … */ }) => { /* … */ });
+```
+
+The host must provide:
+
+- An `axios.AxiosInstance` with `baseURL` (typically `/api`) and `Authorization: Token <…>`.
+- A TanStack `QueryClient` (optional — the component spins up its own otherwise).
+- Either a CTOMOP `personId` or an inline `patientInfo` payload (mutually exclusive; `patientInfo` wins to match the server-side `resolve_patient_info` precedence).
+
+## CSS token contract
+
+Tokens live on `.exact-root` scoped to the remote. Hosts can override any `--exact-*` on `:root` to map them to the host design system (see `frontend/src/federation/exact.css`). Per the hk-labs `docs/module-federation.md` namespace convention.
+
+`assertExactTokens()` returns the list of unset required tokens for dev-time sanity checks — call from the harness to catch missing host overrides.
+
+## Environment variables
+
+| Name | Default | What |
+|------|---------|------|
+| `VITE_EXACT_API_PROXY_TARGET` | `http://localhost:8000` | Where the `/api` proxy points (EXACT's Django). |
+| `VITE_CTOMOP_LOCAL_TARGET` | `http://localhost:8001` | Local CTOMOP for the federation dev harness. |
+| `VITE_CTOMOP_STAGING_TARGET` | `https://ctomop.onrender.com` | Staging CTOMOP for the federation dev harness. |
+| `VITE_EXACT_TOKEN` | _unset_ | DRF token for local dev. Real login flow lands in #104. |
+
+## Status
+
+- ✅ #103 — Scaffold + federation config + CSS token contract + dev harness skeleton.
+- ⏳ #104 — `TrialMatches` body (filters, eligibility grouping, distance sort, trial detail) + CTOMOP picker + token login flow.
+- ⏳ #101 — Closes when #104 ships.

--- a/frontend/dev-harness.html
+++ b/frontend/dev-harness.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>EXACT Federation — Dev Harness</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/dev/dev-harness.tsx"></script>
+  </body>
+</html>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>EXACT Trial Matches</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "exact-frontend",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "dev:remote": "vite --config vite.remote.config.ts",
+    "build": "tsc -b && vite build --config vite.remote.config.ts",
+    "build:spa": "tsc -b && vite build",
+    "preview": "vite preview",
+    "typecheck": "tsc -b"
+  },
+  "dependencies": {
+    "@module-federation/runtime": "^2.4.0",
+    "@module-federation/vite": "1.15.5",
+    "@tanstack/react-query": "^5.32.0",
+    "axios": "^1.6.8",
+    "react": "^19.2.6",
+    "react-dom": "^19.2.6"
+  },
+  "devDependencies": {
+    "@tailwindcss/vite": "^4.3.0",
+    "@types/node": "^20.12.11",
+    "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "^6.0.1",
+    "tailwindcss": "^4.3.0",
+    "typescript": "^5.4.5",
+    "vite": "^8.0.8"
+  }
+}

--- a/frontend/src/dev/dev-harness.tsx
+++ b/frontend/src/dev/dev-harness.tsx
@@ -1,0 +1,38 @@
+// Federation dev harness — `npm run dev:remote` boots this.
+// Scaffold version: renders the federated `TrialMatches` directly with a
+// local axios instance. The CTOMOP picker + token-login flow lands in
+// #104 (Track C of #101).
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import axios from "axios";
+
+import { TrialMatches } from "../federation/TrialMatches";
+
+const queryClient = new QueryClient();
+const apiClient = axios.create({
+  baseURL: "/api",
+  headers: import.meta.env.VITE_EXACT_TOKEN
+    ? { Authorization: `Token ${import.meta.env.VITE_EXACT_TOKEN}` }
+    : {},
+});
+
+const rootEl = document.getElementById("root");
+if (!rootEl) throw new Error("#root not found");
+
+createRoot(rootEl).render(
+  <StrictMode>
+    <QueryClientProvider client={queryClient}>
+      <div style={{ padding: "1rem", fontFamily: "sans-serif" }}>
+        <h1 style={{ margin: 0, fontSize: "1.25rem" }}>
+          EXACT Federation Dev Harness
+        </h1>
+        <p style={{ color: "#6b7280", marginTop: "0.25rem" }}>
+          Scaffold. CTOMOP picker + token login arrive in #104.
+        </p>
+        <hr style={{ margin: "1rem 0", border: "none", borderTop: "1px solid #e5e7eb" }} />
+        <TrialMatches apiClient={apiClient} queryClient={queryClient} />
+      </div>
+    </QueryClientProvider>
+  </StrictMode>,
+);

--- a/frontend/src/federation/TrialMatches.tsx
+++ b/frontend/src/federation/TrialMatches.tsx
@@ -1,0 +1,38 @@
+// Scaffold for the federated `./TrialMatches` export (#103, part of #101).
+// This file deliberately renders a placeholder — the real component
+// (filters, eligibility grouping, distance sort, trial detail) lands in
+// #104. Keeping the export shape stable now means hosts can wire the
+// remote before the component body is filled in.
+import { useEffect } from "react";
+
+import { injectStyles } from "./injectStyles";
+import type { TrialMatchesProps } from "./types";
+
+export function TrialMatches(_props: TrialMatchesProps) {
+  useEffect(() => {
+    injectStyles();
+  }, []);
+
+  return (
+    <div className="exact-root" style={{ padding: "1.5rem" }}>
+      <div
+        style={{
+          borderRadius: "var(--exact-border-radius)",
+          background: "var(--exact-color-surface)",
+          border: "1px solid var(--exact-color-border)",
+          padding: "1.5rem",
+          color: "var(--exact-color-text)",
+        }}
+      >
+        <h2 style={{ marginTop: 0, color: "var(--exact-color-primary)" }}>
+          EXACT Trial Matches
+        </h2>
+        <p style={{ color: "var(--exact-color-text-muted)" }}>
+          Federated component scaffold. Real rendering lands in #104.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+export default TrialMatches;

--- a/frontend/src/federation/exact.css
+++ b/frontend/src/federation/exact.css
@@ -1,0 +1,39 @@
+/* Tailwind v4: import theme + utilities ONLY. Skipping `preflight.css`
+ * keeps Tailwind's global CSS reset (`* { margin: 0 }`, `html,body`
+ * resets, default font-family stripping, etc.) out of the federated
+ * bundle so the host's existing styles aren't clobbered when this remote
+ * mounts. Same trade-off documented in SoC. */
+@layer theme, utilities;
+@import "tailwindcss/theme.css" layer(theme);
+@import "tailwindcss/utilities.css" layer(utilities);
+
+@source "./**/*.tsx";
+
+/* Scoped tokens. The host can override any `--exact-*` var on `:root`
+ * or on a `.exact-root` ancestor without colliding with its own design
+ * system. Per hk-labs `docs/module-federation.md` CSS token contract. */
+.exact-root {
+  --exact-color-primary: #0c5fc0;
+  --exact-color-eligible: #16a34a;
+  --exact-color-potential: #f59e0b;
+  --exact-color-not-eligible: #dc2626;
+  --exact-color-muted: #6b7280;
+  --exact-color-surface: #ffffff;
+  --exact-color-border: #e5e7eb;
+  --exact-color-text: #111827;
+  --exact-color-text-muted: #4b5563;
+  --exact-font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+    "Helvetica Neue", Arial, sans-serif;
+  --exact-border-radius: 0.5rem;
+
+  font-family: var(--exact-font-family);
+  color: var(--exact-color-text);
+  /* Re-introduce only the box-sizing rule preflight would have given us,
+   * scoped to the remote so we don't reach outside `.exact-root`. */
+  box-sizing: border-box;
+}
+.exact-root *,
+.exact-root *::before,
+.exact-root *::after {
+  box-sizing: inherit;
+}

--- a/frontend/src/federation/injectStyles.ts
+++ b/frontend/src/federation/injectStyles.ts
@@ -1,0 +1,37 @@
+// Boring CSS injection. One <style> tag, no fonts (host owns typography),
+// idempotent across re-mounts. Tokens are scoped under `.exact-root`, so
+// a missing one fails visibly inside the remote and doesn't poison the
+// host. Mirrors SoC's `injectStyles.ts`.
+import css from "./exact.css?inline";
+
+let injected = false;
+
+export function injectStyles(): void {
+  if (injected || typeof document === "undefined") return;
+  injected = true;
+  const style = document.createElement("style");
+  style.setAttribute("data-mf", "exact-remote");
+  style.textContent = css;
+  document.head.appendChild(style);
+}
+
+/** Dev-only sanity check that the host (or this remote) actually set the
+ *  `--exact-*` tokens we depend on. Per hk-labs module-federation.md
+ *  recommendation — call from the harness during dev to catch missing
+ *  token overrides early. Portal-safe: reads tokens from `:root`, not
+ *  from a component that may sit inside a dialog/portal where computed
+ *  styles see the dialog's own root. */
+export function assertExactTokens(): string[] {
+  if (typeof document === "undefined") return [];
+  const required = [
+    "--exact-color-primary",
+    "--exact-color-eligible",
+    "--exact-color-potential",
+    "--exact-color-not-eligible",
+    "--exact-color-surface",
+    "--exact-color-border",
+    "--exact-color-text",
+  ];
+  const styles = getComputedStyle(document.documentElement);
+  return required.filter((name) => !styles.getPropertyValue(name).trim());
+}

--- a/frontend/src/federation/types.ts
+++ b/frontend/src/federation/types.ts
@@ -1,0 +1,88 @@
+// TypeScript mirrors of the response shapes EXACT's `/trials/` endpoint
+// returns. Source of truth: `trials/api/trials_serializers.py`
+// (`TrialSerializer`, `TrialDetailsSerializer`) — JSON is camelCased via
+// `djangorestframework-camel-case`. These types are kept permissive
+// on purpose so a new optional field on the backend doesn't break the
+// remote at runtime.
+
+import type { AxiosInstance } from "axios";
+import type { QueryClient } from "@tanstack/react-query";
+
+/** Sparse, schema-tolerant patient payload — mirrors EXACT's stateless
+ *  `PatientInfo` Python class. Keys are camelCase as sent over the wire.
+ *  See `trials/services/patient_info/patient_info.py`. */
+export type PatientInfo = Record<string, unknown>;
+
+// Per-trial verdict returned by the matcher. `matchingType` on each trial
+// in the `/trials/` response. The matcher emits one of these three; the UI
+// groups results by this value.
+export type MatchingType = "eligible" | "potential" | "not_eligible";
+
+export interface TrialMatch {
+  id: number;
+  code: string;
+  studyId?: string;
+  briefTitle?: string;
+  officialTitle?: string;
+  register?: string;
+  recruitmentStatus?: string;
+  phases?: string[];
+  matchScore?: number | null;
+  goodnessScore?: number | null;
+  matchingType?: MatchingType;
+  disease?: string | null;
+  // Distance to the nearest matching location (km/mi), populated when
+  // the caller passes geo/distance prefs. Set to `null` for trials with
+  // no matching location.
+  distance?: number | null;
+  // The full serializer carries many more fields (locations, contacts,
+  // etc.). Permissive index lets the UI surface them without a type
+  // change when needed.
+  [key: string]: unknown;
+}
+
+export interface TrialsResponse {
+  count: number;
+  next?: string | null;
+  previous?: string | null;
+  results: TrialMatch[];
+}
+
+/** Filter prefs the UI surfaces. Keys mirror what
+ *  `study_preferences_from_query_params` consumes (see #44 / #63 / #102). */
+export interface FilterState {
+  recruitmentStatus?: string;
+  country?: string;
+  region?: string;
+  trialType?: string;
+  trialPurpose?: string;
+  studyType?: string;
+  distance?: number;
+  distanceUnits?: "km" | "mi";
+  validatedOnly?: boolean;
+  sponsor?: string;
+  register?: string;
+}
+
+/** Public props for the federated `./TrialMatches` export. Host-agnostic:
+ *  the host wires its own axios instance (with `Authorization: Token …`)
+ *  and either a person_id (CTOMOP federation path) or an inline payload
+ *  (legacy CB path). */
+export interface TrialMatchesProps {
+  /** Axios instance pre-configured with `baseURL` (e.g. `/api`) and
+   *  `Authorization: Token <…>` header. Required. */
+  apiClient: AxiosInstance;
+  /** Optional shared TanStack QueryClient — when omitted, the component
+   *  spins up its own. Set when the host wants to share the cache. */
+  queryClient?: QueryClient;
+  /** CTOMOP person_id. Mutually exclusive with `patientInfo` — when
+   *  both are provided, `patientInfo` wins (matches the server-side
+   *  precedence in `resolve_patient_info`). */
+  personId?: string | number;
+  /** Inline patient payload. The other half of the resolver contract. */
+  patientInfo?: PatientInfo | null;
+  /** Initial filter state. The UI lets the user mutate from here. */
+  initialFilters?: FilterState;
+  /** Called when the user opens a trial card / detail view. */
+  onTrialSelect?: (trial: TrialMatch) => void;
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,30 @@
+// SPA harness entry — `npm run dev` boots this. Renders the federated
+// `TrialMatches` component with a minimal local axios instance so you
+// can iterate on the remote without standing up CTOMOP.
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import axios from "axios";
+
+import { TrialMatches } from "./federation/TrialMatches";
+
+const queryClient = new QueryClient();
+const apiClient = axios.create({
+  baseURL: "/api",
+  // Token auth: paste your DRF token here for local dev, or wire a
+  // real login flow in the dev harness (`src/dev/dev-harness.tsx`).
+  headers: import.meta.env.VITE_EXACT_TOKEN
+    ? { Authorization: `Token ${import.meta.env.VITE_EXACT_TOKEN}` }
+    : {},
+});
+
+const rootEl = document.getElementById("root");
+if (!rootEl) throw new Error("#root not found");
+
+createRoot(rootEl).render(
+  <StrictMode>
+    <QueryClientProvider client={queryClient}>
+      <TrialMatches apiClient={apiClient} queryClient={queryClient} />
+    </QueryClientProvider>
+  </StrictMode>,
+);

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,0 +1,13 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_EXACT_API_PROXY_TARGET?: string;
+  readonly VITE_CTOMOP_LOCAL_TARGET?: string;
+  readonly VITE_CTOMOP_STAGING_TARGET?: string;
+  readonly VITE_CTOMOP_BASE?: string;
+  readonly VITE_EXACT_TOKEN?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "skipLibCheck": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowSyntheticDefaultImports": true,
+    "strict": true
+  },
+  "include": ["vite.config.ts", "vite.remote.config.ts"]
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,39 @@
+import dns from "node:dns";
+import path from "node:path";
+import { defineConfig, loadEnv } from "vite";
+import react from "@vitejs/plugin-react";
+import tailwindcss from "@tailwindcss/vite";
+
+// Resolve `localhost` to 127.0.0.1 (IPv4) before ::1 so the Vite dev proxy
+// reaches Django's runserver, which only binds to IPv4 by default.
+dns.setDefaultResultOrder("ipv4first");
+
+// SPA build / dev server. Used for `npm run dev` (standalone SPA) and
+// `npm run build:spa` (host-agnostic harness output). The federated remote
+// is built by `vite.remote.config.ts`.
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), "");
+  const apiProxyTarget = env.VITE_EXACT_API_PROXY_TARGET || "http://localhost:8000";
+
+  return {
+    plugins: [react(), tailwindcss()],
+    resolve: {
+      alias: { "@": path.resolve(__dirname, "./src") },
+    },
+    server: {
+      port: 5178,
+      strictPort: true,
+      proxy: {
+        // EXACT's API runs on Django; the harness calls
+        //   /api/trials/...      → http://localhost:8000/trials/...
+        //   /api/form-settings/  → http://localhost:8000/form-settings/
+        // The proxy strips the `/api` mount so Django sees its own paths.
+        "/api": {
+          target: apiProxyTarget,
+          changeOrigin: true,
+          rewrite: (p) => p.replace(/^\/api/, ""),
+        },
+      },
+    },
+  };
+});

--- a/frontend/vite.remote.config.ts
+++ b/frontend/vite.remote.config.ts
@@ -1,0 +1,134 @@
+import dns from "node:dns";
+import path from "node:path";
+import { defineConfig, loadEnv, type Plugin, type ProxyOptions } from "vite";
+import react from "@vitejs/plugin-react";
+import tailwindcss from "@tailwindcss/vite";
+import { federation } from "@module-federation/vite";
+
+dns.setDefaultResultOrder("ipv4first");
+
+// When the dev:remote server is hit at `/`, serve the dev harness instead of
+// the SPA index. This lets `npm run dev:remote` boot a standalone surface
+// that exercises the exposed `./TrialMatches` module exactly the way a host
+// would consume it.
+function devHarnessRedirect(): Plugin {
+  return {
+    name: "exact-dev-harness-redirect",
+    configureServer(server) {
+      server.middlewares.use((req, _res, next) => {
+        if (req.url === "/" || req.url === "/index.html") {
+          req.url = "/dev-harness.html";
+        }
+        next();
+      });
+    },
+  };
+}
+
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), "");
+  const apiProxyTarget = env.VITE_EXACT_API_PROXY_TARGET || "http://localhost:8000";
+  // Two named CTOMOP backends, each behind its own proxy path so the dev
+  // harness can flip between them via a tab without losing the staging
+  // session when local is running. Mirror SoC's naming so the harness
+  // ports cleanly.
+  const ctomopLocalTarget =
+    env.VITE_CTOMOP_LOCAL_TARGET || "http://localhost:8001";
+  const ctomopStagingTarget =
+    env.VITE_CTOMOP_STAGING_TARGET || "https://ctomop.onrender.com";
+
+  // Shared http-proxy cookie-rewrite. Strips Secure/SameSite=None and
+  // rescopes Path=/ to the proxy mount point so plain-http localhost dev
+  // keeps a working session cookie AND CTOMOP cookies don't leak to every
+  // other localhost service.
+  const makeCookieRewriter = (mountPath: string): ProxyOptions["configure"] => {
+    const rewriteCookie = (raw: string): string =>
+      raw
+        .replace(/;\s*Secure/gi, "")
+        .replace(/;\s*SameSite=None/gi, "; SameSite=Lax")
+        .replace(/(;\s*Path=)\/(?=;|$)/gi, `$1${mountPath}`);
+
+    return (proxy) => {
+      proxy.on("proxyRes", (proxyRes) => {
+        const sc = proxyRes.headers["set-cookie"];
+        if (Array.isArray(sc)) {
+          proxyRes.headers["set-cookie"] = sc.map(rewriteCookie);
+        } else if (typeof sc === "string") {
+          proxyRes.headers["set-cookie"] = [rewriteCookie(sc)];
+        }
+      });
+    };
+  };
+
+  return {
+    plugins: [
+      devHarnessRedirect(),
+      react(),
+      tailwindcss(),
+      federation({
+        name: "exact_remote",
+        filename: "remoteEntry.js",
+        exposes: {
+          "./TrialMatches": "./src/federation/TrialMatches.tsx",
+          "./types": "./src/federation/types.ts",
+        },
+        // Same singletons as SoC / hk-labs so a host that loads multiple
+        // remotes shares one React tree and one query cache. No
+        // radix/recharts yet — add them here when this remote uses them.
+        shared: {
+          react: { singleton: true, strictVersion: false },
+          "react-dom": { singleton: true, strictVersion: false },
+          "react/jsx-runtime": { singleton: true, strictVersion: false },
+          "react/jsx-dev-runtime": { singleton: true, strictVersion: false },
+          "@tanstack/react-query": { singleton: true, strictVersion: false },
+          axios: { singleton: true, strictVersion: false },
+        },
+        dts: false,
+      }),
+    ],
+    resolve: {
+      alias: { "@": path.resolve(__dirname, "./src") },
+    },
+    cacheDir: "node_modules/.vite-remote",
+    build: {
+      outDir: "dist/remote",
+      target: "esnext",
+      // Explicit empty input: only the federation plugin's `remoteEntry.js`
+      // + exposed modules end up in `dist/remote/`. Without this, Vite
+      // auto-discovers `index.html` and would pull in the dev harness +
+      // any future fixtures into the published bundle — leaking harness
+      // assets to every host that mounts the remote. Mirrors SoC.
+      rollupOptions: { input: {} },
+    },
+    server: {
+      port: 5177,
+      strictPort: true,
+      proxy: {
+        "/api": {
+          target: apiProxyTarget,
+          changeOrigin: true,
+          rewrite: (p) => p.replace(/^\/api/, ""),
+        },
+        // CTOMOP proxies for the dev harness:
+        //   /ctomop-local/api/...   → http://localhost:8001
+        //   /ctomop-staging/api/... → https://ctomop.onrender.com
+        // Going same-origin via the proxy is the only path where CTOMOP's
+        // SESSION_COOKIE_SECURE = True cookie survives a plain-http dev
+        // loop. Set-Cookie is rewritten so the cookie scopes to the
+        // proxy mount (sessions don't collide between local + staging).
+        "/ctomop-local": {
+          target: ctomopLocalTarget,
+          changeOrigin: true,
+          rewrite: (p) => p.replace(/^\/ctomop-local/, ""),
+          configure: makeCookieRewriter("/ctomop-local"),
+        },
+        "/ctomop-staging": {
+          target: ctomopStagingTarget,
+          changeOrigin: true,
+          rewrite: (p) => p.replace(/^\/ctomop-staging/, ""),
+          configure: makeCookieRewriter("/ctomop-staging"),
+        },
+      },
+    },
+  };
+});


### PR DESCRIPTION
Closes #103 (Track B of #101). Stands up `frontend/` mirroring SoC / ctomop / hk-labs so EXACT can ship a federated React 19 remote that hosts mount alongside the other org remotes with one React tree + one TanStack QueryClient.

## Layout

| File | What |
|------|------|
| `frontend/package.json` | Vite + React 19 + Tailwind v4 + module federation. `@module-federation/vite` is exact `1.15.5` (no caret — runtime contract brittle to minor bumps). |
| `frontend/tsconfig.json` + `tsconfig.node.json` | Strict mode, `noUnusedLocals/Parameters`, `react-jsx` transform. |
| `frontend/vite.config.ts` | SPA harness (`npm run dev`, port 5178). `/api` proxy to Django on `:8000`. |
| `frontend/vite.remote.config.ts` | Federation remote (`npm run dev:remote`, port 5177). Exposes `./TrialMatches` + `./types`. Includes `devHarnessRedirect()` plugin, `rollupOptions.input: {}` so harness assets stay out of `dist/remote/`, and CTOMOP proxies (`/ctomop-local`, `/ctomop-staging`) with Set-Cookie rewriting (CTOMOP's `SESSION_COOKIE_SECURE = True` cookie needs same-origin proxying to survive plain-http dev). |
| `frontend/src/federation/TrialMatches.tsx` | Placeholder. Real component lands in #104. |
| `frontend/src/federation/types.ts` | `TrialMatch`, `TrialsResponse`, `FilterState`, `TrialMatchesProps`. Mirrors EXACT's `TrialSerializer` (camelCase via `djangorestframework-camel-case`). |
| `frontend/src/federation/exact.css` + `injectStyles.ts` | CSS token contract on `--exact-*` per hk-labs `docs/module-federation.md`. Tailwind v4 theme+utilities only (skipping `preflight.css` so host reset isn't clobbered). `assertExactTokens()` for missing-token dev check. |
| `frontend/src/main.tsx` | SPA harness entry. |
| `frontend/src/dev/dev-harness.tsx` | Federation harness entry, scaffold version. CTOMOP picker + token-login flow arrive in #104. |

## Shared singletons

`react`, `react-dom`, `react/jsx-runtime`, `react/jsx-dev-runtime`, `@tanstack/react-query`, `axios` — matching SoC / hk-labs so a host loading multiple remotes shares one React tree. No radix/recharts yet — added when this remote uses them.

## CI

`.github/workflows/frontend.yml` runs on `frontend/**` changes: `npm install` (falls back from `ci` when the scaffold ships without a lockfile), `typecheck`, `build` (federation). Uses no untrusted GitHub event inputs in run commands (security-guidance compliant).

## What I couldn't validate locally

I have no node/browser in this environment, so I can't run `npm install && npm run dev:remote` to confirm the federation server actually boots. Configs mirror SoC byte-for-byte where possible, JSON files validate, TypeScript syntax is checked by hand. **CI will catch typecheck + build failures** at PR time — that's the validation path for this scaffold.

## Out of scope — next PRs

- **#104** — `TrialMatches` component body (filters, eligibility grouping, distance sort, trial detail) + CTOMOP picker harness + token-login flow.
- **#101** closes when #104 ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)