### PR TITLE
fix(security): stop leaking DB credentials & PHI to disk/logs (#151, #152)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ scripts/cb/
 scripts/harvard/
 scripts/harvard*/
 scripts/*.zip
+scripts/cache/
 *.csv
 !scripts/evaluator/ground_truth.csv
 

--- a/scripts/trials4patients.sh
+++ b/scripts/trials4patients.sh
@@ -33,6 +33,16 @@ if [ -f "$ROOT_DIR/.env" ]; then
   set +o allexport
 fi
 
+# Redact credentials from a DSN before logging: keep scheme/host/db, mask user:pass.
+mask_dsn() {
+  local dsn="$1"
+  if [[ "$dsn" =~ ^([^:]+://)[^@]*@(.*)$ ]]; then
+    printf '%s***@%s' "${BASH_REMATCH[1]}" "${BASH_REMATCH[2]}"
+  else
+    printf '%s' "$dsn"
+  fi
+}
+
 PATIENT_DB="${PATIENT_DATABASE_URL:-}"
 PERSON_IDS="${PERSON_IDS:-}"
 PATIENT_LIMIT="${PATIENT_LIMIT:-}"
@@ -55,8 +65,8 @@ fi
 echo "=============================================="
 echo "Step 1: Verify connectivity"
 echo "=============================================="
-echo "  Trials DB: $TRIALS_DATABASE_URL"
-echo "  Patient DB: $PATIENT_DATABASE_URL"
+echo "  Trials DB: $(mask_dsn "$TRIALS_DATABASE_URL")"
+echo "  Patient DB: $(mask_dsn "$PATIENT_DATABASE_URL")"
 
 TRIAL_COUNT=$(python manage.py shell -c "
 from trials.models import Trial

--- a/scripts/trials4patients.sh
+++ b/scripts/trials4patients.sh
@@ -34,10 +34,14 @@ if [ -f "$ROOT_DIR/.env" ]; then
 fi
 
 # Redact credentials from a DSN before logging: keep scheme/host/db, mask user:pass.
+# Greedy match to the LAST '@' so a password containing '@' is fully masked, and
+# handle schemeless DSNs (user:pass@host/db) that still carry credentials.
 mask_dsn() {
   local dsn="$1"
-  if [[ "$dsn" =~ ^([^:]+://)[^@]*@(.*)$ ]]; then
+  if [[ "$dsn" =~ ^([^:]+://).*@(.*)$ ]]; then
     printf '%s***@%s' "${BASH_REMATCH[1]}" "${BASH_REMATCH[2]}"
+  elif [[ "$dsn" =~ ^.*@(.*)$ ]]; then
+    printf '***@%s' "${BASH_REMATCH[1]}"
   else
     printf '%s' "$dsn"
   fi

--- a/trials/management/commands/fetch_exact_for_patients.py
+++ b/trials/management/commands/fetch_exact_for_patients.py
@@ -342,6 +342,9 @@ class Command(BaseCommand):
                 fd = os.open(cache_file, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
                 with os.fdopen(fd, 'w') as f:
                     json.dump(cache_data, f, indent=2, default=str)
+                # O_CREAT's mode is ignored when the file already exists (e.g. a
+                # 0644 file from a prior run on --refresh), so enforce 0600 here.
+                os.chmod(cache_file, 0o600)
 
                 self.stdout.write(self.style.SUCCESS(
                     f' OK ({trial_count} trials)'

--- a/trials/management/commands/fetch_exact_for_patients.py
+++ b/trials/management/commands/fetch_exact_for_patients.py
@@ -15,14 +15,18 @@ Usage
 -----
     python manage.py fetch_exact_for_patients \\
       --source-db-url $PATIENT_DATABASE_URL \\
-      --cache-dir scripts/cache/patients \\
+      --cache-dir ~/.cache/exact/patients \\
       --limit 10
+
+Cache files contain PHI (patient names + full patient_info), so the default
+cache dir is OUTSIDE the repo tree and files are written mode 0600. Writing
+the cache inside the repo requires the explicit --allow-in-repo-cache flag.
 
 Options
 -------
     --source-db-url   PostgreSQL URL for the patient DB
                       (falls back to PATIENT_DATABASE_URL env var)
-    --cache-dir       Directory to write cache files (default: scripts/cache/patients)
+    --cache-dir       Directory to write cache files (default: ~/.cache/exact/patients)
     --limit           Top-N trials to fetch per patient (default: 10)
     --person-ids      Comma-separated list of person IDs to restrict to
     --refresh         Re-fetch even if a cache file already exists
@@ -33,10 +37,16 @@ import logging
 import os
 from datetime import date
 from decimal import Decimal
+from pathlib import Path
 
-from django.core.management.base import BaseCommand
+from django.core.management.base import BaseCommand, CommandError
 
 logger = logging.getLogger(__name__)
+
+# Files written here contain PHI (names, full patient_info). Default to a
+# secure location outside the repo working tree so it can never be committed.
+DEFAULT_CACHE_DIR = os.path.expanduser('~/.cache/exact/patients')
+REPO_ROOT = Path(__file__).resolve().parents[3]
 
 
 # ── helpers reused from sister command ─────────────────────────────────────
@@ -212,8 +222,14 @@ class Command(BaseCommand):
         )
         parser.add_argument(
             '--cache-dir',
-            default='scripts/cache/patients',
-            help='Directory to write cache files (default: scripts/cache/patients)',
+            default=DEFAULT_CACHE_DIR,
+            help=f'Directory to write PHI cache files (default: {DEFAULT_CACHE_DIR})',
+        )
+        parser.add_argument(
+            '--allow-in-repo-cache',
+            action='store_true',
+            help='Explicitly permit writing the PHI cache inside the repo tree '
+                 '(unsafe — files may be committed). Off by default.',
         )
         parser.add_argument(
             '--limit',
@@ -258,7 +274,16 @@ class Command(BaseCommand):
             return
 
         cache_dir = options['cache_dir']
+        cache_path = Path(cache_dir).resolve()
+        if REPO_ROOT in cache_path.parents or cache_path == REPO_ROOT:
+            if not options['allow_in_repo_cache']:
+                raise CommandError(
+                    f'Refusing to write PHI cache inside the repo tree ({cache_path}). '
+                    f'Use an outside-repo --cache-dir (default: {DEFAULT_CACHE_DIR}) '
+                    f'or pass --allow-in-repo-cache to override.'
+                )
         os.makedirs(cache_dir, exist_ok=True)
+        os.chmod(cache_dir, 0o700)
 
         person_ids = [int(x) for x in options['person_ids'].split(',') if x.strip()]
         limit = options['limit']
@@ -314,7 +339,8 @@ class Command(BaseCommand):
                     'details': details,
                 }
                 trial_count = len(trial_ids)
-                with open(cache_file, 'w') as f:
+                fd = os.open(cache_file, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+                with os.fdopen(fd, 'w') as f:
                     json.dump(cache_data, f, indent=2, default=str)
 
                 self.stdout.write(self.style.SUCCESS(

--- a/trials/management/commands/fetch_exact_for_patients.py
+++ b/trials/management/commands/fetch_exact_for_patients.py
@@ -339,7 +339,10 @@ class Command(BaseCommand):
                     'details': details,
                 }
                 trial_count = len(trial_ids)
-                fd = os.open(cache_file, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+                # O_NOFOLLOW: refuse to follow a planted symlink at the cache
+                # path (would otherwise write PHI / chmod the link target).
+                fd = os.open(cache_file,
+                             os.O_WRONLY | os.O_CREAT | os.O_TRUNC | os.O_NOFOLLOW, 0o600)
                 with os.fdopen(fd, 'w') as f:
                     json.dump(cache_data, f, indent=2, default=str)
                 # O_CREAT's mode is ignored when the file already exists (e.g. a


### PR DESCRIPTION
## Summary
- **#152**: mask `user:pass` in DB DSNs before echoing them in `scripts/trials4patients.sh`.
- **#151**: default the patient cache to an outside-repo dir (`~/.cache/exact/patients`), write files mode `0600` / dir `0700`, refuse in-repo cache unless `--allow-in-repo-cache`, and gitignore `scripts/cache/`.
- Enforce `0600` on **refreshed** cache files too (codex review follow-up — `O_CREAT` mode is ignored for existing files).

## Review
- Codex review: 1×P2 (refresh perms) — addressed.
- Claude fresh-context review: no further findings.

## Test plan
- [ ] `trials4patients.sh` prints `postgresql://***@host/db` (creds masked)
- [ ] Default run writes cache outside repo, files are `0600`
- [ ] In-repo `--cache-dir` refused without `--allow-in-repo-cache`

🤖 Generated with [Claude Code](https://claude.com/claude-code)