### PR TITLE
fix(frontend): drop axios from federation shared list — shim corrupts instance methods

### DIFF
--- a/frontend/vite.remote.config.ts
+++ b/frontend/vite.remote.config.ts
@@ -81,7 +81,24 @@ export default defineConfig(({ mode }) => {
           "react/jsx-runtime": { singleton: true, strictVersion: false },
           "react/jsx-dev-runtime": { singleton: true, strictVersion: false },
           "@tanstack/react-query": { singleton: true, strictVersion: false },
-          axios: { singleton: true, strictVersion: false },
+          // axios deliberately NOT shared. The @module-federation/vite
+          // 1.15.5 dev-mode shim wraps the axios default export through
+          // a `__mfNormalizeShareModule` peeling pass that mishandles
+          // axios's identity (its `default` self-reference combined with
+          // its `function`-typed value). The net effect at runtime: the
+          // host imports axios, calls `axios.create(...)`, and gets an
+          // instance whose method properties (`get`, `post`, …) are
+          // stripped — `apiClient.get is not a function`. Symptom-only
+          // when running `dev:remote` from a remote whose deps include
+          // axios; SoC isn't affected because it never calls `axios.create`
+          // on imported axios in code paths that the shim reaches.
+          //
+          // Loading axios normally (no federation shim) fixes the issue.
+          // Hosts that mount this remote will end up with two axios
+          // copies — fine because axios has no module-level state worth
+          // sharing (interceptors and defaults are per-instance, not
+          // per-module). Re-add when @module-federation/vite ships a
+          // fix for function-typed shared defaults.
         },
         dts: false,
       }),


### PR DESCRIPTION
## Bug

\`@module-federation/vite\` 1.15.5's dev-mode "shared" runtime wraps each declared singleton through a \`__mfNormalizeShareModule\` peeling pass: it walks \`module.default.default…\` and exports whatever pops out.

For **axios**, the prebuild's \`default\` IS the axios function (callable, typeof 'function'), and the prebuild contains the self-reference \`axios.default = axios\` and named exports destructured from the function (\`{ create, get, post, … } = axios\`). The peeling logic interacts with this in a way that **strips instance methods from \`axios.create(...)\` results**: the returned object exists but \`.get\` / \`.post\` / etc. are undefined.

## Symptom

Any consumer holding an axios instance via \`axios.create()\` errors on the first request:

\`\`\`
Failed to load trials: apiClient.get is not a function
\`\`\`

In this repo that's the \`TrialMatches\` component (every API call) and the dev harness's \`CtomopClient\`. Surfaced during a local demo run — the federated harness mount errored even though the same EXACT API was reachable via \`curl\` through the Vite proxy.

## Fix

Drop \`axios\` from the federation \`shared:\` map so it loads normally via Vite's deps prebuild — no shim, no peeling. Hosts that mount this remote alongside another remote that also uses axios end up with two copies, which is fine because axios has no module-level state worth sharing (interceptors and defaults are per-instance, not per-module).

Re-add once @module-federation/vite ships a fix for function-typed shared defaults.

## How surfaced

Hypothesis-driven elimination: removing axios from shared made the runtime error disappear. Comparing the served \`loadShare\` shim vs. the normal Vite prebuild confirmed the peeling step is the culprit.

## Test plan

- [ ] CI: \`typecheck\` + \`build\` pass.
- [ ] Local: \`npm run dev:remote\`, sign into EXACT, pick a CTOMOP patient. TrialMatches should load trials without the "apiClient.get is not a function" error.
- [ ] Local: FilterBar dropdowns populate (recruitment status, country, trial type) — they previously stayed empty because \`/form-settings/\` and \`/countries/\` calls also failed silently with the same bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)