### PR TITLE
feat(docker): gate entrypoint migrations behind RUN_MIGRATIONS

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,8 +1,15 @@
 #!/usr/bin/env bash
 set -e
 
-echo "Running migrations..."
-python manage.py migrate --run-syncdb
+case "${RUN_MIGRATIONS:-true}" in
+    0|false|no|off|FALSE|False)
+        echo "Skipping migrations (RUN_MIGRATIONS=${RUN_MIGRATIONS}); expecting a separate migrate job."
+        ;;
+    *)
+        echo "Running migrations..."
+        python manage.py migrate --run-syncdb
+        ;;
+esac
 
 bash /app/docker/init_trials_db.sh
 bash /app/docker/init_patients_db.sh


### PR DESCRIPTION
## Summary
Second of the #128 breakdown. Stops the web container from running `migrate` on every boot so Cloud Run blue-green can run migrations in a dedicated pre-traffic job instead.

- `docker/entrypoint.sh`: gate the `migrate --run-syncdb` step behind `RUN_MIGRATIONS` (default `true`).

## Behavior
- Default / unset / `true` / `1` / `yes` → migrations run (local `docker compose up` and the existing Docker Hub image are unchanged).
- Explicit falsy (`false` / `0` / `no` / `off` / `FALSE`) → migrations skipped, with a log line.
- Fail-safe: a mistyped flag runs migrations rather than booting against an unmigrated DB.

On Cloud Run, the web service sets `RUN_MIGRATIONS=false`; the `exact-staging-migrate` job runs `python manage.py migrate` between the no-traffic rollout and the traffic switch.

## Test plan
- [ ] `docker compose up` still auto-migrates (default)
- [ ] Container run with `-e RUN_MIGRATIONS=false` skips migrate and starts gunicorn
- [ ] Migrate job command `python manage.py migrate` applies migrations standalone

## Review note
Claude fresh-context self-review passed (reworked the gate to fail-safe on truthy/falsy values). `codex review` could not run: codex CLI v0.130.0 rejects every model for ChatGPT accounts (`"... model is not supported when using Codex with a ChatGPT account"`). Codex half of the house two-part review is deferred until the CLI auth/model gating is resolved.

Part of #128. Stacks logically after #137 (port fix).