### PR TITLE
ci: gate deploy-staging to manual dispatch only

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -17,8 +17,6 @@ name: deploy-staging
 #   GCP_SERVICE_ACCOUNT          exact-staging-gh@<project>.iam.gserviceaccount.com
 
 on:
-  push:
-    branches: [main]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary
- EXACT staging is deployed **manually** (build/push image → `terraform apply` in ht-phr → add Secret Manager values → run the `exact-staging-migrate` job), not via CI.
- This workflow currently triggers on `push: [main]`, so every merge to `main` would auto-build-and-deploy — or leave failing red runs when the WIF repo variables aren't configured.
- Drop the `push` trigger; keep `workflow_dispatch` so the pipeline can still be run on demand once the infra (service + migrate job + repo vars) exists.

## Test plan
- [ ] Confirm the workflow no longer appears as a triggered run on push to `main`.
- [ ] Confirm it can still be launched from the Actions tab via "Run workflow" (workflow_dispatch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)