### PR TITLE
fix: eval pipeline fails loudly on DB errors + re-tag :latest (#47)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -20,6 +20,7 @@ jobs:
           type=sha,format=long
           type=ref,event=branch
           type=ref,event=tag
+          type=raw,value=latest,enable={{is_default_branch}}
 
     - name: Login to Docker Registry
       uses: docker/login-action@v3

--- a/tests/management/test_eval_pipeline_robustness.py
+++ b/tests/management/test_eval_pipeline_robustness.py
@@ -1,0 +1,33 @@
+"""
+Regression tests for #47 — the eval pipeline must fail loudly (non-zero exit)
+instead of silently exiting 0 when the patient DB fetch fails or every patient
+errors. A silent exit-0 previously left trials4patients.sh proceeding to a
+missing-output FileNotFoundError downstream.
+"""
+from unittest.mock import patch
+
+import pytest
+from django.core.management import call_command
+from django.core.management.base import CommandError
+
+_CMD = 'trials.management.commands.search_trials_for_patients.Command'
+
+
+@pytest.mark.django_db
+class TestEvalPipelineFailsLoudly:
+    def test_db_fetch_failure_raises(self):
+        # _fetch_via_db returns None on any fetch failure (bad URL, psql missing,
+        # non-zero psql exit). handle() must turn that into a non-zero exit.
+        with patch(f'{_CMD}._fetch_via_db', return_value=None):
+            with pytest.raises(CommandError, match='Patient DB fetch failed'):
+                call_command('search_trials_for_patients', person_ids='1')
+
+    def test_all_patients_failing_raises(self):
+        # Rows fetched, but every per-patient match raises (e.g. trials DB down).
+        # A run that produced zero results must exit non-zero, not write an empty
+        # output file and report success.
+        rows = [{'person_id': 1, 'disease': 'multiple myeloma'}]
+        with patch(f'{_CMD}._fetch_via_db', return_value=rows), \
+                patch(f'{_CMD}._search_trials_direct', side_effect=RuntimeError('boom')):
+            with pytest.raises(CommandError, match='no results produced'):
+                call_command('search_trials_for_patients', person_ids='1')

--- a/trials/management/commands/fetch_exact_for_patients.py
+++ b/trials/management/commands/fetch_exact_for_patients.py
@@ -72,10 +72,18 @@ def _psql_query_rows(db_url, sql):
     if result.returncode != 0:
         raise RuntimeError(f'psql error: {result.stderr.strip()}')
     rows = []
+    skipped = 0
     for line in result.stdout.splitlines():
         line = line.strip()
-        if line:
+        if not line:
+            continue
+        try:
             rows.append(json.loads(line))
+        except json.JSONDecodeError as exc:
+            skipped += 1
+            logger.warning('Skipping non-JSON line from psql: %.80s — %s', line, exc)
+    if skipped:
+        logger.warning('Skipped %d non-JSON line(s) from psql output.', skipped)
     return rows
 
 

--- a/trials/management/commands/search_trials_for_patients.py
+++ b/trials/management/commands/search_trials_for_patients.py
@@ -33,7 +33,7 @@ import os
 import shutil
 import subprocess
 
-from django.core.management.base import BaseCommand
+from django.core.management.base import BaseCommand, CommandError
 from trials.services.patient_info.ctomop_adapter import (
     JSON_FIELDS,
     OUTCOME_MAP as _OUTCOME_MAP,
@@ -257,7 +257,9 @@ class Command(BaseCommand):
         rows = self._fetch_via_db(options, person_ids)
 
         if rows is None:
-            return  # error already reported
+            # Exit non-zero so a wrapping shell pipeline (trials4patients.sh)
+            # halts instead of proceeding to a missing-output FileNotFoundError.
+            raise CommandError('Patient DB fetch failed — see error above.')
 
         all_results = []
         processed = 0
@@ -319,6 +321,14 @@ class Command(BaseCommand):
         self.stdout.write(self.style.SUCCESS(
             f'\nDone. Patients processed: {processed}, Errors: {errors}'
         ))
+
+        # A run where every patient errored produced no usable results. Fail
+        # non-zero rather than writing an empty output file and exiting 0,
+        # which would let a wrapping pipeline mistake total failure for success.
+        if processed == 0 and errors > 0:
+            raise CommandError(
+                f'All {errors} patient(s) failed — no results produced.'
+            )
 
         if options['output']:
             self._write_output(all_results, options['output'], options['output_format'])
@@ -384,10 +394,20 @@ class Command(BaseCommand):
             return None
 
         rows = []
+        skipped = 0
         for line in result.stdout.splitlines():
             line = line.strip()
-            if line:
+            if not line:
+                continue
+            try:
                 rows.append(json.loads(line))
+            except json.JSONDecodeError as exc:
+                skipped += 1
+                logger.warning('Skipping non-JSON line from psql: %.80s — %s', line, exc)
+        if skipped:
+            self.stderr.write(self.style.WARNING(
+                f'  Skipped {skipped} non-JSON line(s) from psql output.'
+            ))
 
         return rows
 


### PR DESCRIPTION
Closes #47. Supersedes #48 (its branch predated the `ctomop_adapter` extraction and no longer rebased cleanly onto main).

## Root cause of #47

Two compounding issues, neither in the matching logic itself:

1. **Stale `:latest`** — `cancerbot/exact:latest` was last built 2026-04-16 and never re-tagged after the #46 crash fix. `docker.yml` only emitted `:sha` / `:branch` / `:tag`, never `:latest`, so `docker run …:latest` kept hitting the old `AttributeError`.
2. **Silent exit-0 on failure** — when the patient DB fetch failed (bad URL, psql missing, non-zero exit), `search_trials_for_patients` reported the error but `return`ed, exiting 0. `trials4patients.sh` then proceeded to Step 3, which reads the (never-written) results JSON → `FileNotFoundError`, masking the real cause.

## Changes

- **`.github/workflows/docker.yml`** — `type=raw,value=latest,enable={{is_default_branch}}` so every push to `main` re-tags `:latest`. (A one-time manual republish is still needed to backfill the current `:latest`.)
- **`search_trials_for_patients.py`** — raise `CommandError` (non-zero exit) when the patient DB fetch fails, and when every patient errors (zero results produced). Skip non-JSON `psql` lines with a warning instead of crashing.
- **`fetch_exact_for_patients.py`** — same non-JSON-line robustness in `_psql_query_rows`.
- **`tests/management/test_eval_pipeline_robustness.py`** — regression coverage for both fail-loudly paths (mocks `_fetch_via_db`, no live DB needed for the assertions).

## Testing

- `codex review --base origin/main` — no findings.
- Settings/command modules compile clean.
- The new tests can't run in my local env (the session-scoped `django_db_setup` fixture needs a seeded PostGIS test DB with grants this machine lacks) — **CI (`django.yml`) is the gate** for executing them, consistent with the rest of the suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)