### PR TITLE
ci: add keyless WIF Cloud Run staging deploy workflow

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -5,13 +5,14 @@ name: deploy-staging
 # Artifact Registry, roll out a no-traffic revision, run migrations in the
 # dedicated Cloud Run job, then switch traffic.
 #
-# Env/secret wiring for both the service and the migrate job lives in
-# Terraform (HealthTree/ht-phr infra/envs/staging/exact.tf); this workflow only
-# swaps the container image and orchestrates the rollout.
+# Env/secret wiring for both the service and the migrate job lives in the
+# staging infra Terraform; this workflow only swaps the container image and
+# orchestrates the rollout.
 #
 # Required GitHub Actions repository variables:
 #   GCP_PROJECT_ID               shared project id
 #   GCP_REGION                   e.g. us-central1
+#   GCP_AR_REPO                  Artifact Registry repository id holding the exact image
 #   GCP_WORKLOAD_IDENTITY_PROVIDER  projects/.../providers/...
 #   GCP_SERVICE_ACCOUNT          exact-staging-gh@<project>.iam.gserviceaccount.com
 
@@ -36,7 +37,7 @@ jobs:
       MIGRATE_JOB: exact-staging-migrate
       REGION: ${{ vars.GCP_REGION }}
       REGISTRY: ${{ vars.GCP_REGION }}-docker.pkg.dev
-      IMAGE: ${{ vars.GCP_REGION }}-docker.pkg.dev/${{ vars.GCP_PROJECT_ID }}/ht-phr/exact
+      IMAGE: ${{ vars.GCP_REGION }}-docker.pkg.dev/${{ vars.GCP_PROJECT_ID }}/${{ vars.GCP_AR_REPO }}/exact
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,0 +1,83 @@
+name: deploy-staging
+
+# Keyless (Workload Identity Federation) build + blue-green deploy to the
+# shared staging GCP project. Mirrors the house pattern: build the image into
+# Artifact Registry, roll out a no-traffic revision, run migrations in the
+# dedicated Cloud Run job, then switch traffic.
+#
+# Env/secret wiring for both the service and the migrate job lives in
+# Terraform (HealthTree/ht-phr infra/envs/staging/exact.tf); this workflow only
+# swaps the container image and orchestrates the rollout.
+#
+# Required GitHub Actions repository variables:
+#   GCP_PROJECT_ID               shared project id
+#   GCP_REGION                   e.g. us-central1
+#   GCP_WORKLOAD_IDENTITY_PROVIDER  projects/.../providers/...
+#   GCP_SERVICE_ACCOUNT          exact-staging-gh@<project>.iam.gserviceaccount.com
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: deploy-staging
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    env:
+      SERVICE: exact-staging
+      MIGRATE_JOB: exact-staging-migrate
+      REGION: ${{ vars.GCP_REGION }}
+      REGISTRY: ${{ vars.GCP_REGION }}-docker.pkg.dev
+      IMAGE: ${{ vars.GCP_REGION }}-docker.pkg.dev/${{ vars.GCP_PROJECT_ID }}/ht-phr/exact
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Authenticate to Google Cloud (WIF)
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ vars.GCP_SERVICE_ACCOUNT }}
+
+      - name: Set up gcloud
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          project_id: ${{ vars.GCP_PROJECT_ID }}
+
+      - name: Configure Docker for Artifact Registry
+        run: gcloud auth configure-docker "$REGISTRY" --quiet
+
+      - name: Build and push image
+        run: |
+          docker build -t "$IMAGE:${{ github.sha }}" -t "$IMAGE:latest" .
+          docker push "$IMAGE:${{ github.sha }}"
+          docker push "$IMAGE:latest"
+
+      - name: Deploy new revision (no traffic)
+        run: |
+          gcloud run deploy "$SERVICE" \
+            --image "$IMAGE:${{ github.sha }}" \
+            --region "$REGION" \
+            --no-traffic
+
+      - name: Run database migrations
+        run: |
+          gcloud run jobs update "$MIGRATE_JOB" \
+            --image "$IMAGE:${{ github.sha }}" \
+            --region "$REGION"
+          gcloud run jobs execute "$MIGRATE_JOB" \
+            --region "$REGION" \
+            --wait
+
+      - name: Route traffic to new revision
+        run: |
+          gcloud run services update-traffic "$SERVICE" \
+            --region "$REGION" \
+            --to-latest


### PR DESCRIPTION
## Summary
Third of the #128 breakdown. Adds `.github/workflows/deploy-staging.yml`: a keyless (Workload Identity Federation) build + blue-green deploy to the shared staging GCP project.

Sequence (matches the infra-documented order):
1. WIF auth (no long-lived JSON keys)
2. Build + push image to Artifact Registry, tagged `:${{ github.sha }}` and `:latest`
3. Deploy a **no-traffic** revision
4. Run migrations in the `exact-staging-migrate` Cloud Run job (`--wait`)
5. Switch traffic to the new revision **only after migrations succeed**

Env/secret wiring for both the service and the migrate job stays in the staging infra Terraform; this workflow only swaps the container image and orchestrates the rollout.

## Prerequisites / required ops actions
1. **Set repo variables** (Settings → Secrets and variables → Actions → Variables): `GCP_PROJECT_ID`, `GCP_REGION`, `GCP_AR_REPO`, `GCP_WORKLOAD_IDENTITY_PROVIDER`, `GCP_SERVICE_ACCOUNT`.
2. **`RUN_MIGRATIONS=false` on the EXACT web service** — needs adding to the web service `env_vars` in the staging infra, otherwise #138's gate has no effect on Cloud Run (the web container would auto-migrate on boot in addition to the migrate job; idempotent but redundant). The migrate *job* is unaffected — it runs `python manage.py migrate --noinput` via command override, bypassing the entrypoint. Tracked as #140.
3. **Bootstrap order:** the first image must exist in Artifact Registry before `terraform apply` creates the service/job (they reference `exact:latest`). First deploy: push an initial image → `terraform apply` → subsequent workflow runs are clean.

## Notes
- This repo is public, so internal infra naming is kept out of the workflow: the Artifact Registry repository id is supplied via `GCP_AR_REPO` rather than hardcoded. No secrets are exposed — all real values come from `vars`/secrets.
- Tags with `:${{ github.sha }}` (immutable/rollback) and pushes `:latest`. Terraform tracks `:latest`, so a deploy shows cosmetic image drift; reverting to `:latest` points at the same digest.
- `concurrency: deploy-staging` with `cancel-in-progress: false` serializes deploys.
- Replaces the Docker-Hub-only `docker.yml` for staging; that retirement is a separate PR once this is proven on a real deploy.

## Depends on
- #137 (port fix), #138 (migrate gate)
- Staging infra applied (creates the service, migrate job, WIF, secrets)

## Review note
Two-part self-review complete: Claude fresh-context + `codex review` (v0.136.0). Codex's one finding — the service entrypoint still migrates on startup — is resolved across the stack by #138 (gate) + #140 (infra `RUN_MIGRATIONS=false`), not a PR 3 change.

Part of #128.