### PR TITLE
Deploy EXACT to staging: keyless-WIF Cloud Run + house serving shape

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM python:3.12-slim
 
-ENV PYTHONUNBUFFERED=1 PYTHONHASHSEED=random PYTHONDONTWRITEBYTECODE=1 PORT=8000
+# Cloud Run injects $PORT and routes to the container's configured port
+# (8080 in the house cloud_run module). gunicorn binds $PORT below.
+ENV PYTHONUNBUFFERED=1 PYTHONHASHSEED=random PYTHONDONTWRITEBYTECODE=1 PORT=8080
 
 RUN apt-get update \
     && apt-get -y --no-install-recommends install \
@@ -28,6 +30,11 @@ COPY . /app
 
 RUN python manage.py collectstatic --no-input
 
-EXPOSE 8000
+EXPOSE 8080
 
-CMD ["/app/docker/entrypoint.sh"]
+# Cloud Run serving command: gunicorn only. Migrations run in the dedicated
+# `exact-staging-migrate` Cloud Run job (command overridden by the house
+# cloud_run module to `manage.py migrate`), NOT in the serving container.
+# Local dev uses docker/entrypoint.sh instead, pinned via docker-compose's
+# own `entrypoint:` override — so that path (migrate + seed) is unaffected.
+CMD ["sh", "-c", "exec gunicorn exact.wsgi --workers ${GUNICORN_WORKERS:-4} --timeout ${GUNICORN_TIMEOUT:-300} --log-file - --bind 0.0.0.0:${PORT}"]


### PR DESCRIPTION
## Summary

Prepares EXACT for a staging deploy to GCP Cloud Run, following the house pattern (centralized Terraform in `HealthTree/ht-phr`, public Cloud Run :8080, shared Cloud SQL, keyless WIF, secrets-as-env), the same shape SoC and ctomop use.

- **`deploy-staging.yml`** — keyless WIF GitHub Actions deploy: build/push image to the shared `ht-phr` Artifact Registry, no-traffic rollout, run the dedicated `exact-staging-migrate` Cloud Run job, then switch traffic. Triggers on push to `main` + `workflow_dispatch`.
- **`Dockerfile`** — serving container now uses the house shape: port **8080**, `gunicorn` bound to `$PORT`, **no** migrate/seed in the serving path (migrations run in the migrate job; its command is overridden to `manage.py migrate --noinput` by the house `cloud_run` module). Local dev is unaffected — `docker-compose.yml` pins its own `entrypoint:` override.

Infra for EXACT (DB+user on shared Cloud SQL, IAM, secrets, Cloud Run service, migrate job, WIF) is defined in **`exact.tf`** within **ht-phr PR #36**.

## Already deploy-ready (no change needed)
- GDAL/PostGIS libs in the image; `CreateExtension('postgis')` is the first op in `trials/0001_initial.py`.
- Settings read `DATABASE_URL`/`TRIALS_DATABASE_URL`, `SECRET_KEY`, `FIREBASE_CREDENTIALS_JSON`, `SERVICE_AUTH_TOKEN`, `ALLOWED_HOSTS`, `CSRF_TRUSTED_ORIGINS` from env; PostGIS engine forced; `SECURE_PROXY_SSL_HEADER` set for Cloud Run. No `TRIALS_DATABASE_URL` is injected in staging, so trials models fall back to the `exact` DB via the router (already coded).
- House OIDC auth (`AUTH_USER_MODEL=accounts.Identity` + migrations, Firebase init in settings).
- No divergent infra in the repo (no cloudbuild.yaml / deploy.sh / VPC / internal ingress).

## Privileged steps to go live (infra owner)
1. Merge **ht-phr #36** → `terraform apply` (creates DB/user, SAs, secret containers, Cloud Run service `exact-staging`, job `exact-staging-migrate`, WIF pool).
2. Populate secret values: `exact-staging-django-secret-key`, `exact-staging-database-url` (socket DSN `postgres://exact:<pw>@/exact?host=/cloudsql/<connection_name>`).
3. Ensure the `exact` Cloud SQL user can `CREATE EXTENSION postgis` (needs `cloudsqlsuperuser`) **or** pre-create the extension — otherwise the migrate job's first op fails.
4. Set repo variables on `healthkey-ai/exact` (from `terraform output`): `GCP_PROJECT_ID`, `GCP_REGION`, `GCP_AR_REPO=ht-phr`, `GCP_WORKLOAD_IDENTITY_PROVIDER`, `GCP_SERVICE_ACCOUNT`.
5. Merge this PR → workflow deploys.

## Out of scope / follow-ups
- Trials/patients catalog seeding in staging (no Cloud Run seed job in exact.tf yet; service comes up with empty trials).
- **Deferred (cross-service hardening):** the traffic switch uses `--to-latest`, matching SoC's house workflow. Codex flagged that capturing the no-traffic revision and routing `--to-revisions <rev>=100` is marginally safer against an out-of-band revision racing the CI deploy. Low-probability (the `concurrency` group serializes CI deploys); should be applied to SoC + EXACT together, not diverged here.

## Test plan
- [ ] Image builds (GDAL/PostGIS layers + `collectstatic`).
- [ ] After infra apply + repo vars: workflow runs end-to-end (build → no-traffic → migrate job → traffic).
- [ ] `exact-staging` serves on 8080; `/healthz` (or equivalent) returns 200.
- [ ] Migrate job applies `trials/0001_initial` incl. PostGIS extension.

🤖 Generated with [Claude Code](https://claude.com/claude-code)