### PR TITLE
fix(frontend): TrialCard meta line stray leading separator

### DIFF
--- a/frontend/src/federation/TrialCard.tsx
+++ b/frontend/src/federation/TrialCard.tsx
@@ -55,14 +55,28 @@ export function TrialCard({ trial, onSelect, isSelected }: Props) {
         <span style={{ ...parseStyle(m.badge) }}>{m.label}</span>
       </div>
       <div style={meta}>
-        {trial.studyId} · {trial.recruitingStatus}
-        {trial.phase && trial.phase.length ? ` · ${trial.phase.join(" / ")}` : null}
+        {[
+          trial.studyId,
+          trial.recruitingStatus,
+          trial.phase && trial.phase.length ? trial.phase.join(" / ") : null,
+        ]
+          .filter(Boolean)
+          .join(" · ")}
       </div>
-      <div style={meta}>
-        {trial.matchScore != null ? `Match score: ${trial.matchScore}` : null}
-        {trial.goodnessScore != null ? ` · Goodness: ${trial.goodnessScore}` : null}
-        {trial.distance != null ? ` · ${trial.distance} ${trial.distanceUnits ?? ""}` : null}
-      </div>
+      {(() => {
+        // Build the score/distance line by filtering out missing pieces
+        // before joining — a naive concatenation puts a stray leading
+        // separator on the line when matchScore is null but
+        // goodnessScore is present (the common case for the `/trials/`
+        // list when patient context is missing).
+        const pieces: string[] = [];
+        if (trial.matchScore != null) pieces.push(`Match score: ${trial.matchScore}`);
+        if (trial.goodnessScore != null) pieces.push(`Goodness: ${trial.goodnessScore}`);
+        if (trial.distance != null) {
+          pieces.push(`${trial.distance} ${trial.distanceUnits ?? ""}`.trim());
+        }
+        return pieces.length ? <div style={meta}>{pieces.join(" · ")}</div> : null;
+      })()}
       {trial.sponsor ? (
         <div style={meta}>Sponsor: {trial.sponsor}</div>
       ) : null}


### PR DESCRIPTION
## Bug

`/trials/` list (without patient context) returns `matchScore=null` but `goodnessScore=25`. The card's meta line used naive `&&`-conditional concatenation:

\`\`\`tsx
{trial.matchScore != null ? \`Match score: \${trial.matchScore}\` : null}
{trial.goodnessScore != null ? \` · Goodness: \${trial.goodnessScore}\` : null}
\`\`\`

When matchScore is null and goodnessScore is set, the second chunk's leading \` · \` is the first thing rendered → cards show ` · Goodness: 25` with a stray dot.

## Fix

Collect present pieces into an array and \`join(' · ')\` between them. Same pattern applied to the studyId/status/phase line above for symmetry. The whole meta \`<div>\` is hidden when no pieces are present.

## How surfaced

During a local demo run of the federation harness against a local EXACT instance. Patient context was silently missing because the local EXACT's `CTOMOP_BASE` server-to-server resolver wasn't wired with credentials → matcher returned matchScore=null → leading-dot bug fired on every card.

The underlying server-to-server CTOMOP-auth gap is a separate concern (effectively blocked on #108's identity flow). This PR only fixes the rendering.

## Test plan

- [ ] CI: `typecheck` + `build` pass.
- [ ] Local: cards with patient context show `Match score: 100 · Goodness: 25`.
- [ ] Local: cards without patient context show just `Goodness: 25` (no leading dot).
- [ ] Local: a trial with no scores at all hides the meta line entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)