### PR TITLE
fix(trials): clamp goodness score and rescale seed data to 0–20

### DIFF
--- a/trials/management/commands/seed_test_trials.py
+++ b/trials/management/commands/seed_test_trials.py
@@ -37,10 +37,10 @@ TRIALS = [
         no_hiv_required=True,
         no_hepatitis_b_required=True,
         no_hepatitis_c_required=True,
-        # Scoring
-        benefit_score=80,
-        patient_burden_score=30,
-        risk_score=20,
+        # Scoring (0–20 scale; see Trial.get_goodness_score)
+        benefit_score=16,
+        patient_burden_score=6,
+        risk_score=4,
     ),
     dict(
         code='TEST-MM-002',
@@ -56,9 +56,9 @@ TRIALS = [
         prior_therapy_lines='none',
         therapy_lines_count_min=0,
         therapy_lines_count_max=0,
-        benefit_score=90,
-        patient_burden_score=60,
-        risk_score=40,
+        benefit_score=18,
+        patient_burden_score=12,
+        risk_score=8,
     ),
 
     # ── Follicular Lymphoma ───────────────────────────────────────────
@@ -76,9 +76,9 @@ TRIALS = [
         prior_therapy_lines='none',
         therapy_lines_count_min=0,
         therapy_lines_count_max=0,
-        benefit_score=75,
-        patient_burden_score=40,
-        risk_score=25,
+        benefit_score=15,
+        patient_burden_score=8,
+        risk_score=5,
     ),
     dict(
         code='TEST-FL-002',
@@ -93,9 +93,9 @@ TRIALS = [
         age_high_limit=85,
         prior_therapy_lines='moreThanOne',
         therapy_lines_count_min=2,
-        benefit_score=70,
-        patient_burden_score=25,
-        risk_score=20,
+        benefit_score=14,
+        patient_burden_score=5,
+        risk_score=4,
     ),
 
     # ── Breast Cancer ─────────────────────────────────────────────────
@@ -111,9 +111,9 @@ TRIALS = [
         age_low_limit=18,
         age_high_limit=80,
         tnbc_status=True,
-        benefit_score=85,
-        patient_burden_score=50,
-        risk_score=35,
+        benefit_score=17,
+        patient_burden_score=10,
+        risk_score=7,
     ),
     dict(
         code='TEST-BC-002',
@@ -126,9 +126,9 @@ TRIALS = [
         phases=['Phase 3'],
         age_low_limit=18,
         age_high_limit=80,
-        benefit_score=78,
-        patient_burden_score=30,
-        risk_score=20,
+        benefit_score=16,
+        patient_burden_score=6,
+        risk_score=4,
     ),
 
     # ── CLL ───────────────────────────────────────────────────────────
@@ -145,9 +145,9 @@ TRIALS = [
         age_high_limit=85,
         prior_therapy_lines='moreThanOne',
         therapy_lines_count_min=1,
-        benefit_score=82,
-        patient_burden_score=25,
-        risk_score=18,
+        benefit_score=16,
+        patient_burden_score=5,
+        risk_score=4,
     ),
     dict(
         code='TEST-CLL-002',
@@ -163,9 +163,9 @@ TRIALS = [
         prior_therapy_lines='none',
         therapy_lines_count_min=0,
         therapy_lines_count_max=0,
-        benefit_score=88,
-        patient_burden_score=35,
-        risk_score=22,
+        benefit_score=18,
+        patient_burden_score=7,
+        risk_score=4,
     ),
 ]
 

--- a/trials/models.py
+++ b/trials/models.py
@@ -716,14 +716,26 @@ class Trial(TimeStampMixin):
         weights_sum = benefit_weight + patient_burden_weight + risk_weight + distance_penalty_weight
         distance_penalty = self.get_distance_penalty(patient_info)
         max_val = 20.0
-        return int(
-            (
-                float(benefit_weight) * (self.benefit_score if self.benefit_score is not None else 0.0) / max_val +
-                float(patient_burden_weight) * (1 - (self.patient_burden_score if self.patient_burden_score is not None else max_val) / max_val) +
-                float(risk_weight) * (1 - (self.risk_score if self.risk_score is not None else max_val) / max_val) +
-                float(distance_penalty_weight) * (1 - distance_penalty / max_val)
-            ) * 100 / float(weights_sum) + 0.5
-        )
+
+        # Component scores live on a 0–20 scale. Clamp before normalizing so
+        # out-of-range inputs (e.g. mis-scaled data) can't drive a component
+        # term past its weight and push the composite outside [0, 100].
+        def _clamp(value, default):
+            if value is None:
+                return default
+            return min(max_val, max(0.0, float(value)))
+
+        benefit = _clamp(self.benefit_score, 0.0)
+        burden = _clamp(self.patient_burden_score, max_val)
+        risk = _clamp(self.risk_score, max_val)
+
+        raw = (
+            float(benefit_weight) * benefit / max_val +
+            float(patient_burden_weight) * (1 - burden / max_val) +
+            float(risk_weight) * (1 - risk / max_val) +
+            float(distance_penalty_weight) * (1 - distance_penalty / max_val)
+        ) * 100 / float(weights_sum)
+        return max(0, min(100, int(raw + 0.5)))
 
     def sorted_locations_by_distance(self, user_geo_point, recruitment_status=None):
         """Return LocationTrial rows ordered by distance from user_geo_point.

--- a/trials/querysets/trial.py
+++ b/trials/querysets/trial.py
@@ -763,7 +763,7 @@ class TrialQuerySet(models.QuerySet):
                                         geo_point=None,
                                         recruitment_status=None) -> QuerySet["Trial"]:
         from django.db.models import F, ExpressionWrapper, Value, FloatField, Subquery, OuterRef, Min
-        from django.db.models.functions import Cast, Least, Coalesce
+        from django.db.models.functions import Cast, Least, Greatest, Coalesce
 
         meters_per_200_miles = 200 * 1609.34
 
@@ -798,21 +798,32 @@ class TrialQuerySet(models.QuerySet):
 
         weights_sum = benefit_weight + patient_burden_weight + risk_weight + distance_penalty_weight
 
+        zero = Value(0.0, output_field=FloatField())
         max_benefit = Value(20.0, output_field=FloatField())
         max_burden = Value(20.0, output_field=FloatField())
         max_risk = Value(20.0, output_field=FloatField())
 
+        # Component scores live on a 0–20 scale; clamp each to [0, 20] (mirrors
+        # the defensive clamp in Trial.get_goodness_score) so out-of-range data
+        # can't drive a term past its weight. distance_expr is already bounded
+        # to [0, 1] by the Least(..., 1.0) above.
+        benefit_clamped = Least(Greatest(Coalesce(F('benefit_score'), zero), zero), max_benefit)
+        burden_clamped = Least(Greatest(Coalesce(F('patient_burden_score'), max_burden), zero), max_burden)
+        risk_clamped = Least(Greatest(Coalesce(F('risk_score'), max_risk), zero), max_risk)
+
         # score = (Wb×Benefit/20 + Wpb×(1−PB/20) + Wr×(1−Risk/20) + Wd×(1−DistancePenalty)) × 100 / ΣW + 0.5
         # Wb / Wpb / Wr / Wd are the caller-supplied benefit / patient-burden /
         # risk / distance weights (default 25/25/25/25 — equal). +0.5 is a
-        # rounding nudge before the IntegerField cast.
+        # rounding nudge before the IntegerField cast. The composite is clamped
+        # to [0, 100] as a final guard.
+        raw_score = (
+                benefit_weight * benefit_clamped / max_benefit +
+                patient_burden_weight * (1 - burden_clamped / max_burden) +
+                risk_weight * (1 - risk_clamped / max_risk) +
+                distance_penalty_weight * (1 - distance_expr)
+        ) * 100 / weights_sum + 0.5
         score_expr = ExpressionWrapper(
-            (
-                    benefit_weight * Coalesce(F('benefit_score'), Value(0.0)) / max_benefit +
-                    patient_burden_weight * (1 - Coalesce(F('patient_burden_score'), max_burden) / max_burden) +
-                    risk_weight * (1 - Coalesce(F('risk_score'), max_risk) / max_risk) +
-                    distance_penalty_weight * (1 - distance_expr)
-            ) * 100 / weights_sum + 0.5,
+            Least(Greatest(raw_score, zero), Value(100.0, output_field=FloatField())),
             output_field=IntegerField()
         )
 


### PR DESCRIPTION
## Summary
- The goodness score normalizes benefit/burden/risk on a **0–20** scale, but the test seed data (`seed_test_trials`) used a **0–100** scale, producing composite scores above 100 (observed `Goodness: 113` for `NCT-TEST-0001`).
- Rescale all 8 test trials to the documented 0–20 range.
- Add defensive clamps so out-of-range component data can never push the composite outside `[0, 100]`, in **both** code paths:
  - Python `Trial.get_goodness_score` — clamp each component to `[0, 20]`, clamp composite to `[0, 100]`.
  - ORM `TrialQuerySet.with_goodness_score_optimized` — `Least(Greatest(...))` clamps mirroring the Python logic.

## Why
A scale mismatch between seed data and the scoring formula surfaced a >100 goodness score in the Find Trials UI. The clamps make the invariant (`0 ≤ goodness ≤ 100`) hold defensively regardless of input data quality.

## Test plan
- [x] `tests/querysets/test_trial_querysets.py` + `tests/views/test_trials_goodness_weights.py` — 50 passed (incl. Python↔ORM parity)
- [x] `test_explain_param.py`, `test_trials_match_post.py`, `test_trial_attributes.py`, `test_trial_templates.py` — 24 passed
- [x] Reseeded `exact_trials`; running container now computes 83/73/75 for NCT-TEST-0001/0002/0005 (was 113)
- [x] No model schema change → no migration needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)