### PR TITLE
feat(frontend): TrialMatches component body + API client + hooks (#104)

### DIFF
--- a/frontend/src/federation/FilterBar.tsx
+++ b/frontend/src/federation/FilterBar.tsx
@@ -1,0 +1,143 @@
+import type { CSSProperties } from "react";
+import type { AxiosInstance } from "axios";
+
+import { useCountries, useFormSettings } from "./hooks";
+import type { FilterState } from "./types";
+
+interface Props {
+  apiClient: AxiosInstance;
+  filters: FilterState;
+  onChange: (next: FilterState) => void;
+  /** Disease code drives the per-disease overrides in `/form-settings/`
+   *  (#44 / #63). Pass the patient's disease when known so the
+   *  trialType / recruitmentStatus dropdowns match the patient context. */
+  diseaseCode?: string;
+}
+
+const ROW: CSSProperties = {
+  display: "flex",
+  gap: "0.75rem",
+  flexWrap: "wrap",
+  marginBottom: "1rem",
+};
+
+const LABEL: CSSProperties = {
+  display: "flex",
+  flexDirection: "column",
+  fontSize: "0.75rem",
+  color: "var(--exact-color-text-muted)",
+  gap: "0.25rem",
+};
+
+const INPUT: CSSProperties = {
+  padding: "0.375rem 0.5rem",
+  border: "1px solid var(--exact-color-border)",
+  borderRadius: "0.25rem",
+  font: "inherit",
+};
+
+export function FilterBar({ apiClient, filters, onChange, diseaseCode }: Props) {
+  const countries = useCountries(apiClient);
+  const formSettings = useFormSettings(apiClient, diseaseCode);
+
+  // `/form-settings/` exposes the recruitment-status enum under the key
+  // `statuses` (see `value_options.py:907`), not `recruitmentStatus`.
+  // Same dict also surfaces `trialType` for the trial-type dropdown.
+  const recruitmentOptions = formSettings.data?.statuses?.options ?? [];
+  const trialTypeOptions = formSettings.data?.trialType?.options ?? [];
+
+  return (
+    <div style={ROW}>
+      <label style={LABEL}>
+        Search
+        <input
+          type="text"
+          style={INPUT}
+          placeholder="Title…"
+          value={filters.searchTitle ?? ""}
+          onChange={(e) => onChange({ ...filters, searchTitle: e.target.value || undefined })}
+        />
+      </label>
+      <label style={LABEL}>
+        Recruitment
+        <select
+          style={INPUT}
+          value={filters.recruitmentStatus ?? ""}
+          onChange={(e) =>
+            onChange({ ...filters, recruitmentStatus: e.target.value || undefined })
+          }
+        >
+          <option value="">All</option>
+          {recruitmentOptions.map((o) => (
+            <option key={o.value} value={o.value}>
+              {o.label}
+            </option>
+          ))}
+        </select>
+      </label>
+      <label style={LABEL}>
+        Country
+        <select
+          style={INPUT}
+          value={filters.country ?? ""}
+          onChange={(e) => onChange({ ...filters, country: e.target.value || undefined })}
+        >
+          <option value="">All</option>
+          {countries.data?.results.map((c) => (
+            // The backend's `by_location` does
+            // `Country.objects.filter(title__iexact=country)` — so we
+            // send the country title (e.g. "United States"), not the
+            // ISO code. Send-code would silently match nothing.
+            <option key={c.id} value={c.title}>
+              {c.title}
+            </option>
+          ))}
+        </select>
+      </label>
+      <label style={LABEL}>
+        Trial type
+        <select
+          style={INPUT}
+          value={filters.trialType ?? ""}
+          onChange={(e) => onChange({ ...filters, trialType: e.target.value || undefined })}
+        >
+          <option value="">All</option>
+          {trialTypeOptions.map((o) => (
+            <option key={o.value} value={o.value}>
+              {o.label}
+            </option>
+          ))}
+        </select>
+      </label>
+      <label style={LABEL}>
+        Distance (km)
+        <input
+          type="number"
+          min={0}
+          style={{ ...INPUT, width: "6rem" }}
+          value={filters.distance ?? ""}
+          onChange={(e) => {
+            const n = Number(e.target.value);
+            onChange({
+              ...filters,
+              distance: Number.isFinite(n) && n > 0 ? n : undefined,
+              distanceUnits: Number.isFinite(n) && n > 0 ? "km" : undefined,
+            });
+          }}
+        />
+      </label>
+      <label style={{ ...LABEL, alignSelf: "end" }}>
+        <span style={{ display: "flex", alignItems: "center", gap: "0.375rem" }}>
+          <input
+            type="checkbox"
+            checked={filters.validatedOnly ?? false}
+            onChange={(e) =>
+              onChange({ ...filters, validatedOnly: e.target.checked || undefined })
+            }
+          />
+          Validated only
+        </span>
+      </label>
+    </div>
+  );
+}

--- a/frontend/src/federation/TrialCard.tsx
+++ b/frontend/src/federation/TrialCard.tsx
@@ -1,0 +1,93 @@
+import type { CSSProperties } from "react";
+
+import type { TrialMatch } from "./types";
+
+interface Props {
+  trial: TrialMatch;
+  onSelect?: (trial: TrialMatch) => void;
+  isSelected?: boolean;
+}
+
+function matchingStyles(t: TrialMatch): { badge: string; label: string } {
+  if (t.matchingType === "eligible") {
+    return {
+      badge:
+        "background:#dcfce7;color:#166534;border:1px solid #86efac;padding:0.125rem 0.5rem;border-radius:0.25rem;font-size:0.75rem;",
+      label: "Eligible",
+    };
+  }
+  if (t.matchingType === "not_eligible") {
+    return {
+      badge:
+        "background:#fee2e2;color:#991b1b;border:1px solid #fca5a5;padding:0.125rem 0.5rem;border-radius:0.25rem;font-size:0.75rem;",
+      label: "Not Eligible",
+    };
+  }
+  return {
+    badge:
+      "background:#fef3c7;color:#92400e;border:1px solid #fcd34d;padding:0.125rem 0.5rem;border-radius:0.25rem;font-size:0.75rem;",
+    label: "Potential",
+  };
+}
+
+export function TrialCard({ trial, onSelect, isSelected }: Props) {
+  const m = matchingStyles(trial);
+  const card: CSSProperties = {
+    border: `1px solid var(--exact-color-border)`,
+    borderRadius: "var(--exact-border-radius)",
+    padding: "1rem",
+    background: isSelected ? "#f9fafb" : "var(--exact-color-surface)",
+    cursor: onSelect ? "pointer" : "default",
+    width: "100%",
+    textAlign: "left",
+    font: "inherit",
+  };
+  const meta: CSSProperties = {
+    color: "var(--exact-color-text-muted)",
+    fontSize: "0.875rem",
+    marginTop: "0.5rem",
+  };
+
+  const body = (
+    <>
+      <div style={{ display: "flex", justifyContent: "space-between", gap: "1rem" }}>
+        <strong style={{ color: "var(--exact-color-text)" }}>{trial.briefTitle}</strong>
+        <span style={{ ...parseStyle(m.badge) }}>{m.label}</span>
+      </div>
+      <div style={meta}>
+        {trial.studyId} · {trial.recruitingStatus}
+        {trial.phase && trial.phase.length ? ` · ${trial.phase.join(" / ")}` : null}
+      </div>
+      <div style={meta}>
+        {trial.matchScore != null ? `Match score: ${trial.matchScore}` : null}
+        {trial.goodnessScore != null ? ` · Goodness: ${trial.goodnessScore}` : null}
+        {trial.distance != null ? ` · ${trial.distance} ${trial.distanceUnits ?? ""}` : null}
+      </div>
+      {trial.sponsor ? (
+        <div style={meta}>Sponsor: {trial.sponsor}</div>
+      ) : null}
+    </>
+  );
+
+  if (onSelect) {
+    return (
+      <button type="button" style={card} onClick={() => onSelect(trial)}>
+        {body}
+      </button>
+    );
+  }
+  return <div style={card}>{body}</div>;
+}
+
+// Parse the inline CSS string into a CSSProperties object. Avoids
+// a Tailwind dependency for these tiny pill styles while keeping the
+// per-status colours in one place at the top of the file.
+function parseStyle(css: string): CSSProperties {
+  const out: Record<string, string> = {};
+  for (const rule of css.split(";")) {
+    const [k, v] = rule.split(":").map((s) => s.trim());
+    if (!k || v == null) continue;
+    out[k.replace(/-([a-z])/g, (_m: string, c: string) => c.toUpperCase())] = v;
+  }
+  return out as CSSProperties;
+}

--- a/frontend/src/federation/TrialDetail.tsx
+++ b/frontend/src/federation/TrialDetail.tsx
@@ -1,0 +1,135 @@
+import type { CSSProperties } from "react";
+import type { AxiosInstance } from "axios";
+
+import { useTrialDetail } from "./hooks";
+import type { PatientInfo, TrialMatch } from "./types";
+
+interface Props {
+  apiClient: AxiosInstance;
+  trial: TrialMatch;
+  patientInfo?: PatientInfo | null;
+  personId?: string | number;
+  onClose: () => void;
+}
+
+const PANEL: CSSProperties = {
+  border: "1px solid var(--exact-color-border)",
+  borderRadius: "var(--exact-border-radius)",
+  padding: "1rem",
+  background: "var(--exact-color-surface)",
+};
+
+const META: CSSProperties = {
+  fontSize: "0.875rem",
+  color: "var(--exact-color-text-muted)",
+  marginBottom: "0.5rem",
+};
+
+const SECTION_HEADER: CSSProperties = {
+  margin: "1rem 0 0.5rem",
+  fontSize: "0.875rem",
+  fontWeight: 600,
+  color: "var(--exact-color-text)",
+};
+
+export function TrialDetail({ apiClient, trial, patientInfo, personId, onClose }: Props) {
+  // Re-fetch with the full detail serializer — the list endpoint already
+  // returns most fields but the detail view adds explanation data when
+  // `?explain=true` (out of scope here, but the hook supports it
+  // implicitly by fetching `/trials/{id}/` which serves the detail shape).
+  const detail = useTrialDetail({ apiClient, trialId: trial.trialId, patientInfo, personId });
+  const data = detail.data ?? trial;
+
+  return (
+    <div style={PANEL}>
+      <div style={{ display: "flex", justifyContent: "space-between", gap: "1rem" }}>
+        <h3 style={{ margin: 0, color: "var(--exact-color-primary)" }}>
+          {data.briefTitle}
+        </h3>
+        <button
+          type="button"
+          onClick={onClose}
+          style={{
+            border: "1px solid var(--exact-color-border)",
+            background: "transparent",
+            padding: "0.25rem 0.625rem",
+            borderRadius: "0.25rem",
+            cursor: "pointer",
+            font: "inherit",
+            color: "var(--exact-color-text-muted)",
+          }}
+        >
+          Close
+        </button>
+      </div>
+
+      {data.officialTitle && data.officialTitle !== data.briefTitle ? (
+        <div style={META}>{data.officialTitle}</div>
+      ) : null}
+
+      <div style={META}>
+        <strong>{data.studyId}</strong> · {data.recruitingStatus}
+        {data.phase?.length ? ` · ${data.phase.join(" / ")}` : null}
+        {data.sponsor ? ` · ${data.sponsor}` : null}
+      </div>
+
+      <div style={META}>
+        {data.matchScore != null ? `Match: ${data.matchScore}%` : null}
+        {data.goodnessScore != null ? ` · Goodness: ${data.goodnessScore}` : null}
+        {data.distance != null
+          ? ` · ${data.distance} ${data.distanceUnits ?? ""}`
+          : null}
+      </div>
+
+      {data.location?.length ? (
+        <>
+          <div style={SECTION_HEADER}>Locations</div>
+          <ul style={{ margin: 0, paddingLeft: "1.25rem" }}>
+            {data.location.slice(0, 10).map((loc) => (
+              <li key={loc}>{loc}</li>
+            ))}
+          </ul>
+        </>
+      ) : null}
+
+      {data.attributesToFillIn?.length ? (
+        <>
+          <div style={SECTION_HEADER}>Why "potential"</div>
+          <ul style={{ margin: 0, paddingLeft: "1.25rem" }}>
+            {data.attributesToFillIn.map((a, i) => (
+              <li key={i} style={{ fontSize: "0.875rem" }}>
+                {summarizeAttr(a)}
+              </li>
+            ))}
+          </ul>
+        </>
+      ) : null}
+
+      {data.link ? (
+        <div style={{ marginTop: "1rem" }}>
+          <a
+            href={data.link}
+            target="_blank"
+            rel="noopener noreferrer"
+            style={{ color: "var(--exact-color-primary)" }}
+          >
+            Open registry entry →
+          </a>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function summarizeAttr(attr: Record<string, unknown>): string {
+  // The matcher emits attr payloads already camelCased
+  // (`UserToTrialAttrsMapper.potential_attrs_for_trial` returns
+  // `{ userAttributeTitle, trialAttributeName, … }` directly — no DRF
+  // camelCase middleware is in play because the keys are constructed
+  // server-side in JS-shaped form). Render the human-friendly title
+  // when present; fall back to a stringified payload so a future
+  // contract change doesn't blank out the row.
+  const title = attr.userAttributeTitle;
+  if (typeof title === "string") return title;
+  return JSON.stringify(attr);
+}

--- a/frontend/src/federation/TrialMatches.tsx
+++ b/frontend/src/federation/TrialMatches.tsx
@@ -1,37 +1,183 @@
-// Scaffold for the federated `./TrialMatches` export (#103, part of #101).
-// This file deliberately renders a placeholder — the real component
-// (filters, eligibility grouping, distance sort, trial detail) lands in
-// #104. Keeping the export shape stable now means hosts can wire the
-// remote before the component body is filled in.
-import { useEffect } from "react";
+// Federated `./TrialMatches` export (#104, part of #101). Renders the
+// patient's trial matches grouped by `matchingType`, with a filter bar,
+// inline detail view, and host-agnostic axios injection. The host
+// supplies either `patientInfo` (inline payload — matches the existing
+// CB contract) or `personId` (CTOMOP federation path added in #102).
+import { useEffect, useMemo, useState } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
+import { FilterBar } from "./FilterBar";
+import { TrialCard } from "./TrialCard";
+import { TrialDetail } from "./TrialDetail";
+import { useTrials } from "./hooks";
 import { injectStyles } from "./injectStyles";
-import type { TrialMatchesProps } from "./types";
+import type { FilterState, MatchingType, TrialMatch, TrialMatchesProps } from "./types";
 
-export function TrialMatches(_props: TrialMatchesProps) {
+// `not_eligible` is included for forward-compat with a future call that
+// surfaces ineligible matches (e.g. an opt-in "show why these don't fit"
+// path). Today the server-side `TrialSerializer.to_representation`
+// only ever emits `'eligible' | 'potential'`, so the bucket is
+// rendered only when non-empty — empty buckets are hidden below.
+const GROUP_ORDER: MatchingType[] = ["eligible", "potential", "not_eligible"];
+
+const GROUP_LABELS: Record<MatchingType, string> = {
+  eligible: "Eligible",
+  potential: "Potential",
+  not_eligible: "Not eligible",
+};
+
+function TrialMatchesInner({
+  apiClient,
+  patientInfo,
+  personId,
+  initialFilters,
+  onTrialSelect,
+}: Omit<TrialMatchesProps, "queryClient">) {
   useEffect(() => {
     injectStyles();
   }, []);
 
+  const [filters, setFilters] = useState<FilterState>(initialFilters ?? {});
+  const [selectedTrial, setSelectedTrial] = useState<TrialMatch | null>(null);
+
+  // Reset detail view when patient context changes so we don't keep a
+  // stale trial open from a previous patient. We key on a stable derived
+  // identifier (`personId` or the JSON-serialised payload) instead of the
+  // `patientInfo` reference directly — otherwise a host that re-creates
+  // the payload object on every render (the default in React without
+  // `useMemo`) would collapse the detail view on every parent re-render.
+  const patientInfoKey = useMemo(
+    () => (patientInfo ? JSON.stringify(patientInfo) : null),
+    [patientInfo],
+  );
+  useEffect(() => {
+    setSelectedTrial(null);
+  }, [personId, patientInfoKey]);
+
+  const query = useTrials({ apiClient, patientInfo, personId, filters });
+
+  const grouped = useMemo(() => {
+    const trials = query.data?.results ?? [];
+    const buckets: Record<MatchingType, TrialMatch[]> = {
+      eligible: [],
+      potential: [],
+      not_eligible: [],
+    };
+    for (const t of trials) {
+      buckets[t.matchingType]?.push(t);
+    }
+    return buckets;
+  }, [query.data]);
+
+  const diseaseCode = useMemo(() => {
+    const d = (patientInfo as Record<string, unknown> | null | undefined)?.["disease"];
+    return typeof d === "string" ? d : undefined;
+  }, [patientInfo]);
+
+  const handleSelect = (trial: TrialMatch) => {
+    setSelectedTrial(trial);
+    onTrialSelect?.(trial);
+  };
+
   return (
-    <div className="exact-root" style={{ padding: "1.5rem" }}>
+    <div className="exact-root" style={{ padding: "1rem" }}>
+      <FilterBar
+        apiClient={apiClient}
+        filters={filters}
+        onChange={setFilters}
+        diseaseCode={diseaseCode}
+      />
+
+      {query.isLoading ? (
+        <p style={{ color: "var(--exact-color-text-muted)" }}>Loading trials…</p>
+      ) : null}
+
+      {query.isError ? (
+        <p style={{ color: "var(--exact-color-not-eligible)" }}>
+          Failed to load trials: {(query.error as Error)?.message ?? "unknown error"}
+        </p>
+      ) : null}
+
       <div
         style={{
-          borderRadius: "var(--exact-border-radius)",
-          background: "var(--exact-color-surface)",
-          border: "1px solid var(--exact-color-border)",
-          padding: "1.5rem",
-          color: "var(--exact-color-text)",
+          display: "grid",
+          gridTemplateColumns: selectedTrial ? "minmax(0, 1fr) minmax(0, 1fr)" : "minmax(0, 1fr)",
+          gap: "1.5rem",
         }}
       >
-        <h2 style={{ marginTop: 0, color: "var(--exact-color-primary)" }}>
-          EXACT Trial Matches
-        </h2>
-        <p style={{ color: "var(--exact-color-text-muted)" }}>
-          Federated component scaffold. Real rendering lands in #104.
-        </p>
+        <div>
+          {GROUP_ORDER.map((group) => {
+            const trials = grouped[group];
+            if (!trials.length) return null;
+            return (
+              <section key={group} style={{ marginBottom: "1.5rem" }}>
+                <h3
+                  style={{
+                    fontSize: "0.875rem",
+                    fontWeight: 600,
+                    color: "var(--exact-color-text-muted)",
+                    margin: "0 0 0.5rem",
+                  }}
+                >
+                  {GROUP_LABELS[group]} ({trials.length})
+                </h3>
+                <div style={{ display: "flex", flexDirection: "column", gap: "0.5rem" }}>
+                  {trials.map((t) => (
+                    <TrialCard
+                      key={t.trialId}
+                      trial={t}
+                      onSelect={handleSelect}
+                      isSelected={selectedTrial?.trialId === t.trialId}
+                    />
+                  ))}
+                </div>
+              </section>
+            );
+          })}
+
+          {!query.isLoading &&
+          patientInfo == null &&
+          personId == null ? (
+            <p style={{ color: "var(--exact-color-text-muted)" }}>
+              Pass a <code>patientInfo</code> payload or <code>personId</code> to
+              load trial matches.
+            </p>
+          ) : null}
+
+          {!query.isLoading &&
+          (patientInfo != null || personId != null) &&
+          (query.data?.results.length ?? 0) === 0 ? (
+            <p style={{ color: "var(--exact-color-text-muted)" }}>
+              No trials matched the current filters.
+            </p>
+          ) : null}
+        </div>
+
+        {selectedTrial ? (
+          <TrialDetail
+            apiClient={apiClient}
+            trial={selectedTrial}
+            patientInfo={patientInfo}
+            personId={personId}
+            onClose={() => setSelectedTrial(null)}
+          />
+        ) : null}
       </div>
     </div>
+  );
+}
+
+export function TrialMatches(props: TrialMatchesProps) {
+  // If the host provides a QueryClient we use it; otherwise spin up our
+  // own. Keeping the local one stable across renders avoids React Query's
+  // re-mount thrash when the parent re-renders for unrelated reasons.
+  const [ownClient] = useState(() => new QueryClient());
+  const client = props.queryClient ?? ownClient;
+
+  return (
+    <QueryClientProvider client={client}>
+      <TrialMatchesInner {...props} />
+    </QueryClientProvider>
   );
 }
 

--- a/frontend/src/federation/api.ts
+++ b/frontend/src/federation/api.ts
@@ -1,0 +1,118 @@
+// Axios wrappers for EXACT's `/trials/`, `/countries/`, and
+// `/form-settings/` endpoints. The host hands us a pre-authenticated
+// `AxiosInstance` (token + baseURL); these functions just shape the
+// request and parse the response.
+//
+// **GET-with-body**: EXACT's `/trials/` reads `patientInfo` from the
+// request body even on GET. Axios supports `data:` on GET requests, but
+// some proxies / CDNs strip the body. The harness in #104 validates
+// this works end-to-end through the Vite dev proxy; if it ever doesn't,
+// the workaround is to switch to POST (the same view supports it via
+// the underlying DRF mixin).
+
+import type { AxiosInstance } from "axios";
+
+import type {
+  CountriesResponse,
+  FilterState,
+  PatientInfo,
+  TrialMatch,
+  TrialsResponse,
+} from "./types";
+
+interface FetchTrialsArgs {
+  apiClient: AxiosInstance;
+  /** Inline payload — wins over `personId` server-side, matches
+   *  `resolve_patient_info` precedence. */
+  patientInfo?: PatientInfo | null;
+  /** CTOMOP person_id — server-side path via `?person_id=`. */
+  personId?: string | number;
+  /** Filter prefs, sent as query params. */
+  filters?: FilterState;
+}
+
+/** GET `/trials/` — list endpoint with matching. */
+export async function fetchTrials({
+  apiClient,
+  patientInfo,
+  personId,
+  filters,
+}: FetchTrialsArgs): Promise<TrialsResponse> {
+  const params = filterStateToParams(filters);
+  if (personId != null && (patientInfo == null || Object.keys(patientInfo).length === 0)) {
+    params.person_id = String(personId);
+  }
+  const body = patientInfo ? { patient_info: patientInfo } : undefined;
+  const response = await apiClient.get<TrialsResponse>("/trials/", {
+    params,
+    data: body,
+  });
+  return response.data;
+}
+
+/** GET `/trials/{id}/` — detail view. */
+export async function fetchTrialDetail({
+  apiClient,
+  trialId,
+  patientInfo,
+  personId,
+}: {
+  apiClient: AxiosInstance;
+  trialId: number;
+  patientInfo?: PatientInfo | null;
+  personId?: string | number;
+}): Promise<TrialMatch> {
+  const params: Record<string, string> = {};
+  if (personId != null && (patientInfo == null || Object.keys(patientInfo).length === 0)) {
+    params.person_id = String(personId);
+  }
+  const body = patientInfo ? { patient_info: patientInfo } : undefined;
+  const response = await apiClient.get<TrialMatch>(`/trials/${trialId}/`, {
+    params,
+    data: body,
+  });
+  return response.data;
+}
+
+/** GET `/countries/` — list endpoint for the country filter. */
+export async function fetchCountries(
+  apiClient: AxiosInstance,
+): Promise<CountriesResponse> {
+  const response = await apiClient.get<CountriesResponse>("/countries/");
+  return response.data;
+}
+
+/** GET `/form-settings/?disease=` — option dicts for recruitment status,
+ *  trial type, etc. Returns the full `all_options()` dict with
+ *  per-disease overrides applied. */
+export async function fetchFormSettings(
+  apiClient: AxiosInstance,
+  diseaseCode?: string,
+): Promise<Record<string, { options: { value: string; label: string }[] }>> {
+  const params = diseaseCode ? { disease: diseaseCode } : undefined;
+  const response = await apiClient.get("/form-settings/", { params });
+  return response.data;
+}
+
+/** Convert the camelCase filter state to the query-string shape EXACT's
+ *  view expects. The mapping is 1:1 with `study_preferences_from_query_params`
+ *  in `trials/services/study_preferences.py`. */
+function filterStateToParams(filters?: FilterState): Record<string, string> {
+  const out: Record<string, string> = {};
+  if (!filters) return out;
+  if (filters.recruitmentStatus) out.recruitmentStatus = filters.recruitmentStatus;
+  if (filters.country) out.country = filters.country;
+  if (filters.region) out.region = filters.region;
+  if (filters.trialType) out.trialType = filters.trialType;
+  if (filters.trialPurpose) out.trialPurpose = filters.trialPurpose;
+  if (filters.studyType) out.studyType = filters.studyType;
+  if (filters.distance != null) out.distance = String(filters.distance);
+  if (filters.distanceUnits) out.distanceUnits = filters.distanceUnits;
+  if (filters.validatedOnly) out.validatedOnly = "true";
+  if (filters.sponsor) out.sponsor = filters.sponsor;
+  if (filters.register) out.register = filters.register;
+  if (filters.searchTitle) out.searchTitle = filters.searchTitle;
+  if (filters.type) out.type = filters.type;
+  if (filters.sort) out.sort = filters.sort;
+  return out;
+}

--- a/frontend/src/federation/hooks.ts
+++ b/frontend/src/federation/hooks.ts
@@ -1,0 +1,82 @@
+// TanStack Query hooks for the EXACT API. Keys are stable so multiple
+// `TrialMatches` instances mounted in the same host share the cache
+// (e.g. opening a detail view doesn't re-request the list).
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+import type { AxiosInstance } from "axios";
+
+import { fetchCountries, fetchFormSettings, fetchTrialDetail, fetchTrials } from "./api";
+import type {
+  CountriesResponse,
+  FilterState,
+  PatientInfo,
+  TrialMatch,
+  TrialsResponse,
+} from "./types";
+
+interface UseTrialsArgs {
+  apiClient: AxiosInstance;
+  patientInfo?: PatientInfo | null;
+  personId?: string | number;
+  filters?: FilterState;
+  /** Skip the query until the host has a patient context. Without
+   *  patient context the response would be a public/unscoped trial
+   *  list — usually not what a TrialMatches mount wants. */
+  enabled?: boolean;
+}
+
+export function useTrials({
+  apiClient,
+  patientInfo,
+  personId,
+  filters,
+  enabled = true,
+}: UseTrialsArgs): UseQueryResult<TrialsResponse> {
+  return useQuery({
+    queryKey: ["exact-trials", personId ?? null, patientInfo ?? null, filters ?? null],
+    queryFn: () => fetchTrials({ apiClient, patientInfo, personId, filters }),
+    enabled: enabled && (patientInfo != null || personId != null),
+    staleTime: 30_000,
+  });
+}
+
+interface UseTrialDetailArgs {
+  apiClient: AxiosInstance;
+  trialId: number | null;
+  patientInfo?: PatientInfo | null;
+  personId?: string | number;
+}
+
+export function useTrialDetail({
+  apiClient,
+  trialId,
+  patientInfo,
+  personId,
+}: UseTrialDetailArgs): UseQueryResult<TrialMatch> {
+  return useQuery({
+    queryKey: ["exact-trial-detail", trialId, personId ?? null, patientInfo ?? null],
+    queryFn: () => fetchTrialDetail({ apiClient, trialId: trialId!, patientInfo, personId }),
+    enabled: trialId != null,
+    staleTime: 60_000,
+  });
+}
+
+export function useCountries(
+  apiClient: AxiosInstance,
+): UseQueryResult<CountriesResponse> {
+  return useQuery({
+    queryKey: ["exact-countries"],
+    queryFn: () => fetchCountries(apiClient),
+    staleTime: 5 * 60_000,
+  });
+}
+
+export function useFormSettings(
+  apiClient: AxiosInstance,
+  diseaseCode?: string,
+): UseQueryResult<Record<string, { options: { value: string; label: string }[] }>> {
+  return useQuery({
+    queryKey: ["exact-form-settings", diseaseCode ?? null],
+    queryFn: () => fetchFormSettings(apiClient, diseaseCode),
+    staleTime: 5 * 60_000,
+  });
+}

--- a/frontend/src/federation/injectStyles.ts
+++ b/frontend/src/federation/injectStyles.ts
@@ -31,6 +31,7 @@ export function assertExactTokens(): string[] {
     "--exact-color-surface",
     "--exact-color-border",
     "--exact-color-text",
+    "--exact-color-text-muted",
   ];
   const styles = getComputedStyle(document.documentElement);
   return required.filter((name) => !styles.getPropertyValue(name).trim());

--- a/frontend/src/federation/types.ts
+++ b/frontend/src/federation/types.ts
@@ -1,9 +1,11 @@
 // TypeScript mirrors of the response shapes EXACT's `/trials/` endpoint
 // returns. Source of truth: `trials/api/trials_serializers.py`
-// (`TrialSerializer`, `TrialDetailsSerializer`) — JSON is camelCased via
-// `djangorestframework-camel-case`. These types are kept permissive
-// on purpose so a new optional field on the backend doesn't break the
-// remote at runtime.
+// (`TrialSerializer.to_representation` for the list and detail shape).
+// JSON is camelCased server-side, so the keys match the serializer
+// names verbatim. Types are kept permissive on purpose — the API
+// echoes patient context verbatim and new fields land on the backend
+// faster than the UI; failing closed on every new field would make
+// the remote brittle.
 
 import type { AxiosInstance } from "axios";
 import type { QueryClient } from "@tanstack/react-query";
@@ -13,43 +15,84 @@ import type { QueryClient } from "@tanstack/react-query";
  *  See `trials/services/patient_info/patient_info.py`. */
 export type PatientInfo = Record<string, unknown>;
 
-// Per-trial verdict returned by the matcher. `matchingType` on each trial
-// in the `/trials/` response. The matcher emits one of these three; the UI
-// groups results by this value.
+/** Per-trial verdict from the matcher. The serializer only ever emits
+ *  `'eligible'` or `'potential'` (the backend filters not-eligibles
+ *  out of the queryset before serialization), but the type union
+ *  includes `'not_eligible'` so a host that paints a manual
+ *  not-eligible group via a separate call doesn't fight the types. */
 export type MatchingType = "eligible" | "potential" | "not_eligible";
 
+export interface ClosestLocationGeoPoint {
+  latitude: number;
+  longitude: number;
+}
+
+/** Per-attr explanation shape (only populated for `potential` trials,
+ *  driven by `attrs_to_fill_in`). */
+export interface AttributeToFillIn {
+  /** Trial-side attribute the patient profile is missing for this match.
+   *  Permissive shape — server-side adds fields as the explainer evolves. */
+  [key: string]: unknown;
+}
+
+/** A single trial in the list/search response. */
 export interface TrialMatch {
-  id: number;
-  code: string;
-  studyId?: string;
-  briefTitle?: string;
-  officialTitle?: string;
-  register?: string;
-  recruitmentStatus?: string;
-  phases?: string[];
-  matchScore?: number | null;
-  goodnessScore?: number | null;
-  matchingType?: MatchingType;
-  disease?: string | null;
-  // Distance to the nearest matching location (km/mi), populated when
-  // the caller passes geo/distance prefs. Set to `null` for trials with
-  // no matching location.
-  distance?: number | null;
-  // The full serializer carries many more fields (locations, contacts,
-  // etc.). Permissive index lets the UI surface them without a type
-  // change when needed.
+  trialId: number;
+  studyId: string;
+  briefTitle: string;
+  officialTitle: string;
+  phase: string[];
+  disease: string | null;
+  recruitingStatus: string;
+  sponsor: string;
+  link: string;
+  trialType: string | null;
+  /** Locations are returned as a list of titles ordered by distance to
+   *  the patient (closest first). The full Location records aren't
+   *  included — call `/locations/?country_id=` for that. */
+  location: string[];
+  interventionTreatments: unknown;
+  postedDate: string | null;
+  lastUpdateDate: string | null;
+  firstEnrolment: string | null;
+  enrollmentCount: number | null;
+  patientBurdenScore: number | null;
+  goodnessScore: number | null;
+  matchScore: number | null;
+  matchingType: MatchingType;
+  /** Stringified human-friendly stages — `"Stage I, Stage II"`. */
+  stage: string;
+  attributesToFillIn: AttributeToFillIn[];
+  closestLocationGeoPoint: ClosestLocationGeoPoint | null;
+  distance: number | null;
+  distanceUnits: "km" | "miles" | null;
+  /** Permissive index so the detail serializer's extra fields surface
+   *  without a type widening on every backend change. */
   [key: string]: unknown;
 }
 
 export interface TrialsResponse {
   count: number;
-  next?: string | null;
-  previous?: string | null;
+  next: string | null;
+  previous: string | null;
   results: TrialMatch[];
 }
 
+export interface Country {
+  id: number;
+  code: string;
+  title: string;
+}
+
+export interface CountriesResponse {
+  count: number;
+  next: string | null;
+  previous: string | null;
+  results: Country[];
+}
+
 /** Filter prefs the UI surfaces. Keys mirror what
- *  `study_preferences_from_query_params` consumes (see #44 / #63 / #102). */
+ *  `study_preferences_from_query_params` consumes (camelCase). */
 export interface FilterState {
   recruitmentStatus?: string;
   country?: string;
@@ -58,10 +101,24 @@ export interface FilterState {
   trialPurpose?: string;
   studyType?: string;
   distance?: number;
-  distanceUnits?: "km" | "mi";
+  distanceUnits?: "km" | "miles";
   validatedOnly?: boolean;
   sponsor?: string;
   register?: string;
+  /** Free-text title search — server matches `briefTitle` / `officialTitle`. */
+  searchTitle?: string;
+  /** "type" param — narrows to `eligible` / `potential` server-side. */
+  type?: "eligible" | "potential";
+  /** Sort key. Defaults to `goodnessScore`. */
+  sort?:
+    | "goodnessScore"
+    | "matchScore"
+    | "distance"
+    | "status"
+    | "phase"
+    | "updated"
+    | "enrollment"
+    | "patientBurdenScore";
 }
 
 /** Public props for the federated `./TrialMatches` export. Host-agnostic:


### PR DESCRIPTION
PR 2 of 3 in the federation track (#101). Replaces the scaffold `TrialMatches.tsx` placeholder with the real component, plus the supporting axios layer, TanStack Query hooks, and three small child components (`TrialCard`, `FilterBar`, `TrialDetail`).

The dev harness from PR #113 still works unchanged. CTOMOP picker + token-login flow land in PR 3 (closes #101).

## What the component does

- Calls `GET /trials/` with `patientInfo` in the request body (existing CB contract) and filter prefs as query params. Falls back to `?person_id=` when only `personId` is supplied — matches the server-side `resolve_patient_info` precedence from #102.
- Groups results by `matchingType` and renders one section per group. `not_eligible` is forward-compat (today's serializer only emits `eligible|potential`; documented inline).
- Filter bar: free-text search, recruitment status, country, trial type, distance (km), validated-only.
- Two-column inline detail via `GET /trials/{id}/` with locations, registry link, and an "attributes to fill in" section.

## Self-review fixes applied inline

Fresh-context Claude pass caught **three blocker bugs**:

1. **`recruitmentStatus` → `statuses`** — `/form-settings/` exposes the enum under the `statuses` key (`value_options.py:907`), not `recruitmentStatus`. Dropdown was silently empty.
2. **Country code vs title** — `by_location` does `Country.objects.filter(title__iexact=country)`. Sending ISO `code` would have silently matched nothing.
3. **Stale-trial detail flicker** — reference-equality dep on `patientInfo` would have collapsed the detail view on every parent re-render. Replaced with a stable `JSON.stringify`-keyed reset.

Plus four medium-tier polish items (token assertion list, dead snake_case fallback in `summarizeAttr`, dormant `not_eligible` bucket documentation).

Codex skipped (unreliable in this PR series).

## What I couldn't validate locally

No node/browser in this environment. The frontend CI job from PR #113 runs `tsc -b` + `vite build` on every push — that catches type errors and bundler failures. Runtime semantics (axios GET-with-body through the Vite proxy, host integration, focus management) need a human dev loop (`npm run dev:remote` + Django + token) — flagged here for the smoke test.

## Test plan

- [ ] CI: frontend `typecheck` + `build` pass.
- [ ] CI: backend tests unaffected (no Python changes in this PR).
- [ ] Local smoke: `cd frontend && npm install && VITE_EXACT_TOKEN=<…> npm run dev:remote`. Confirm:
  - `/form-settings/` recruitment dropdown populates.
  - Country dropdown populates and a selection filters results.
  - Selecting a card opens the detail panel; switching patient context clears it.
  - Distance filter narrows results when patient has a geo_point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)