### PR TITLE
fix(frontend): recruitment-status dropdown was wired to patient-invitation enum

### DIFF
--- a/frontend/src/federation/FilterBar.tsx
+++ b/frontend/src/federation/FilterBar.tsx
@@ -40,10 +40,30 @@ export function FilterBar({ apiClient, filters, onChange, diseaseCode }: Props) 
   const countries = useCountries(apiClient);
   const formSettings = useFormSettings(apiClient, diseaseCode);
 
-  // `/form-settings/` exposes the recruitment-status enum under the key
-  // `statuses` (see `value_options.py:907`), not `recruitmentStatus`.
-  // Same dict also surfaces `trialType` for the trial-type dropdown.
-  const recruitmentOptions = formSettings.data?.statuses?.options ?? [];
+  // Recruitment status isn't actually exposed by `/form-settings/` —
+  // the `statuses` key there is the patient-invitation enum
+  // ("Looking for trial", "Waiting for patient acceptance", etc.),
+  // not the trial recruitment state. The PR that originally wired
+  // `recruitmentStatus` to `statuses` (#114) made the dropdown surface
+  // semantically wrong values.
+  //
+  // The backend filter `by_recruitment_status` (`querysets/trial.py`)
+  // treats `RECRUITING` and `RECRUITING_AND_NOT_YET_RECRUITING` as
+  // special cases and falls through to a case-insensitive exact match
+  // on the raw `Trial.recruitment_status` field for anything else.
+  // The canonical CT.gov values are below; `RECRUITING_AND_NOT_YET_…`
+  // is the combined convenience value the queryset documents.
+  const recruitmentOptions = [
+    { value: "RECRUITING", label: "Recruiting" },
+    { value: "RECRUITING_AND_NOT_YET_RECRUITING", label: "Recruiting + not yet recruiting" },
+    { value: "NOT_YET_RECRUITING", label: "Not yet recruiting" },
+    { value: "ENROLLING_BY_INVITATION", label: "Enrolling by invitation" },
+    { value: "ACTIVE_NOT_RECRUITING", label: "Active, not recruiting" },
+    { value: "COMPLETED", label: "Completed" },
+    { value: "SUSPENDED", label: "Suspended" },
+    { value: "TERMINATED", label: "Terminated" },
+    { value: "WITHDRAWN", label: "Withdrawn" },
+  ];
   const trialTypeOptions = formSettings.data?.trialType?.options ?? [];
 
   return (


### PR DESCRIPTION
## Bug

PR #114 wired the Recruitment dropdown to \`formSettings.data?.statuses?.options\`. The \`statuses\` key in \`/form-settings/\` IS NOT the trial recruitment-status enum — it's the **patient-invitation** enum (\`Looking for trial\`, \`Waiting for patient acceptance\`, \`Patient accepted invite\`, …) populated by some other code path in \`value_options.py\`. The dropdown surfaced semantically wrong values; picking one either case-folded into a CT.gov-shaped exact match that never hit or silently no-oped on the backend filter.

## Root cause

Trial recruitment state isn't exposed by \`/form-settings/\` at all — \`Trial.recruitment_status\` is a free-form \`TextField\` holding ClinicalTrials.gov vocabulary, no value_options enum.

## Fix

Hardcode the canonical CT.gov vocabulary in \`FilterBar.tsx\`:

\`\`\`
RECRUITING
RECRUITING_AND_NOT_YET_RECRUITING  (combined convenience)
NOT_YET_RECRUITING
ENROLLING_BY_INVITATION
ACTIVE_NOT_RECRUITING
COMPLETED
SUSPENDED
TERMINATED
WITHDRAWN
\`\`\`

Backend's \`by_recruitment_status\` (\`querysets/trial.py\`) treats the first two as special cases and falls through to \`iexact\` match on the raw field for the rest. The combined value is the queryset's documented convenience.

## How surfaced

Caught during the local demo run that's also producing PR #117 (harness inline-fetch + meta-line) and PR #118 (federation axios shim).

## Test plan

- [ ] CI: \`typecheck\` + \`build\` pass.
- [ ] Local: dropdown shows the CT.gov values listed above.
- [ ] Local: picking "Recruiting" narrows results to RECRUITING trials.
- [ ] Local: picking "Completed" narrows results to COMPLETED trials.

🤖 Generated with [Claude Code](https://claude.com/claude-code)