### PR TITLE
fix(docker): bind $PORT (default 8080) for Cloud Run

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.12-slim
 
-ENV PYTHONUNBUFFERED=1 PYTHONHASHSEED=random PYTHONDONTWRITEBYTECODE=1 PORT=8000
+ENV PYTHONUNBUFFERED=1 PYTHONHASHSEED=random PYTHONDONTWRITEBYTECODE=1 PORT=8080
 
 RUN apt-get update \
     && apt-get -y --no-install-recommends install \
@@ -28,6 +28,6 @@ COPY . /app
 
 RUN python manage.py collectstatic --no-input
 
-EXPOSE 8000
+EXPOSE 8080
 
 CMD ["/app/docker/entrypoint.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,7 @@ services:
       DATABASE_PASSWORD: exact
       DATABASE_PORT: "5432"
       MALLOC_NANO_ZONE: "0"
+      PORT: "${PORT:-8000}"
     volumes:
       - /tmp:/tmp
     entrypoint: ["/app/docker/entrypoint.sh"]

--- a/docker/Image.md
+++ b/docker/Image.md
@@ -75,6 +75,7 @@ services:
         condition: service_healthy
     environment:
       SECRET_KEY: change-me
+      PORT: "8000"
       DATABASE_HOST: main_db
       DATABASE_NAME: exact
       DATABASE_USER: exact

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -19,4 +19,4 @@ cat <<'EOF'
 EOF
 
 echo "Starting gunicorn..."
-exec gunicorn exact.wsgi --workers 4 --timeout 300 --log-file - --bind 0.0.0.0:8000
+exec gunicorn exact.wsgi --workers 4 --timeout 300 --log-file - --bind "0.0.0.0:${PORT:-8080}"


### PR DESCRIPTION
## Summary
First of the #128 breakdown. Makes the container honor Cloud Run's injected `$PORT` (house default 8080) instead of a hardcoded 8000.

- `Dockerfile`: `PORT=8000` → `8080`, `EXPOSE 8000` → `8080`
- `docker/entrypoint.sh`: gunicorn `--bind 0.0.0.0:8000` → `--bind "0.0.0.0:${PORT:-8080}"`
- `docker-compose.yml`: pin container `PORT: "${PORT:-8000}"` so local dev stays on 8000 (the published mapping) while Cloud Run injects 8080

## Why the compose change
Baking `PORT=8080` into the Dockerfile would otherwise break local `docker compose up`: compose publishes `${PORT:-8000}:${PORT:-8000}`, but the container would inherit `PORT=8080` from the Dockerfile ENV and gunicorn would bind 8080 with nothing on the mapped 8000. Pinning the container's `PORT` keeps the published port and the bind port in sync locally.

## Test plan
- [ ] `docker compose up` serves on http://localhost:8000
- [ ] Image run with `-e PORT=8080` binds 8080 (Cloud Run path)

## Review note
Claude fresh-context self-review passed (caught + fixed the compose regression above). `codex review` could not run: codex CLI v0.130.0 rejects every model for ChatGPT accounts (`"... model is not supported when using Codex with a ChatGPT account"`). Codex half of the house two-part review is deferred until the CLI auth/model gating is resolved.

Part of #128.