### PR TITLE
fix(ctomop): map OMOP gender concept name to EXACT F/M code (#145)

### DIFF
--- a/tests/management/test_normalize_ctomop_row.py
+++ b/tests/management/test_normalize_ctomop_row.py
@@ -337,6 +337,36 @@ class TestGenderNormalization:
         result = _normalize_ctomop_row(_row(gender='F', gender_source_value='M'))
         assert result['gender'] == 'F'
 
+    def test_omop_concept_name_female(self):
+        # HTTP path sends the OMOP concept name 'Female' (concept_id 8532).
+        assert _normalize_ctomop_row(_row(gender='Female'))['gender'] == 'F'
+
+    def test_omop_concept_name_male(self):
+        assert _normalize_ctomop_row(_row(gender='Male'))['gender'] == 'M'
+
+    def test_omop_concept_name_case_insensitive(self):
+        assert _normalize_ctomop_row(_row(gender='FEMALE'))['gender'] == 'F'
+        assert _normalize_ctomop_row(_row(gender=' male '))['gender'] == 'M'
+
+    def test_coded_gender_is_idempotent(self):
+        assert _normalize_ctomop_row(_row(gender='F'))['gender'] == 'F'
+        assert _normalize_ctomop_row(_row(gender='M'))['gender'] == 'M'
+
+    def test_full_word_gender_wins_over_source_value(self):
+        # A populated full-word gender is translated unconditionally; the
+        # empty-gender source-value fallback never overrides it.
+        result = _normalize_ctomop_row(_row(gender='Female', gender_source_value='M'))
+        assert result['gender'] == 'F'
+
+    def test_unknown_gender_left_unmapped(self):
+        # Non-binary OMOP concepts have no EXACT code; left as-is → non-matching.
+        assert _normalize_ctomop_row(_row(gender='Unknown'))['gender'] == 'Unknown'
+
+    def test_bare_concept_id_in_gender_field(self):
+        # The endpoint may put the OMOP concept id directly in `gender`.
+        assert _normalize_ctomop_row(_row(gender=8507))['gender'] == 'M'
+        assert _normalize_ctomop_row(_row(gender=8532))['gender'] == 'F'
+
 
 # ---------------------------------------------------------------------------
 # Receptor-status alias resolution — requires _build_code_lookup()

--- a/tests/management/test_normalize_ctomop_row.py
+++ b/tests/management/test_normalize_ctomop_row.py
@@ -358,9 +358,27 @@ class TestGenderNormalization:
         result = _normalize_ctomop_row(_row(gender='Female', gender_source_value='M'))
         assert result['gender'] == 'F'
 
-    def test_unknown_gender_left_unmapped(self):
-        # Non-binary OMOP concepts have no EXACT code; left as-is → non-matching.
-        assert _normalize_ctomop_row(_row(gender='Unknown'))['gender'] == 'Unknown'
+    def test_unknown_gender_mapped_to_blank(self):
+        # Non-binary OMOP concepts have no EXACT code; blank (None) so the
+        # matcher treats gender as unknown instead of excluding the patient.
+        assert _normalize_ctomop_row(_row(gender='Unknown'))['gender'] is None
+        assert _normalize_ctomop_row(_row(gender='Ambiguous'))['gender'] is None
+        assert _normalize_ctomop_row(_row(gender='Other'))['gender'] is None
+
+    def test_unmapped_concept_id_mapped_to_blank(self):
+        # An unrecognized concept id in `gender` is also blanked, not left as int.
+        assert _normalize_ctomop_row(_row(gender=99999))['gender'] is None
+
+    def test_empty_string_gender_falls_back_to_concept_id(self):
+        # An empty-string gender is blanked, then recovered from the concept id.
+        result = _normalize_ctomop_row(_row(gender='', gender_concept_id=8532))
+        assert result['gender'] == 'F'
+
+    def test_unknown_gender_falls_back_to_source_value(self):
+        # Blanking an unrecognized name lets the empty-gender fallback recover
+        # a value from gender_source_value when one is present.
+        result = _normalize_ctomop_row(_row(gender='Unknown', gender_source_value='M'))
+        assert result['gender'] == 'M'
 
     def test_bare_concept_id_in_gender_field(self):
         # The endpoint may put the OMOP concept id directly in `gender`.

--- a/trials/services/patient_info/ctomop_adapter.py
+++ b/trials/services/patient_info/ctomop_adapter.py
@@ -451,9 +451,16 @@ def normalize_ctomop_row(row: dict) -> dict:
     # fallback below never sees it. Also accept a bare concept id arriving in
     # the `gender` field itself (the endpoint may surface either shape, #145);
     # the separate `gender_concept_id` field is still handled by the fallback.
-    # Idempotent: an already-coded 'F'/'M' row maps to itself. Other OMOP
-    # values ('Unknown'/'Ambiguous'/'Other') are left as-is and treated as
-    # non-matching by the matcher (#145).
+    # Idempotent: an already-coded 'F'/'M' row maps to itself.
+    #
+    # Unrecognized non-binary concepts ('Unknown'/'Ambiguous'/'Other', or an
+    # unmapped id) are blanked to None rather than left as a literal string.
+    # The matcher treats a blank gender as unknown (`_match_type_str_value` →
+    # 'unknown'), keeping the patient a potential match for gender-gated trials;
+    # an un-blanked 'Unknown' would instead read as an active criterion and
+    # silently EXCLUDE the patient from every gender-restricted trial (#145).
+    # Blanking also lets the empty-gender fallback below recover a value from
+    # gender_source_value / gender_concept_id when one is present.
     g = row.get('gender')
     if isinstance(g, str):
         gl = g.strip().lower()
@@ -461,10 +468,14 @@ def normalize_ctomop_row(row: dict) -> dict:
             row['gender'] = 'F'
         elif gl in ('m', 'male'):
             row['gender'] = 'M'
+        else:
+            row['gender'] = None
     elif g == 8507:
         row['gender'] = 'M'
     elif g == 8532:
         row['gender'] = 'F'
+    elif g is not None:
+        row['gender'] = None
 
     # ── Gender from person.gender_source_value (added by _fetch_via_db) ─
     # gender_source_value is typically 'M' / 'F' in OMOP; fallback to concept IDs.

--- a/trials/services/patient_info/ctomop_adapter.py
+++ b/trials/services/patient_info/ctomop_adapter.py
@@ -444,6 +444,28 @@ def normalize_ctomop_row(row: dict) -> dict:
         if isinstance(dob, date):
             row['patient_age'] = (date.today() - dob).days // 365
 
+    # ── Gender — OMOP concept name / id → EXACT code ───────────────────
+    # The CTOMOP HTTP path sends the OMOP-standard gender as the concept
+    # name ('Female'=8532, 'Male'=8507); EXACT expects 'F'/'M'. Translate
+    # unconditionally — the value is already populated, so the empty-gender
+    # fallback below never sees it. Also accept a bare concept id arriving in
+    # the `gender` field itself (the endpoint may surface either shape, #145);
+    # the separate `gender_concept_id` field is still handled by the fallback.
+    # Idempotent: an already-coded 'F'/'M' row maps to itself. Other OMOP
+    # values ('Unknown'/'Ambiguous'/'Other') are left as-is and treated as
+    # non-matching by the matcher (#145).
+    g = row.get('gender')
+    if isinstance(g, str):
+        gl = g.strip().lower()
+        if gl in ('f', 'female'):
+            row['gender'] = 'F'
+        elif gl in ('m', 'male'):
+            row['gender'] = 'M'
+    elif g == 8507:
+        row['gender'] = 'M'
+    elif g == 8532:
+        row['gender'] = 'F'
+
     # ── Gender from person.gender_source_value (added by _fetch_via_db) ─
     # gender_source_value is typically 'M' / 'F' in OMOP; fallback to concept IDs.
     if not row.get('gender'):


### PR DESCRIPTION
## Summary

On the CTOMOP HTTP fetch path, `/api/patient-info/{id}/` returns `gender` as the
OMOP-standard concept name (`"Female"` = concept_id 8532, `"Male"` = 8507), but
EXACT's `PatientInfo.gender` expects the short code `"F"`/`"M"`. The adapter only
derived gender inside the `if not row.get('gender'):` branch, so a populated
full-word value passed through unmapped and the matcher compared trial gender
criteria (`'M'`/`'F'`/`'all'`) against `'Female'` — which never matches.

Fix: translate the OMOP gender to the EXACT code **unconditionally**, before the
existing `gender_source_value` / concept-id fallback. Maps `Female`/`Male`
(case- and whitespace-tolerant) → `F`/`M`, and a bare concept id (8507/8532)
arriving directly in the `gender` field. Idempotent for already-coded rows.

**Unknown gender → blank.** Non-binary OMOP concepts (`Unknown`/`Ambiguous`/
`Other`) and unmapped ids are blanked to `None`, not left as a literal string.
The matcher treats a blank gender as unknown (`_match_type_str_value` → `'unknown'`),
keeping the patient a **potential** match for gender-restricted trials; an
un-blanked `'Unknown'` would instead read as an active criterion and silently
**exclude** the patient from every gender-gated trial. Blanking also lets the
empty-gender fallback recover a value from `gender_source_value` /
`gender_concept_id` when one is present.

Closes #145. Depended on #144 (envelope unwrap, merged in #146) for the gender
value to reach the adapter at all.

## Changes
- `trials/services/patient_info/ctomop_adapter.py` — `normalize_ctomop_row`
  gender block: unconditional concept-name/id → code translation; unrecognized
  values blanked to `None`.
- Tests (`tests/management/test_normalize_ctomop_row.py`): `Female`/`Male`, case +
  whitespace variants, idempotence of `F`/`M`, full-word-wins-over-source-value,
  bare concept id in `gender`, unknown/ambiguous/other → blank, unmapped id →
  blank, and blank-then-fallback recovery (source value + concept id).

## Review
Two-part self-review per repo convention, run on both commits:
- Claude `/review` (fresh-context adversarial) — APPROVE. Verified the
  blank-then-fallback order preserves recoverable `F`/`M`, idempotence holds, and
  `None` reads as blank end-to-end (`build_patient_info_from_ctomop_row` skips
  None → `is_attr_blank` True → matcher `'unknown'`, not `'not_matched'`).
- `codex review` — APPROVE. (Earlier pass requested changes on a bare integer
  concept id bypassing the mapping; hardened to map 8507/8532 and re-approved.)

## Test plan
- [x] `pytest tests/management/test_normalize_ctomop_row.py::TestGenderNormalization` — 17 passed
- [x] `pytest tests/management tests/services/patient_info tests/views/test_normalize_ctomop_row_view.py` — no regressions
- [ ] Confirm CTOMOP's live `/api/patient-info/{id}/` gender shape (concept name vs bare id) — mapping tolerates both

🤖 Generated with [Claude Code](https://claude.com/claude-code)