### PR TITLE
fix(ctomop): unwrap patient_info envelope in fetch_patient (#144)

### DIFF
--- a/tests/services/patient_info/test_ctomop_client.py
+++ b/tests/services/patient_info/test_ctomop_client.py
@@ -151,17 +151,20 @@ class TestCtomopClientFetch:
             result = client.fetch_patient(9005)
         assert result == flat
 
-    def test_envelope_with_sibling_keys_not_unwrapped(self):
-        """Only a sole `patient_info` key is the envelope. A flat row that
-        happens to carry a nested `patient_info` alongside other columns is
-        ambiguous — pass it through rather than guess (#144).
+    def test_envelope_with_sibling_keys_is_unwrapped(self):
+        """An envelope that carries metadata alongside the row (status,
+        pagination, request id) must STILL unwrap to the inner row — matching
+        the inline contract, which reads `patient_info` and ignores siblings.
+        Requiring a sole key would silently revert to the all-defaults bug if
+        CTOMOP ever adds envelope metadata (#144).
         """
         client = CtomopClient(base_url='https://ctomop.example.com', token='tk')
-        body = {'patient_info': {'disease': 'breast cancer'}, 'person_id': 9005}
+        body = {'patient_info': {'person_id': 9005, 'disease': 'breast cancer'},
+                'status': 'ok'}
         with patch('trials.services.patient_info.ctomop_client.requests.get',
                    return_value=_ok_response(body)):
             result = client.fetch_patient(9005)
-        assert result == body
+        assert result == {'person_id': 9005, 'disease': 'breast cancer'}
 
     def test_uses_django_settings_when_no_explicit_args(self, settings):
         """Constructor falls back to CTOMOP_BASE / CTOMOP_SERVICE_TOKEN settings."""

--- a/tests/services/patient_info/test_ctomop_client.py
+++ b/tests/services/patient_info/test_ctomop_client.py
@@ -125,6 +125,44 @@ class TestCtomopClientFetch:
         # URL has the validated integer, not the raw string.
         assert mock_get.call_args.args[0] == 'https://ctomop.example.com/api/patient-info/9001/'
 
+    def test_unwraps_patient_info_envelope(self):
+        """The HTTP endpoint wraps the row in `{"patient_info": {...}}`; the
+        adapter expects a flat row. `fetch_patient` must unwrap so real fields
+        aren't nested one level too deep and silently dropped (#144).
+        """
+        client = CtomopClient(base_url='https://ctomop.example.com', token='tk')
+        envelope = {'patient_info': {'person_id': 9005, 'disease': 'breast cancer',
+                                     'patient_age': 51, 'gender': 'F'}}
+        with patch('trials.services.patient_info.ctomop_client.requests.get',
+                   return_value=_ok_response(envelope)):
+            result = client.fetch_patient(9005)
+        assert result == {'person_id': 9005, 'disease': 'breast cancer',
+                          'patient_age': 51, 'gender': 'F'}
+
+    def test_flat_row_passes_through_unchanged(self):
+        """Invariant: an already-flat row (the psql management-command shape)
+        must pass through untouched — no double-unwrap, no mangling (#144).
+        """
+        client = CtomopClient(base_url='https://ctomop.example.com', token='tk')
+        flat = {'person_id': 9005, 'disease': 'breast cancer',
+                'patient_age': 51, 'gender': 'F'}
+        with patch('trials.services.patient_info.ctomop_client.requests.get',
+                   return_value=_ok_response(flat)):
+            result = client.fetch_patient(9005)
+        assert result == flat
+
+    def test_envelope_with_sibling_keys_not_unwrapped(self):
+        """Only a sole `patient_info` key is the envelope. A flat row that
+        happens to carry a nested `patient_info` alongside other columns is
+        ambiguous — pass it through rather than guess (#144).
+        """
+        client = CtomopClient(base_url='https://ctomop.example.com', token='tk')
+        body = {'patient_info': {'disease': 'breast cancer'}, 'person_id': 9005}
+        with patch('trials.services.patient_info.ctomop_client.requests.get',
+                   return_value=_ok_response(body)):
+            result = client.fetch_patient(9005)
+        assert result == body
+
     def test_uses_django_settings_when_no_explicit_args(self, settings):
         """Constructor falls back to CTOMOP_BASE / CTOMOP_SERVICE_TOKEN settings."""
         settings.CTOMOP_BASE = 'https://settings.example.com'

--- a/tests/services/patient_info/test_resolve_ctomop.py
+++ b/tests/services/patient_info/test_resolve_ctomop.py
@@ -94,6 +94,43 @@ class TestResolvePatientInfoDispatch:
         MockClient.return_value.fetch_patient.assert_not_called()
         assert result == 'inline_pi'
 
+    @pytest.mark.django_db
+    def test_enveloped_fetch_survives_into_patient_info(self):
+        """End-to-end regression for #144: an enveloped HTTP body
+        (`{"patient_info": {...}}`) fetched via CtomopClient and run through the
+        adapter must yield a PatientInfo carrying the patient's real disease /
+        age / gender — NOT the silent myeloma defaults that result when the
+        envelope is left un-unwrapped and every field is filtered away.
+        """
+        from unittest.mock import MagicMock
+        from trials.services.patient_info.ctomop_client import CtomopClient
+        from trials.services.patient_info.ctomop_adapter import (
+            build_patient_info_from_ctomop_row,
+        )
+
+        resp = MagicMock()
+        resp.ok = True
+        resp.status_code = 200
+        resp.reason = 'OK'
+        resp.json.return_value = {
+            'patient_info': {
+                'person_id': 9005,
+                'disease': 'breast cancer',
+                'patient_age': 51,
+                'gender': 'F',
+            },
+        }
+        client = CtomopClient(base_url='https://ctomop.example.com', token='tk')
+        with patch('trials.services.patient_info.ctomop_client.requests.get',
+                   return_value=resp):
+            row = client.fetch_patient(9005)
+
+        pi = build_patient_info_from_ctomop_row(row)
+
+        assert pi.disease == 'breast cancer'   # not the 'multiple myeloma' default
+        assert pi.patient_age == 51            # not None
+        assert pi.gender == 'F'                # not None
+
     def test_ctomop_client_returns_none_propagates(self):
         """Client failure (network, 4xx/5xx, malformed JSON) → resolver returns None."""
         req = _mock_request(query_params={'person_id': '9001'})

--- a/trials/services/patient_info/ctomop_client.py
+++ b/trials/services/patient_info/ctomop_client.py
@@ -114,13 +114,17 @@ class CtomopClient:
             return None
 
         # Unwrap the `{"patient_info": {...}}` envelope the HTTP endpoint emits
-        # so the adapter receives a flat row. Only unwrap when `patient_info` is
-        # the sole key and maps to a dict — that is the envelope shape. A flat
-        # row from the psql path has many top-level columns and never a nested
-        # `patient_info`, so it passes straight through. Logged at debug so any
-        # future envelope drift is observable rather than silent (#144).
+        # so the adapter receives a flat row. Unwrap whenever a dict-valued
+        # `patient_info` key is present — NOT only when it is the sole key. This
+        # mirrors the inline request-body contract (`resolve_patient_info` reads
+        # `data['patient_info']` and ignores siblings like `person_id`), so any
+        # envelope metadata CTOMOP adds alongside the row (status, pagination,
+        # request id) still unwraps correctly instead of silently reverting to
+        # the all-defaults bug. A flat psql-path row has no `patient_info`
+        # column, so it passes straight through. Logged at debug so future
+        # envelope drift stays observable (#144).
         inner = data.get('patient_info')
-        if isinstance(inner, dict) and len(data) == 1:
+        if isinstance(inner, dict):
             logger.debug(
                 'CtomopClient unwrapped patient_info envelope for person_id=%s', person_id,
             )

--- a/trials/services/patient_info/ctomop_client.py
+++ b/trials/services/patient_info/ctomop_client.py
@@ -37,7 +37,16 @@ class CtomopClient:
         self.timeout = timeout
 
     def fetch_patient(self, person_id) -> dict | None:
-        """GET {base}/api/patient-info/{person_id}/ and return the JSON row.
+        """GET {base}/api/patient-info/{person_id}/ and return the flat JSON row.
+
+        The endpoint wraps the row in a `{"patient_info": {...}}` envelope (the
+        same shape the inline-payload request body uses). This method unwraps
+        that envelope so callers always receive a flat row — matching the shape
+        `normalize_ctomop_row`/`build_patient_info_from_ctomop_row` expect and
+        the psql management-command path already yields. Without unwrapping,
+        every real field would be nested one level too deep, silently dropped
+        by the model-field filter in `_build_in_memory`, and the PatientInfo
+        would be built entirely from defaults (#144).
 
         `person_id` MUST be a positive integer (CTOMOP's primary key shape);
         anything else returns None without making a network call. This guards
@@ -103,5 +112,18 @@ class CtomopClient:
                 person_id, type(data).__name__,
             )
             return None
+
+        # Unwrap the `{"patient_info": {...}}` envelope the HTTP endpoint emits
+        # so the adapter receives a flat row. Only unwrap when `patient_info` is
+        # the sole key and maps to a dict — that is the envelope shape. A flat
+        # row from the psql path has many top-level columns and never a nested
+        # `patient_info`, so it passes straight through. Logged at debug so any
+        # future envelope drift is observable rather than silent (#144).
+        inner = data.get('patient_info')
+        if isinstance(inner, dict) and len(data) == 1:
+            logger.debug(
+                'CtomopClient unwrapped patient_info envelope for person_id=%s', person_id,
+            )
+            return inner
 
         return data


### PR DESCRIPTION
## Summary

`CtomopClient.fetch_patient` returned the raw CTOMOP HTTP body, which wraps the
row in a `{"patient_info": {...}}` envelope, without unwrapping it. The adapter
(`build_patient_info_from_ctomop_row`) expects a flat row, so every real field
was nested one level too deep, silently dropped by the model-field filter in
`_build_in_memory`, and the `PatientInfo` was built entirely from defaults
(`disease='multiple myeloma'`, age/gender `None`). Net effect: the `?person_id=`
trial-matching path resolved the **wrong patient** with no error raised.

Fix: unwrap the envelope at the HTTP boundary in `fetch_patient`, whenever
`patient_info` is a dict. This mirrors the inline-payload contract in
`resolve_patient_info` (which reads `data['patient_info']` and ignores siblings
like `person_id`), so any envelope metadata CTOMOP adds alongside the row still
unwraps correctly instead of reverting to the all-defaults bug. A flat psql-path
row has no `patient_info` column, so it passes through unchanged.

Closes #144.

## Changes
- `trials/services/patient_info/ctomop_client.py` — unwrap dict-valued
  `patient_info` envelope; docstring updated to reflect the flat-row contract.
- Regression tests: envelope unwrap, flat-row passthrough invariant,
  sibling-keyed envelope still unwraps, and an end-to-end test that
  disease/age/gender survive a CTOMOP fetch (not the myeloma defaults).

## Review
Two-part self-review per repo convention:
- Claude `/review` (fresh-context structured + adversarial) — caught that an
  initial sole-key (`len(data)==1`) guard was stricter than the inline contract
  and would silently revert to the bug if CTOMOP's envelope carried sibling
  metadata. Fixed before push.
- `codex review` (gpt-5.5, structured) — no blocking correctness issues.

## Test plan
- [x] `pytest tests/services/patient_info/test_ctomop_client.py tests/services/patient_info/test_resolve_ctomop.py` — 35 passed
- [ ] Confirm CTOMOP's live `/api/patient-info/{id}/` response shape matches the envelope assumption (the unwrap is tolerant of both flat and enveloped bodies regardless)

🤖 Generated with [Claude Code](https://claude.com/claude-code)