### PR TITLE
feat(frontend): CTOMOP picker + EXACT token-login dev harness (closes #101)

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -2,17 +2,24 @@
 
 Federated React 19 remote that ships the `TrialMatches` component. Toolchain mirrors SoC / ctomop / hk-labs so a host can mount EXACT alongside the other org remotes with one React tree + one TanStack QueryClient.
 
-This package was scaffolded in #103 (part of #101). The real component lands in #104.
-
 ## Scripts
 
 | Script | What |
 |--------|------|
-| `npm run dev` | SPA harness for iterating on the component in isolation. Serves `index.html` at http://localhost:5178/. Proxies `/api/*` → Django on :8000. |
-| `npm run dev:remote` | Federation dev server. Serves `dev-harness.html` at http://localhost:5177/ and exposes the remote at `/remoteEntry.js`. Adds CTOMOP proxies (`/ctomop-local`, `/ctomop-staging`) with Set-Cookie rewriting. |
+| `npm run dev` | SPA harness for iterating on the component in isolation. Serves `index.html` at http://localhost:5178/. Proxies `/api/*` → Django on :8000. Use this to develop the component against an EXACT instance without CTOMOP. |
+| `npm run dev:remote` | Federation dev server with the full CTOMOP picker → TrialMatches flow. Serves `dev-harness.html` at http://localhost:5177/ and exposes the remote at `/remoteEntry.js`. Adds CTOMOP proxies (`/ctomop-local`, `/ctomop-staging`) with Set-Cookie rewriting. |
 | `npm run build` | Production federation build. Output: `dist/remote/remoteEntry.js` + exposed modules. |
 | `npm run build:spa` | Production SPA build. Output: `dist/`. Use this if you want to deploy the harness as a static site. |
 | `npm run typecheck` | `tsc -b`. CI gates this. |
+
+## Dev harness flow (`npm run dev:remote`)
+
+1. **EXACT sign-in** — `POST /api-token-auth/` with username + password returns a DRF token. Stored in `localStorage` so a refresh keeps the session. Can also be skipped by setting `VITE_EXACT_TOKEN` in `.env.local`.
+   - Sign-out clears the local token and calls `CtomopClient.logout()` (tolerant of 401/403), but does **not** revoke the EXACT token server-side — DRF's default token model has no revoke endpoint. Rotate via `manage.py drf_create_token <user>` if needed.
+2. **CTOMOP source toggle** — local (`/ctomop-local`) vs staging (`/ctomop-staging`). The dev proxy rewrites Set-Cookie so the CTOMOP session is scoped to its mount path and doesn't bleed into other localhost services.
+3. **CTOMOP login (inline)** — when the patient-list call returns 401/403, the picker surfaces an inline form for `POST /api/auth/login/` (CTOMOP's Django session login). No EXACT token mixing — separate axios instances.
+4. **Patient picker** — list of `{person_id, patient_name, disease, …}` summaries from `/api/patient-info/`. Click a row to pick.
+5. **TrialMatches mount** — federated component receives the EXACT axios instance + `personId`. EXACT's resolver (#102) fetches the CTOMOP row server-side via the `?person_id=` path.
 
 ## Exposed modules
 
@@ -32,7 +39,7 @@ The host must provide:
 
 Tokens live on `.exact-root` scoped to the remote. Hosts can override any `--exact-*` on `:root` to map them to the host design system (see `frontend/src/federation/exact.css`). Per the hk-labs `docs/module-federation.md` namespace convention.
 
-`assertExactTokens()` returns the list of unset required tokens for dev-time sanity checks — call from the harness to catch missing host overrides.
+`assertExactTokens()` returns the list of unset required tokens for dev-time sanity checks.
 
 ## Environment variables
 
@@ -41,10 +48,12 @@ Tokens live on `.exact-root` scoped to the remote. Hosts can override any `--exa
 | `VITE_EXACT_API_PROXY_TARGET` | `http://localhost:8000` | Where the `/api` proxy points (EXACT's Django). |
 | `VITE_CTOMOP_LOCAL_TARGET` | `http://localhost:8001` | Local CTOMOP for the federation dev harness. |
 | `VITE_CTOMOP_STAGING_TARGET` | `https://ctomop.onrender.com` | Staging CTOMOP for the federation dev harness. |
-| `VITE_EXACT_TOKEN` | _unset_ | DRF token for local dev. Real login flow lands in #104. |
+| `VITE_EXACT_TOKEN` | _unset_ | DRF token. When set, skips the EXACT login form. |
+| `VITE_CTOMOP_BASE` | `/ctomop-local` | Override the default CTOMOP proxy mount used by `CtomopClient`. |
 
 ## Status
 
-- ✅ #103 — Scaffold + federation config + CSS token contract + dev harness skeleton.
-- ⏳ #104 — `TrialMatches` body (filters, eligibility grouping, distance sort, trial detail) + CTOMOP picker + token login flow.
-- ⏳ #101 — Closes when #104 ships.
+- ✅ #103 — Scaffold + federation config + CSS token contract.
+- ✅ #104 part 1 (PR #114) — `TrialMatches` body: filters, eligibility grouping, distance sort, inline detail.
+- ✅ #104 part 2 (this PR) — CTOMOP picker + EXACT token-login flow + dev harness wiring.
+- ✅ #101 — closed when this PR merges.

--- a/frontend/src/dev/CtomopPicker.tsx
+++ b/frontend/src/dev/CtomopPicker.tsx
@@ -1,0 +1,281 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+import { CtomopClient, type CtomopPatientSummary } from "./ctomopClient";
+
+type Source = "ctomop-local" | "ctomop-staging";
+
+const SOURCE_STORAGE_KEY = "exact-harness-source";
+const VALID_SOURCES: readonly Source[] = ["ctomop-local", "ctomop-staging"] as const;
+
+function loadSource(): Source {
+  try {
+    const v = localStorage.getItem(SOURCE_STORAGE_KEY);
+    if (v && (VALID_SOURCES as readonly string[]).includes(v)) return v as Source;
+  } catch {
+    /* ignore */
+  }
+  return "ctomop-local";
+}
+
+function saveSource(s: Source): void {
+  try {
+    localStorage.setItem(SOURCE_STORAGE_KEY, s);
+  } catch {
+    /* ignore */
+  }
+}
+
+interface Props {
+  /** Called when the user picks a patient. The harness wires this to
+   *  TrialMatches's `personId` prop so EXACT fetches the row server-side
+   *  via the resolver added in #102. */
+  onSelect: (personId: number | null) => void;
+  selectedPersonId: number | null;
+}
+
+export function CtomopPicker({ onSelect, selectedPersonId }: Props) {
+  const [source, setSource] = useState<Source>(() => loadSource());
+  const [needsLogin, setNeedsLogin] = useState(false);
+  const [patients, setPatients] = useState<CtomopPatientSummary[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  // Reachability + auth status + patient list — driven by a single
+  // effect so the UI never blinks between "no patients" and "logged out".
+  const baseFor = useCallback(
+    (s: Source) => (s === "ctomop-local" ? "/ctomop-local" : "/ctomop-staging"),
+    [],
+  );
+
+  const client = useMemo(() => new CtomopClient(baseFor(source)), [source, baseFor]);
+
+  useEffect(() => {
+    let cancelled = false;
+    setError(null);
+    setLoading(true);
+    setPatients(null);
+    setNeedsLogin(false);
+
+    (async () => {
+      const reachable = await client.ping();
+      if (cancelled) return;
+      if (!reachable) {
+        setError(
+          `CTOMOP at ${baseFor(source)} is not reachable. Is the backend running?`,
+        );
+        setLoading(false);
+        return;
+      }
+      try {
+        const list = await client.listPatients();
+        if (cancelled) return;
+        setPatients(list);
+      } catch (e) {
+        if (cancelled) return;
+        const status = (e as { response?: { status?: number } }).response?.status;
+        if (status === 401 || status === 403) {
+          setNeedsLogin(true);
+        } else {
+          setError((e as Error).message);
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [client, baseFor, source]);
+
+  const handleSource = (s: Source) => {
+    setSource(s);
+    saveSource(s);
+    onSelect(null);
+  };
+
+  return (
+    <div style={{ padding: "1rem", border: "1px solid #e5e7eb", borderRadius: "0.5rem", background: "#fff" }}>
+      <div style={{ display: "flex", gap: "0.5rem", marginBottom: "0.75rem" }}>
+        {VALID_SOURCES.map((s) => (
+          <button
+            key={s}
+            type="button"
+            onClick={() => handleSource(s)}
+            style={{
+              padding: "0.25rem 0.625rem",
+              borderRadius: "0.25rem",
+              border: "1px solid #d1d5db",
+              background: source === s ? "#0c5fc0" : "#fff",
+              color: source === s ? "#fff" : "#111827",
+              fontSize: "0.75rem",
+              cursor: "pointer",
+            }}
+          >
+            {s === "ctomop-local" ? "Local" : "Staging"}
+          </button>
+        ))}
+      </div>
+
+      {loading ? (
+        <p style={{ color: "#6b7280", fontSize: "0.875rem", margin: 0 }}>
+          Loading patients…
+        </p>
+      ) : null}
+
+      {needsLogin ? (
+        <CtomopInlineLogin
+          client={client}
+          onLoggedIn={() => {
+            // Re-list after login. If the post-login fetch also fails
+            // (token raced, network blip, 5xx), surface the error and
+            // re-arm the login form so the user can try again — without
+            // the catch the spinner would stay forever.
+            setNeedsLogin(false);
+            setLoading(true);
+            client
+              .listPatients()
+              .then((list) => {
+                setPatients(list);
+                setLoading(false);
+              })
+              .catch((e) => {
+                const status = (e as { response?: { status?: number } }).response
+                  ?.status;
+                if (status === 401 || status === 403) {
+                  setNeedsLogin(true);
+                } else {
+                  setError((e as Error).message);
+                }
+                setLoading(false);
+              });
+          }}
+        />
+      ) : null}
+
+      {error ? (
+        <p style={{ color: "#991b1b", fontSize: "0.875rem" }}>{error}</p>
+      ) : null}
+
+      {patients?.length === 0 ? (
+        <p style={{ color: "#6b7280", fontSize: "0.875rem" }}>
+          No patients available on this CTOMOP backend.
+        </p>
+      ) : null}
+
+      {patients && patients.length > 0 ? (
+        <ul style={{ listStyle: "none", padding: 0, margin: 0, maxHeight: "20rem", overflowY: "auto" }}>
+          {patients.map((p) => (
+            <li key={p.id ?? p.person_id} style={{ borderBottom: "1px solid #f3f4f6" }}>
+              <button
+                type="button"
+                onClick={() => onSelect(p.person_id)}
+                style={{
+                  width: "100%",
+                  textAlign: "left",
+                  padding: "0.5rem",
+                  background: selectedPersonId === p.person_id ? "#eff6ff" : "transparent",
+                  border: "none",
+                  cursor: "pointer",
+                  font: "inherit",
+                }}
+              >
+                <div style={{ fontWeight: 500 }}>
+                  #{p.person_id} {p.patient_name ? ` · ${p.patient_name}` : ""}
+                </div>
+                <div style={{ fontSize: "0.75rem", color: "#6b7280" }}>
+                  {p.disease ?? "—"}
+                  {p.stage ? ` · ${p.stage}` : ""}
+                  {p.age != null ? ` · age ${p.age}` : ""}
+                </div>
+              </button>
+            </li>
+          ))}
+        </ul>
+      ) : null}
+    </div>
+  );
+}
+
+function CtomopInlineLogin({
+  client,
+  onLoggedIn,
+}: {
+  client: CtomopClient;
+  onLoggedIn: () => void;
+}) {
+  const [username, setUsername] = useState("");
+  const [password, setPassword] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault();
+    setSubmitting(true);
+    setError(null);
+    try {
+      await client.login(username, password);
+      onLoggedIn();
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <form
+      onSubmit={submit}
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: "0.375rem",
+        marginBottom: "0.75rem",
+      }}
+    >
+      <p style={{ margin: 0, fontSize: "0.75rem", color: "#6b7280" }}>
+        CTOMOP requires sign-in to list patients.
+      </p>
+      <label style={{ fontSize: "0.75rem", color: "#6b7280" }}>
+        <span style={{ position: "absolute", left: "-9999px" }}>CTOMOP username</span>
+        <input
+          type="text"
+          placeholder="username"
+          autoComplete="username"
+          value={username}
+          onChange={(e) => setUsername(e.target.value)}
+          style={{ width: "100%", padding: "0.375rem 0.5rem", border: "1px solid #d1d5db", borderRadius: "0.25rem" }}
+        />
+      </label>
+      <label style={{ fontSize: "0.75rem", color: "#6b7280" }}>
+        <span style={{ position: "absolute", left: "-9999px" }}>CTOMOP password</span>
+        <input
+          type="password"
+          placeholder="password"
+          autoComplete="current-password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          style={{ width: "100%", padding: "0.375rem 0.5rem", border: "1px solid #d1d5db", borderRadius: "0.25rem" }}
+        />
+      </label>
+      {error ? (
+        <div style={{ color: "#991b1b", fontSize: "0.75rem" }}>{error}</div>
+      ) : null}
+      <button
+        type="submit"
+        disabled={submitting}
+        style={{
+          padding: "0.375rem",
+          background: submitting ? "#9ca3af" : "#0c5fc0",
+          color: "#fff",
+          border: "none",
+          borderRadius: "0.25rem",
+          cursor: submitting ? "not-allowed" : "pointer",
+          fontSize: "0.75rem",
+        }}
+      >
+        {submitting ? "Signing in…" : "Sign in to CTOMOP"}
+      </button>
+    </form>
+  );
+}

--- a/frontend/src/dev/ExactLoginForm.tsx
+++ b/frontend/src/dev/ExactLoginForm.tsx
@@ -1,0 +1,97 @@
+import { useState } from "react";
+
+import { obtainExactToken } from "./exactAuth";
+
+interface Props {
+  onTokenObtained: (token: string) => void;
+}
+
+export function ExactLoginForm({ onTokenObtained }: Props) {
+  const [username, setUsername] = useState("");
+  const [password, setPassword] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+    setSubmitting(true);
+    try {
+      const token = await obtainExactToken(username, password);
+      onTokenObtained(token);
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: "0.5rem",
+        maxWidth: "20rem",
+        padding: "1rem",
+        border: "1px solid #e5e7eb",
+        borderRadius: "0.5rem",
+        background: "#fff",
+      }}
+    >
+      <h2 style={{ margin: 0, fontSize: "1rem" }}>Sign in to EXACT</h2>
+      <p style={{ margin: 0, fontSize: "0.75rem", color: "#6b7280" }}>
+        Calls <code>POST /api-token-auth/</code>. The token is stored in{" "}
+        <code>localStorage</code>.
+      </p>
+      <label style={{ display: "flex", flexDirection: "column", fontSize: "0.75rem" }}>
+        Username
+        <input
+          type="text"
+          autoComplete="username"
+          required
+          value={username}
+          onChange={(e) => setUsername(e.target.value)}
+          style={{
+            padding: "0.375rem 0.5rem",
+            border: "1px solid #d1d5db",
+            borderRadius: "0.25rem",
+          }}
+        />
+      </label>
+      <label style={{ display: "flex", flexDirection: "column", fontSize: "0.75rem" }}>
+        Password
+        <input
+          type="password"
+          autoComplete="current-password"
+          required
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          style={{
+            padding: "0.375rem 0.5rem",
+            border: "1px solid #d1d5db",
+            borderRadius: "0.25rem",
+          }}
+        />
+      </label>
+      {error ? (
+        <div style={{ color: "#991b1b", fontSize: "0.75rem" }}>{error}</div>
+      ) : null}
+      <button
+        type="submit"
+        disabled={submitting}
+        style={{
+          padding: "0.5rem 0.75rem",
+          background: submitting ? "#9ca3af" : "#0c5fc0",
+          color: "#fff",
+          border: "none",
+          borderRadius: "0.25rem",
+          cursor: submitting ? "not-allowed" : "pointer",
+        }}
+      >
+        {submitting ? "Signing in…" : "Sign in"}
+      </button>
+    </form>
+  );
+}

--- a/frontend/src/dev/ctomopClient.ts
+++ b/frontend/src/dev/ctomopClient.ts
@@ -1,0 +1,122 @@
+// Thin CTOMOP HTTP client for the EXACT dev harness (PR 3 of #101).
+//
+// CTOMOP exposes a session-authenticated DRF API at `/api/patient-info/`.
+// We keep the cookie jar in the browser (axios `withCredentials: true`)
+// and surface only the calls the harness needs: ping, login, list, fetch
+// one. This file is consumed exclusively by `dev-harness.tsx` and never
+// reaches the published `remoteEntry.js` bundle (federation build excludes
+// `src/dev/` via `rollupOptions.input: {}` in `vite.remote.config.ts`).
+//
+// Adapted from SoC's `frontend/src/dev/ctomopClient.ts` — same wire
+// contract, same proxy strategy.
+import axios, { AxiosError, type AxiosInstance } from "axios";
+
+// Fallback base for callers that don't pass one. CTOMOP sets
+// `SESSION_COOKIE_SECURE = True` + `CSRF_COOKIE_SECURE = True`, so going
+// same-origin via a dev proxy mount is the only path where the session
+// cookie survives a plain-http dev loop.
+const DEFAULT_BASE = "/ctomop-local";
+const DEFAULT_TIMEOUT_MS = 10_000;
+const PING_TIMEOUT_MS = 2_000;
+
+function envBase(): string {
+  return import.meta.env.VITE_CTOMOP_BASE || DEFAULT_BASE;
+}
+
+export interface CtomopPatientSummary {
+  id: number;
+  /** Always an integer per CTOMOP's `PatientListSerializer`. */
+  person_id: number;
+  patient_name?: string | null;
+  age?: number | null;
+  disease?: string | null;
+  stage?: string | null;
+  updated_at?: string | null;
+}
+
+export interface CtomopPatientDetail {
+  patient_info: Record<string, unknown>;
+  user?: Record<string, unknown> | null;
+}
+
+/** CTOMOP error responses are `{error: "<message>"}`; DRF defaults emit
+ *  `{detail: "..."}` for 401/403 from permission classes — read both. */
+interface CtomopErrorBody {
+  error?: string;
+  detail?: string;
+}
+
+function ctomopErrorMessage(
+  ax: AxiosError<CtomopErrorBody>,
+  fallback: string,
+): string {
+  return ax.response?.data?.error ?? ax.response?.data?.detail ?? fallback;
+}
+
+export class CtomopClient {
+  readonly base: string;
+  private client: AxiosInstance;
+
+  constructor(base?: string) {
+    this.base = base ?? envBase();
+    this.client = axios.create({
+      baseURL: this.base,
+      withCredentials: true,
+      timeout: DEFAULT_TIMEOUT_MS,
+      headers: { "X-Requested-With": "XMLHttpRequest" },
+    });
+  }
+
+  async login(username: string, password: string): Promise<void> {
+    try {
+      await this.client.post("/api/auth/login/", { username, password });
+    } catch (e) {
+      const ax = e as AxiosError<CtomopErrorBody>;
+      const status = ax.response?.status;
+      const fallback =
+        status === 400 || status === 401
+          ? "Login rejected — check username and password."
+          : (ax.message ?? "Login failed.");
+      throw new Error(ctomopErrorMessage(ax, fallback));
+    }
+  }
+
+  async logout(): Promise<void> {
+    // Tolerate 401/403 — if we never had a session, "logged out" is the
+    // desired end state regardless.
+    try {
+      await this.client.post("/api/auth/logout/");
+    } catch {
+      /* ignore */
+    }
+  }
+
+  async listPatients(): Promise<CtomopPatientSummary[]> {
+    const res = await this.client.get<
+      CtomopPatientSummary[] | { results: CtomopPatientSummary[] }
+    >("/api/patient-info/");
+    return Array.isArray(res.data) ? res.data : (res.data.results ?? []);
+  }
+
+  async getPatient(personId: number | string): Promise<CtomopPatientDetail> {
+    const res = await this.client.get<CtomopPatientDetail>(
+      `/api/patient-info/${encodeURIComponent(String(personId))}/`,
+    );
+    return res.data;
+  }
+
+  /** Reachability check. Anything CTOMOP responds to — including 5xx,
+   *  405, 404 — counts as reachable; only a network/timeout failure
+   *  (`ax.response` undefined) means the host is genuinely down. */
+  async ping(): Promise<boolean> {
+    try {
+      await this.client.get("/api/patient-info/", {
+        timeout: PING_TIMEOUT_MS,
+      });
+      return true;
+    } catch (e) {
+      const ax = e as AxiosError;
+      return Boolean(ax.response);
+    }
+  }
+}

--- a/frontend/src/dev/dev-harness.tsx
+++ b/frontend/src/dev/dev-harness.tsx
@@ -1,21 +1,156 @@
-// Federation dev harness — `npm run dev:remote` boots this.
-// Scaffold version: renders the federated `TrialMatches` directly with a
-// local axios instance. The CTOMOP picker + token-login flow lands in
-// #104 (Track C of #101).
-import { StrictMode } from "react";
+// EXACT federation dev harness — `npm run dev:remote` boots this at
+// http://localhost:5177/. The full flow:
+//
+//   EXACT token login (POST /api-token-auth/)
+//     ↓
+//   CTOMOP patient picker (session-authed against /ctomop-local or
+//   /ctomop-staging via the Vite proxy with Set-Cookie rewriting)
+//     ↓
+//   TrialMatches mounted with the EXACT axios instance + person_id
+//
+// The two backends use mutually-exclusive auth schemes (DRF Token for
+// EXACT, Django session cookie for CTOMOP), so the harness keeps two
+// separate axios instances — never share, never mix. The TrialMatches
+// component only ever sees the token instance.
+import { StrictMode, useCallback, useEffect, useRef, useState } from "react";
 import { createRoot } from "react-dom/client";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import axios from "axios";
+import type { AxiosInstance } from "axios";
 
 import { TrialMatches } from "../federation/TrialMatches";
+import { CtomopClient } from "./ctomopClient";
+import { CtomopPicker } from "./CtomopPicker";
+import { ExactLoginForm } from "./ExactLoginForm";
+import { makeExactClient, readStoredToken, writeStoredToken } from "./exactAuth";
+
+const CTOMOP_SOURCE_STORAGE_KEY = "exact-harness-source";
+
+function currentCtomopBase(): string {
+  try {
+    const v = localStorage.getItem(CTOMOP_SOURCE_STORAGE_KEY);
+    if (v === "ctomop-staging") return "/ctomop-staging";
+  } catch {
+    /* ignore */
+  }
+  return "/ctomop-local";
+}
 
 const queryClient = new QueryClient();
-const apiClient = axios.create({
-  baseURL: "/api",
-  headers: import.meta.env.VITE_EXACT_TOKEN
-    ? { Authorization: `Token ${import.meta.env.VITE_EXACT_TOKEN}` }
-    : {},
-});
+
+function Harness() {
+  const [token, setToken] = useState<string | null>(() => readStoredToken());
+  const [apiClient, setApiClient] = useState<AxiosInstance | null>(() => {
+    const t = readStoredToken();
+    return t ? makeExactClient(t) : null;
+  });
+  const [personId, setPersonId] = useState<number | null>(null);
+
+  const handleTokenObtained = useCallback((next: string) => {
+    setToken(next);
+    writeStoredToken(next);
+    setApiClient(makeExactClient(next));
+  }, []);
+
+  const handleSignOut = useCallback(() => {
+    setToken(null);
+    writeStoredToken(null);
+    setApiClient(null);
+    setPersonId(null);
+    // Best-effort CTOMOP session cleanup so the user isn't left logged
+    // into the wrong account on the staging host after switching dev
+    // identities. `logout()` tolerates 401/403 internally.
+    void new CtomopClient(currentCtomopBase()).logout();
+  }, []);
+
+  // Token from `VITE_EXACT_TOKEN` env wins on first mount only — a
+  // `.env.local` skips the form for a faster dev loop. We deliberately
+  // do NOT re-apply the env token on every render (the obvious
+  // `[token, handleTokenObtained]` deps would hijack Sign-out: clearing
+  // the token triggers the effect, which re-installs the env token,
+  // making Sign-out a no-op while `VITE_EXACT_TOKEN` is set).
+  const envApplied = useRef(false);
+  useEffect(() => {
+    if (envApplied.current) return;
+    envApplied.current = true;
+    const envToken = import.meta.env.VITE_EXACT_TOKEN;
+    if (envToken && !token) {
+      handleTokenObtained(envToken);
+    }
+  }, [token, handleTokenObtained]);
+
+  if (!apiClient) {
+    return (
+      <div style={{ padding: "1.5rem", display: "flex", flexDirection: "column", gap: "1rem" }}>
+        <h1 style={{ margin: 0, fontSize: "1.25rem" }}>EXACT Federation Dev Harness</h1>
+        <p style={{ color: "#6b7280", margin: 0, maxWidth: "32rem" }}>
+          Sign in to EXACT to load the harness. The token is stored locally;
+          sign out to clear it. CTOMOP login is requested separately when
+          the patient list endpoint returns 401.
+        </p>
+        <ExactLoginForm onTokenObtained={handleTokenObtained} />
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ padding: "1rem" }}>
+      <header
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          gap: "1rem",
+          marginBottom: "1rem",
+        }}
+      >
+        <div>
+          <h1 style={{ margin: 0, fontSize: "1.25rem" }}>EXACT Federation Dev Harness</h1>
+          <p style={{ color: "#6b7280", marginTop: "0.25rem", marginBottom: 0 }}>
+            Pick a CTOMOP patient → mount TrialMatches with the resolved
+            <code style={{ marginLeft: "0.25rem" }}>person_id</code>.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={handleSignOut}
+          style={{
+            padding: "0.25rem 0.625rem",
+            background: "transparent",
+            border: "1px solid #d1d5db",
+            borderRadius: "0.25rem",
+            cursor: "pointer",
+            font: "inherit",
+            color: "#6b7280",
+          }}
+        >
+          Sign out
+        </button>
+      </header>
+
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "minmax(20rem, 1fr) minmax(0, 2fr)",
+          gap: "1.5rem",
+        }}
+      >
+        <CtomopPicker onSelect={setPersonId} selectedPersonId={personId} />
+        <div>
+          {personId == null ? (
+            <p style={{ color: "#6b7280" }}>
+              Pick a CTOMOP patient to load their trial matches.
+            </p>
+          ) : (
+            <TrialMatches
+              apiClient={apiClient}
+              queryClient={queryClient}
+              personId={personId}
+            />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
 
 const rootEl = document.getElementById("root");
 if (!rootEl) throw new Error("#root not found");
@@ -23,16 +158,7 @@ if (!rootEl) throw new Error("#root not found");
 createRoot(rootEl).render(
   <StrictMode>
     <QueryClientProvider client={queryClient}>
-      <div style={{ padding: "1rem", fontFamily: "sans-serif" }}>
-        <h1 style={{ margin: 0, fontSize: "1.25rem" }}>
-          EXACT Federation Dev Harness
-        </h1>
-        <p style={{ color: "#6b7280", marginTop: "0.25rem" }}>
-          Scaffold. CTOMOP picker + token login arrive in #104.
-        </p>
-        <hr style={{ margin: "1rem 0", border: "none", borderTop: "1px solid #e5e7eb" }} />
-        <TrialMatches apiClient={apiClient} queryClient={queryClient} />
-      </div>
+      <Harness />
     </QueryClientProvider>
   </StrictMode>,
 );

--- a/frontend/src/dev/exactAuth.ts
+++ b/frontend/src/dev/exactAuth.ts
@@ -1,0 +1,81 @@
+// EXACT token-login helper for the dev harness.
+//
+// EXACT uses DRF Token auth: `POST /api-token-auth/` with
+// `{username, password}` returns `{token}`. The harness stashes the
+// token in localStorage so a refresh keeps the session, and injects it
+// as `Authorization: Token <…>` on a separate axios instance from the
+// CTOMOP one (cookie + token must NOT mix on the same client — the
+// browser will happily send both, but CTOMOP's `withCredentials` would
+// also drag along EXACT's cross-site CSRF cookie if we shared
+// instances).
+import axios, { AxiosError, type AxiosInstance } from "axios";
+
+const TOKEN_STORAGE_KEY = "exact-harness-token";
+const DEFAULT_BASE = "/api";
+const DEFAULT_TIMEOUT_MS = 10_000;
+
+interface ExactErrorBody {
+  detail?: string;
+  non_field_errors?: string[];
+}
+
+export function readStoredToken(): string | null {
+  try {
+    return localStorage.getItem(TOKEN_STORAGE_KEY);
+  } catch {
+    return null;
+  }
+}
+
+export function writeStoredToken(token: string | null): void {
+  try {
+    if (token) {
+      localStorage.setItem(TOKEN_STORAGE_KEY, token);
+    } else {
+      localStorage.removeItem(TOKEN_STORAGE_KEY);
+    }
+  } catch {
+    /* ignore quota / disabled */
+  }
+}
+
+export async function obtainExactToken(
+  username: string,
+  password: string,
+  baseURL: string = DEFAULT_BASE,
+): Promise<string> {
+  try {
+    const res = await axios.post<{ token: string }>(
+      `${baseURL}/api-token-auth/`,
+      { username, password },
+      { timeout: DEFAULT_TIMEOUT_MS },
+    );
+    return res.data.token;
+  } catch (e) {
+    const ax = e as AxiosError<ExactErrorBody>;
+    const status = ax.response?.status;
+    const fallback =
+      status === 400 || status === 401
+        ? "Login rejected — check username and password."
+        : (ax.message ?? "Login failed.");
+    const detail =
+      ax.response?.data?.detail ??
+      ax.response?.data?.non_field_errors?.[0] ??
+      fallback;
+    throw new Error(detail);
+  }
+}
+
+/** Build the axios instance the host hands to `TrialMatches`. The token
+ *  is required — without it EXACT's DRF returns 401 for every authed
+ *  endpoint. */
+export function makeExactClient(
+  token: string,
+  baseURL: string = DEFAULT_BASE,
+): AxiosInstance {
+  return axios.create({
+    baseURL,
+    timeout: DEFAULT_TIMEOUT_MS,
+    headers: { Authorization: `Token ${token}` },
+  });
+}


### PR DESCRIPTION
PR 3 of 3 in the federation track. Wires the full demo flow:

```
EXACT token sign-in (POST /api-token-auth/)
  ↓
CTOMOP source toggle (local / staging) + session login
  ↓
Patient picker (list /api/patient-info/)
  ↓
TrialMatches mounted with the EXACT axios instance + person_id
```

The two backends use mutually-exclusive auth schemes — DRF Token for EXACT, Django session cookie for CTOMOP — so the harness keeps **two separate axios instances**. EXACT's client has no `withCredentials`; CTOMOP's has no `Authorization` header. The TrialMatches component only ever sees the token-authed EXACT instance.

## New files

| File | What |
|------|------|
| `src/dev/ctomopClient.ts` | Thin axios client. `ping`, `login`, `logout`, `listPatients`, `getPatient`. `withCredentials: true` so the session cookie round-trips through the Vite proxy. |
| `src/dev/exactAuth.ts` | `obtainExactToken` → `POST /api-token-auth/`. `makeExactClient(token)` returns the axios instance the host hands to TrialMatches. Token persisted in `localStorage`. |
| `src/dev/ExactLoginForm.tsx` | Username/password form. |
| `src/dev/CtomopPicker.tsx` | Source toggle (local/staging) + reachability ping + patient list. Inline CTOMOP login form when the list endpoint returns 401/403. |
| `src/dev/dev-harness.tsx` | Top-level `Harness` component. Sign-in gate, 2-col layout, Sign-out clears local state + best-effort CTOMOP logout. |

## Self-review fixes applied inline

Fresh-context Claude pass caught two HIGH bugs:

1. **Post-login `listPatients` had no error handling** — if the second call failed, the spinner stayed forever. Added `.catch()` that re-arms the login form on 401/403 or surfaces the error otherwise.
2. **`VITE_EXACT_TOKEN` effect hijacked Sign-out** — re-installed the env token on `token → null`, making Sign-out a no-op while the env var was set. Switched to `useRef`-gated "applied once" semantics.

Plus three medium polish items (CTOMOP `logout()` called on Sign-out for cleanup symmetry; accessibility labels on the CTOMOP inline login; README note that EXACT tokens aren't revoked server-side).

Codex skipped (unreliable in this PR series).

## What I couldn't validate locally

No node/browser. CI runs `tsc -b` + `vite build` — that catches type errors and bundler failures. The end-to-end flow needs a human dev loop with both backends running:

```
cd frontend && VITE_CTOMOP_LOCAL_TARGET=http://localhost:8001 \
  npm run dev:remote
```

## Test plan

- [ ] CI: frontend `typecheck` + `build` pass.
- [ ] CI: backend tests unaffected (no Python changes).
- [ ] Local smoke (needs both EXACT + CTOMOP running):
  - Sign in to EXACT via the form (or `VITE_EXACT_TOKEN`).
  - CTOMOP picker shows reachable + lists patients.
  - Pick a patient → TrialMatches loads with the correct `personId`-resolved patient context.
  - Sign-out clears the form and (best-effort) the CTOMOP session.

Closes #101.

🤖 Generated with [Claude Code](https://claude.com/claude-code)