### PR TITLE
chore: post-demo follow-ups bundle (review findings + country UX)

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,6 +1,7 @@
 node_modules/
 dist/
 *.tsbuildinfo
+*.bak
 .vite-remote/
 .vite/
 .env.local

--- a/frontend/src/dev/dev-harness.tsx
+++ b/frontend/src/dev/dev-harness.tsx
@@ -125,7 +125,18 @@ function Harness() {
         setPatientInfo(normalized);
       } catch (e) {
         if (cancelled) return;
-        setResolveError((e as Error).message);
+        // Coerce non-Error throws so the UI never renders "undefined".
+        // axios sometimes rejects with `{message, response, …}` objects
+        // that aren't `Error` instances depending on the adapter, and a
+        // direct `(e as Error).message` would silently render an empty
+        // string in those cases.
+        const msg =
+          e instanceof Error
+            ? e.message
+            : typeof e === "string"
+              ? e
+              : "Unknown error";
+        setResolveError(msg);
       } finally {
         if (!cancelled) setResolving(false);
       }

--- a/frontend/src/federation/FilterBar.tsx
+++ b/frontend/src/federation/FilterBar.tsx
@@ -1,7 +1,7 @@
 import type { CSSProperties } from "react";
 import type { AxiosInstance } from "axios";
 
-import { useCountries, useFormSettings } from "./hooks";
+import { useFormSettings } from "./hooks";
 import type { FilterState } from "./types";
 
 interface Props {
@@ -37,7 +37,6 @@ const INPUT: CSSProperties = {
 };
 
 export function FilterBar({ apiClient, filters, onChange, diseaseCode }: Props) {
-  const countries = useCountries(apiClient);
   const formSettings = useFormSettings(apiClient, diseaseCode);
 
   // Recruitment status isn't actually exposed by `/form-settings/` —
@@ -95,25 +94,11 @@ export function FilterBar({ apiClient, filters, onChange, diseaseCode }: Props) 
           ))}
         </select>
       </label>
-      <label style={LABEL}>
-        Country
-        <select
-          style={INPUT}
-          value={filters.country ?? ""}
-          onChange={(e) => onChange({ ...filters, country: e.target.value || undefined })}
-        >
-          <option value="">All</option>
-          {countries.data?.results.map((c) => (
-            // The backend's `by_location` does
-            // `Country.objects.filter(title__iexact=country)` — so we
-            // send the country title (e.g. "United States"), not the
-            // ISO code. Send-code would silently match nothing.
-            <option key={c.id} value={c.title}>
-              {c.title}
-            </option>
-          ))}
-        </select>
-      </label>
+      {/* Country is intentionally NOT user-controlled — `TrialMatches`
+       *  derives `filters.country` from `patientInfo.country` so the
+       *  trial list scopes to the patient's geography without an extra
+       *  click. Hosts that need a cross-border search experience can
+       *  add their own override above this component. */}
       <label style={LABEL}>
         Trial type
         <select

--- a/frontend/src/federation/TrialCard.tsx
+++ b/frontend/src/federation/TrialCard.tsx
@@ -8,26 +8,42 @@ interface Props {
   isSelected?: boolean;
 }
 
-function matchingStyles(t: TrialMatch): { badge: string; label: string } {
+const BADGE_BASE: CSSProperties = {
+  padding: "0.125rem 0.5rem",
+  borderRadius: "0.25rem",
+  fontSize: "0.75rem",
+  border: "1px solid transparent",
+};
+
+const ELIGIBLE_BADGE: CSSProperties = {
+  ...BADGE_BASE,
+  background: "#dcfce7",
+  color: "#166534",
+  borderColor: "#86efac",
+};
+
+const POTENTIAL_BADGE: CSSProperties = {
+  ...BADGE_BASE,
+  background: "#fef3c7",
+  color: "#92400e",
+  borderColor: "#fcd34d",
+};
+
+const NOT_ELIGIBLE_BADGE: CSSProperties = {
+  ...BADGE_BASE,
+  background: "#fee2e2",
+  color: "#991b1b",
+  borderColor: "#fca5a5",
+};
+
+function matchingStyles(t: TrialMatch): { style: CSSProperties; label: string } {
   if (t.matchingType === "eligible") {
-    return {
-      badge:
-        "background:#dcfce7;color:#166534;border:1px solid #86efac;padding:0.125rem 0.5rem;border-radius:0.25rem;font-size:0.75rem;",
-      label: "Eligible",
-    };
+    return { style: ELIGIBLE_BADGE, label: "Eligible" };
   }
   if (t.matchingType === "not_eligible") {
-    return {
-      badge:
-        "background:#fee2e2;color:#991b1b;border:1px solid #fca5a5;padding:0.125rem 0.5rem;border-radius:0.25rem;font-size:0.75rem;",
-      label: "Not Eligible",
-    };
+    return { style: NOT_ELIGIBLE_BADGE, label: "Not Eligible" };
   }
-  return {
-    badge:
-      "background:#fef3c7;color:#92400e;border:1px solid #fcd34d;padding:0.125rem 0.5rem;border-radius:0.25rem;font-size:0.75rem;",
-    label: "Potential",
-  };
+  return { style: POTENTIAL_BADGE, label: "Potential" };
 }
 
 export function TrialCard({ trial, onSelect, isSelected }: Props) {
@@ -52,7 +68,7 @@ export function TrialCard({ trial, onSelect, isSelected }: Props) {
     <>
       <div style={{ display: "flex", justifyContent: "space-between", gap: "1rem" }}>
         <strong style={{ color: "var(--exact-color-text)" }}>{trial.briefTitle}</strong>
-        <span style={{ ...parseStyle(m.badge) }}>{m.label}</span>
+        <span style={m.style}>{m.label}</span>
       </div>
       <div style={meta}>
         {[
@@ -91,17 +107,4 @@ export function TrialCard({ trial, onSelect, isSelected }: Props) {
     );
   }
   return <div style={card}>{body}</div>;
-}
-
-// Parse the inline CSS string into a CSSProperties object. Avoids
-// a Tailwind dependency for these tiny pill styles while keeping the
-// per-status colours in one place at the top of the file.
-function parseStyle(css: string): CSSProperties {
-  const out: Record<string, string> = {};
-  for (const rule of css.split(";")) {
-    const [k, v] = rule.split(":").map((s) => s.trim());
-    if (!k || v == null) continue;
-    out[k.replace(/-([a-z])/g, (_m: string, c: string) => c.toUpperCase())] = v;
-  }
-  return out as CSSProperties;
 }

--- a/frontend/src/federation/TrialDetail.tsx
+++ b/frontend/src/federation/TrialDetail.tsx
@@ -1,14 +1,9 @@
 import type { CSSProperties } from "react";
-import type { AxiosInstance } from "axios";
 
-import { useTrialDetail } from "./hooks";
-import type { PatientInfo, TrialMatch } from "./types";
+import type { TrialMatch } from "./types";
 
 interface Props {
-  apiClient: AxiosInstance;
   trial: TrialMatch;
-  patientInfo?: PatientInfo | null;
-  personId?: string | number;
   onClose: () => void;
 }
 
@@ -32,13 +27,18 @@ const SECTION_HEADER: CSSProperties = {
   color: "var(--exact-color-text)",
 };
 
-export function TrialDetail({ apiClient, trial, patientInfo, personId, onClose }: Props) {
-  // Re-fetch with the full detail serializer — the list endpoint already
-  // returns most fields but the detail view adds explanation data when
-  // `?explain=true` (out of scope here, but the hook supports it
-  // implicitly by fetching `/trials/{id}/` which serves the detail shape).
-  const detail = useTrialDetail({ apiClient, trialId: trial.trialId, patientInfo, personId });
-  const data = detail.data ?? trial;
+export function TrialDetail({ trial, onClose }: Props) {
+  // The list response already carries every field we render here
+  // (briefTitle / officialTitle / phase / sponsor / matchScore /
+  // goodnessScore / distance / location / attributesToFillIn / link).
+  // The previous version re-fetched `/trials/{trialId}/` for "richer
+  // detail data", but that detail re-fetch had to drop `patient_info`
+  // from the request body (Fetch-spec / axios XHR don't allow
+  // GET-with-body), so the matcher annotations on the response came
+  // back patient-less and OVERWROTE the list's good values. Dropping
+  // the re-fetch entirely keeps the patient-scoped values from the
+  // list visible.
+  const data = trial;
 
   return (
     <div style={PANEL}>

--- a/frontend/src/federation/TrialMatches.tsx
+++ b/frontend/src/federation/TrialMatches.tsx
@@ -54,6 +54,24 @@ function TrialMatchesInner({
     setSelectedTrial(null);
   }, [personId, patientInfoKey]);
 
+  // Auto-derive `country` from the patient profile. The country filter
+  // was previously a dropdown but in practice was redundant — patients
+  // are matched to trials in their home country. We sync on every
+  // patient change (not just first mount) so swapping `patientInfo`
+  // — e.g. picking another row in the dev harness — re-scopes the
+  // trial list correctly. The equality guard prevents a `setFilters`
+  // re-render storm when the patient's country is already the active
+  // filter. `undefined` clears the param so a patient without a country
+  // gets the disease-agnostic union, not a stale previous country.
+  const patientCountry = useMemo(() => {
+    const c = (patientInfo as Record<string, unknown> | null | undefined)?.["country"];
+    return typeof c === "string" && c.trim() ? c.trim() : undefined;
+  }, [patientInfo]);
+  useEffect(() => {
+    if (filters.country === patientCountry) return;
+    setFilters((prev) => ({ ...prev, country: patientCountry }));
+  }, [patientCountry, filters.country]);
+
   const query = useTrials({ apiClient, patientInfo, personId, filters });
 
   const grouped = useMemo(() => {
@@ -155,10 +173,7 @@ function TrialMatchesInner({
 
         {selectedTrial ? (
           <TrialDetail
-            apiClient={apiClient}
             trial={selectedTrial}
-            patientInfo={patientInfo}
-            personId={personId}
             onClose={() => setSelectedTrial(null)}
           />
         ) : null}

--- a/frontend/src/federation/api.ts
+++ b/frontend/src/federation/api.ts
@@ -15,10 +15,8 @@
 import type { AxiosInstance } from "axios";
 
 import type {
-  CountriesResponse,
   FilterState,
   PatientInfo,
-  TrialMatch,
   TrialsResponse,
 } from "./types";
 
@@ -69,41 +67,6 @@ export async function fetchTrials({
     params.person_id = String(personId);
   }
   const response = await apiClient.get<TrialsResponse>("/trials/", { params });
-  return response.data;
-}
-
-/** GET `/trials/{id}/` — detail view. Patient context is intentionally
- *  NOT sent on the detail call: the detail endpoint is GET-only
- *  upstream and shaping a POST alias just to pass patient_info on
- *  detail would add backend surface for marginal benefit (the
- *  "attributesToFillIn" explanation already arrived on the list
- *  response). When only `personId` is supplied, we forward it as a
- *  query param so the server-side CTOMOP resolver (#102) can populate
- *  patient context if credentialed. */
-export async function fetchTrialDetail({
-  apiClient,
-  trialId,
-  patientInfo,
-  personId,
-}: {
-  apiClient: AxiosInstance;
-  trialId: number;
-  patientInfo?: PatientInfo | null;
-  personId?: string | number;
-}): Promise<TrialMatch> {
-  const params: Record<string, string> = {};
-  if (personId != null && (patientInfo == null || Object.keys(patientInfo).length === 0)) {
-    params.person_id = String(personId);
-  }
-  const response = await apiClient.get<TrialMatch>(`/trials/${trialId}/`, { params });
-  return response.data;
-}
-
-/** GET `/countries/` — list endpoint for the country filter. */
-export async function fetchCountries(
-  apiClient: AxiosInstance,
-): Promise<CountriesResponse> {
-  const response = await apiClient.get<CountriesResponse>("/countries/");
   return response.data;
 }
 

--- a/frontend/src/federation/hooks.ts
+++ b/frontend/src/federation/hooks.ts
@@ -1,15 +1,14 @@
 // TanStack Query hooks for the EXACT API. Keys are stable so multiple
 // `TrialMatches` instances mounted in the same host share the cache
-// (e.g. opening a detail view doesn't re-request the list).
+// (e.g. mounting two filtered views with the same patient doesn't
+// re-request).
 import { useQuery, type UseQueryResult } from "@tanstack/react-query";
 import type { AxiosInstance } from "axios";
 
-import { fetchCountries, fetchFormSettings, fetchTrialDetail, fetchTrials } from "./api";
+import { fetchFormSettings, fetchTrials } from "./api";
 import type {
-  CountriesResponse,
   FilterState,
   PatientInfo,
-  TrialMatch,
   TrialsResponse,
 } from "./types";
 
@@ -36,37 +35,6 @@ export function useTrials({
     queryFn: () => fetchTrials({ apiClient, patientInfo, personId, filters }),
     enabled: enabled && (patientInfo != null || personId != null),
     staleTime: 30_000,
-  });
-}
-
-interface UseTrialDetailArgs {
-  apiClient: AxiosInstance;
-  trialId: number | null;
-  patientInfo?: PatientInfo | null;
-  personId?: string | number;
-}
-
-export function useTrialDetail({
-  apiClient,
-  trialId,
-  patientInfo,
-  personId,
-}: UseTrialDetailArgs): UseQueryResult<TrialMatch> {
-  return useQuery({
-    queryKey: ["exact-trial-detail", trialId, personId ?? null, patientInfo ?? null],
-    queryFn: () => fetchTrialDetail({ apiClient, trialId: trialId!, patientInfo, personId }),
-    enabled: trialId != null,
-    staleTime: 60_000,
-  });
-}
-
-export function useCountries(
-  apiClient: AxiosInstance,
-): UseQueryResult<CountriesResponse> {
-  return useQuery({
-    queryKey: ["exact-countries"],
-    queryFn: () => fetchCountries(apiClient),
-    staleTime: 5 * 60_000,
   });
 }
 

--- a/frontend/src/federation/types.ts
+++ b/frontend/src/federation/types.ts
@@ -78,19 +78,6 @@ export interface TrialsResponse {
   results: TrialMatch[];
 }
 
-export interface Country {
-  id: number;
-  code: string;
-  title: string;
-}
-
-export interface CountriesResponse {
-  count: number;
-  next: string | null;
-  previous: string | null;
-  results: Country[];
-}
-
 /** Filter prefs the UI surfaces. Keys mirror what
  *  `study_preferences_from_query_params` consumes (camelCase). */
 export interface FilterState {

--- a/tests/querysets/test_trial_querysets.py
+++ b/tests/querysets/test_trial_querysets.py
@@ -703,9 +703,14 @@ class TestTrialQuerySet:
         assert list(Trial.objects.by_recruitment_status('recruiting_and_not_yet_recruiting').order_by('id')) == [t1, t2]
         assert list(Trial.objects.by_recruitment_status('Recruiting_And_Not_Yet_Recruiting').order_by('id')) == [t1, t2]
 
-        # Other specific statuses
-        assert list(Trial.objects.by_recruitment_status('COMPLETED').order_by('id')) == [t3, t5]
-        assert list(Trial.objects.by_recruitment_status('TERMINATED').order_by('id')) == [t4, t5]
+        # Other specific statuses — blank `recruitment_status` rows are NOT
+        # matched by COMPLETED / TERMINATED filters. Trial metadata is a
+        # data-quality signal, not an eligibility-unknown one — the
+        # opposite of how patient-attribute filters treat blanks. (Pre-fix,
+        # `eligible_for_str_value`'s `allow_blank=True` default widened
+        # these filters to also include incompletely-ingested trials.)
+        assert list(Trial.objects.by_recruitment_status('COMPLETED').order_by('id')) == [t3]
+        assert list(Trial.objects.by_recruitment_status('TERMINATED').order_by('id')) == [t4]
 
     @pytest.mark.django_db
     def test_by_trial_type(self):

--- a/tests/views/test_normalize_ctomop_row_view.py
+++ b/tests/views/test_normalize_ctomop_row_view.py
@@ -6,10 +6,18 @@ The adapter itself has exhaustive coverage in
 `tests/management/test_normalize_ctomop_row.py`; the tests here exist
 to lock the HTTP surface — auth, payload shape, response shape — so
 the federation harness (added in #117) can rely on it.
+
+The first class drives the view via direct `.post(MagicMock(...))` for
+fast per-branch behaviour. `TestNormalizeCtomopRowHttp` at the bottom
+uses DRF's `APIClient` to verify the full pipeline (URL routing, token
+auth, JSON parsing).
 """
 from unittest.mock import MagicMock, patch
 
 import pytest
+from django.contrib.auth.models import User
+from rest_framework.authtoken.models import Token
+from rest_framework.test import APIClient
 
 from trials.api.trials_views import NormalizeCtomopRowView
 
@@ -105,3 +113,44 @@ class TestNormalizeCtomopRowView:
         snapshot = dict(original)
         _post(original)
         assert original == snapshot
+
+
+@pytest.mark.django_db
+class TestNormalizeCtomopRowHttp:
+    """HTTP-pipeline coverage via DRF `APIClient` — locks routing, token
+    auth, and JSON parsing. The class above already covers branching;
+    here we only need a smoke test and the 401 path."""
+
+    @pytest.fixture
+    def authed_client(self):
+        user, _ = User.objects.get_or_create(username='normalize-tester')
+        user.set_password('pw')
+        user.save()
+        token, _ = Token.objects.get_or_create(user=user)
+        client = APIClient()
+        client.credentials(HTTP_AUTHORIZATION=f'Token {token.key}')
+        return client
+
+    def test_unauthenticated_returns_401(self):
+        client = APIClient()
+        response = client.post('/normalize-ctomop-row/', {}, format='json')
+        assert response.status_code == 401
+
+    def test_authed_post_normalizes_and_returns_200(self, authed_client):
+        response = authed_client.post(
+            '/normalize-ctomop-row/',
+            {'stage': 'IIIB', 'tumor_grade': 2},
+            format='json',
+        )
+        assert response.status_code == 200
+        # Pure-Python transforms — exercised through real routing this time.
+        assert response.data['stage'] == 'III'
+        assert response.data['tumor_grade'] == '20'
+
+    def test_non_dict_body_returns_400(self, authed_client):
+        response = authed_client.post(
+            '/normalize-ctomop-row/',
+            [1, 2, 3],
+            format='json',
+        )
+        assert response.status_code == 400

--- a/tests/views/test_trials_match_post.py
+++ b/tests/views/test_trials_match_post.py
@@ -1,0 +1,88 @@
+"""Integration tests for `POST /trials/match/` (PR #121).
+
+The action is a thin POST alias for the list endpoint that exists so
+the federation harness can carry `patient_info` in the request body
+(GET-with-body is forbidden by the Fetch spec and silently dropped by
+axios's XHR adapter). These tests lock the HTTP surface — auth,
+response shape, disease-scoping — so a regression that breaks the
+`self.action = 'list'` rebind or the routing wiring would fail CI.
+"""
+import pytest
+from django.contrib.auth.models import User
+from rest_framework.authtoken.models import Token
+from rest_framework.test import APIClient
+
+from tests.factories import TrialFactory
+
+
+@pytest.fixture
+def authed_client(db):
+    user, _ = User.objects.get_or_create(username='match-tester')
+    user.set_password('pw')
+    user.save()
+    token, _ = Token.objects.get_or_create(user=user)
+    client = APIClient()
+    client.credentials(HTTP_AUTHORIZATION=f'Token {token.key}')
+    return client
+
+
+@pytest.mark.django_db
+class TestTrialsMatchPost:
+    def test_unauthenticated_post_returns_401(self):
+        client = APIClient()
+        response = client.post('/trials/match/', {}, format='json')
+        assert response.status_code == 401
+
+    def test_authed_post_returns_200(self, authed_client):
+        TrialFactory(disease='Multiple Myeloma')
+        response = authed_client.post(
+            '/trials/match/',
+            {'patient_info': {'disease': 'multiple myeloma'}},
+            format='json',
+        )
+        assert response.status_code == 200
+        assert 'results' in response.data
+        assert 'itemsTotalCount' in response.data
+
+    def test_inline_patient_info_scopes_to_disease(self, authed_client):
+        """Headline: the POST body's `patient_info` reaches the matcher
+        and the response is disease-scoped. This is the bug PR #121
+        exists to fix — pre-PR, the same body via GET-with-body silently
+        dropped, the matcher saw no patient context, and the response
+        was the disease-agnostic union.
+        """
+        mm = TrialFactory(disease='Multiple Myeloma')
+        TrialFactory(disease='Breast Cancer')
+        TrialFactory(disease='Chronic Lymphocytic Leukemia')
+        response = authed_client.post(
+            '/trials/match/',
+            {'patient_info': {'disease': 'multiple myeloma'}},
+            format='json',
+        )
+        assert response.status_code == 200
+        result_ids = {t['trialId'] for t in response.data['results']}
+        # Strict equality, not membership: a regression that broadens the
+        # response to include BC + CLL trials would silently pass an
+        # `mm.id in result_ids` check. We want it to fail loudly.
+        assert result_ids == {mm.id}, (
+            'expected MM-only scoping; got ids='
+            f'{result_ids} (titles='
+            f'{[t["briefTitle"] for t in response.data["results"]]})'
+        )
+
+    def test_response_shape_matches_list(self, authed_client):
+        """The match endpoint must return the same fields as `GET /trials/`
+        so the frontend can interoperate. Spot-check `matchingType`,
+        `matchScore`, `goodnessScore`, `attributesToFillIn`.
+        """
+        TrialFactory(disease='Multiple Myeloma')
+        response = authed_client.post(
+            '/trials/match/',
+            {'patient_info': {'disease': 'multiple myeloma'}},
+            format='json',
+        )
+        assert response.data['results'], 'expected at least one trial'
+        trial = response.data['results'][0]
+        for required in ('trialId', 'briefTitle', 'matchingType',
+                         'matchScore', 'goodnessScore', 'attributesToFillIn'):
+            assert required in trial, f'missing field {required}'

--- a/trials/querysets/trial.py
+++ b/trials/querysets/trial.py
@@ -720,7 +720,15 @@ class TrialQuerySet(models.QuerySet):
         elif status == "RECRUITING_AND_NOT_YET_RECRUITING":
             return self.filter(recruitment_status__in=["RECRUITING", "NOT_YET_RECRUITING"])
 
-        return self.eligible_for_str_value('recruitment_status', recruitment_status.upper())
+        # `allow_blank=False`: recruitment status is trial metadata, not
+        # patient eligibility — a blank or NULL `recruitment_status` on a
+        # trial is missing data, not "unknown can-match". Defaulting to
+        # `allow_blank=True` (as the helper does) silently widened
+        # filters like "COMPLETED" / "TERMINATED" to also match
+        # incompletely-ingested trials.
+        return self.eligible_for_str_value(
+            'recruitment_status', recruitment_status.upper(), allow_blank=False,
+        )
 
     def by_validated_only(self, validated_only):
         if validated_only is not True:


### PR DESCRIPTION
## Summary
Bundles items surfaced by self-review on PRs #117–#123 plus the country-from-PatientInfo UX change discussed in chat.

### Backend
- `Trial.objects.by_recruitment_status` now passes `allow_blank=False` to `eligible_for_str_value`. Pre-fix, COMPLETED/TERMINATED filters silently widened to include incompletely-ingested trials (blank `recruitment_status`). Trial metadata is a data-quality signal, not an eligibility-unknown one — the opposite of how patient-attribute filters treat blanks. Existing queryset test updated.
- New `tests/views/test_trials_match_post.py` locks the HTTP surface of POST `/trials/match/` (added in #121) — auth, response shape, disease scoping. Strict-equality assertion (`result_ids == {mm.id}`) so a regression leaking BC/CLL into an MM patient's response fails loudly with diagnostic output.
- `tests/views/test_normalize_ctomop_row_view.py` gains `TestNormalizeCtomopRowHttp` that drives the view through DRF `APIClient` (URL routing + token auth + JSON parsing).

### Frontend
- Country dropdown removed from `FilterBar`. `TrialMatches` derives `filters.country` from `patientInfo.country` and re-syncs on every patient change so swapping `patientInfo` (e.g. dev harness picker selects another row) re-scopes the trial list. Clears the filter when the patient has no country instead of leaking the previous value.
- `TrialDetail` no longer re-fetches via `useTrialDetail` — the list response already carries every field rendered there, and the patientless detail fetch was overwriting good list data when the detail panel opened. Verified field-by-field against `TrialSerializer` vs `TrialDetailsSerializer`.
- Dead code removed: `useTrialDetail`, `useCountries`, `fetchTrialDetail`, `fetchCountries`, `Country`, `CountriesResponse`.
- `TrialCard`'s hand-rolled `parseStyle` CSS-string parser replaced with `CSSProperties` literals.
- `dev-harness` coerces non-`Error` throws so the failure banner never renders "undefined" when axios rejects with a plain object.
- `*.bak` added to `frontend/.gitignore`.

### Self-review (per CLAUDE.md)
Fresh-context Claude review run before push; surfaced 1 SHOULD-FIX (country sync stuck on first patient) and 2 NITs (dead types + lax assertion) — all three folded into this PR before pushing. Squashed to a single commit.

## Test plan
- [x] `pytest tests/querysets/ tests/views/test_trials_match_post.py tests/views/test_normalize_ctomop_row_view.py` — 59 passed
- [x] Full backend suite: `pytest --reuse-db` — 669 passed, 5 skipped
- [x] Frontend `tsc -p . --noEmit` — clean
- [ ] CI green on this branch
- [ ] Smoke-test in dev harness: switch CTOMOP patients, confirm country re-scopes; open trial detail, confirm fields render from list payload without a second network call