### PR TITLE
fix(api): resolve patient_info once per request, stop swallowing build errors (#156, #159, #160)

### DIFF
--- a/accounts/authentication.py
+++ b/accounts/authentication.py
@@ -19,7 +19,7 @@ import logging
 
 from django.conf import settings
 from django.core.cache import cache as django_cache
-from rest_framework.authentication import BaseAuthentication, SessionAuthentication
+from rest_framework.authentication import BaseAuthentication
 from rest_framework.exceptions import AuthenticationFailed
 
 from .models import Identity
@@ -151,10 +151,3 @@ class ServiceTokenAuthentication(BaseAuthentication):
 
     def authenticate_header(self, request):
         return "Bearer"
-
-
-class CsrfExemptSessionAuthentication(SessionAuthentication):
-    """SessionAuthentication without the built-in CSRF enforcement."""
-
-    def enforce_csrf(self, request):
-        return

--- a/exact/settings.py
+++ b/exact/settings.py
@@ -251,7 +251,6 @@ REST_FRAMEWORK = {
     },
     'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.PageNumberPagination',
     'PAGE_SIZE': 200,
-    'DEFAULT_SCHEMA_CLASS': 'rest_framework.schemas.coreapi.AutoSchema',
 }
 
 STATIC_URL = '/static/'

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,9 +26,6 @@ redis==6.4.0
 # Units / quantity conversion
 django-pint==1.0.4
 
-# API schema
-coreapi==2.3.3
-
 # Auth — house OIDC Identity model (Firebase ID-token verification)
 firebase-admin==7.4.0
 

--- a/tests/views/test_graph_view_validation.py
+++ b/tests/views/test_graph_view_validation.py
@@ -34,7 +34,9 @@ class TestGraphViewValidation:
 
     def test_non_numeric_n_returns_400(self, authed_client):
         # Patient context present so we exercise the n-validation branch.
-        with patch('trials.api.graph_view.resolve_patient_info', return_value=MagicMock()):
+        # graph resolves via the shared TrialsViewSet._resolve_patient_info,
+        # which calls resolve_patient_info imported into trials_views.
+        with patch('trials.api.trials_views.resolve_patient_info', return_value=MagicMock()):
             resp = authed_client.get('/trials-graph/graph/?n=not-a-number')
         assert resp.status_code == 400
         assert "'n'" in str(resp.data)

--- a/tests/views/test_patient_resolve_errors.py
+++ b/tests/views/test_patient_resolve_errors.py
@@ -1,0 +1,47 @@
+"""Patient-resolution error handling + memoization (#156, #159, #160).
+
+#156: a supplied-but-unbuildable patient payload must surface as a 400, not be
+swallowed into a silent None that runs the matcher with no patient context
+(which returns an unfiltered/unscored trial list that looks valid).
+
+#159/#160: patient context must be resolved at most once per request, even
+though both get_queryset and get_serializer_context need it.
+"""
+import pytest
+from unittest.mock import patch
+
+from rest_framework.authtoken.models import Token
+from rest_framework.test import APIClient
+
+from accounts.models import Identity
+from tests.factories import TrialFactory
+
+
+@pytest.fixture
+def authed_client(db):
+    user, _ = Identity.objects.get_or_create(issuer='urn:local', sub='resolve-tester')
+    token, _ = Token.objects.get_or_create(user=user)
+    client = APIClient()
+    client.credentials(HTTP_AUTHORIZATION=f'Token {token.key}')
+    return client
+
+
+@pytest.mark.django_db
+class TestPatientResolveErrors:
+    def test_unbuildable_inline_payload_returns_400(self, authed_client):
+        # A non-dict patient_info can't be built -> 400, not a silent 200 with
+        # an unfiltered list.
+        resp = authed_client.post(
+            '/trials/match/', {'patient_info': 'not-a-dict'}, format='json'
+        )
+        assert resp.status_code == 400
+        assert 'patient' in str(resp.data).lower()
+
+    def test_patient_info_resolved_once_per_request(self, authed_client):
+        TrialFactory(disease='Multiple Myeloma')
+        with patch(
+            'trials.api.trials_views.resolve_patient_info', return_value=None
+        ) as mock_resolve:
+            resp = authed_client.get('/trials/')
+        assert resp.status_code == 200
+        assert mock_resolve.call_count == 1

--- a/tests/views/test_patient_resolve_errors.py
+++ b/tests/views/test_patient_resolve_errors.py
@@ -45,3 +45,15 @@ class TestPatientResolveErrors:
             resp = authed_client.get('/trials/')
         assert resp.status_code == 200
         assert mock_resolve.call_count == 1
+
+    def test_non_inline_resolve_error_is_not_masked_as_400(self, authed_client):
+        # When no inline payload was supplied (e.g. the person_id/CTOMOP path),
+        # an unexpected build error is a real server/upstream bug and must NOT
+        # be relabeled as a client 400 — it should surface as a 500 (#156).
+        authed_client.raise_request_exception = False
+        with patch(
+            'trials.api.trials_views.resolve_patient_info',
+            side_effect=RuntimeError('ctomop adapter blew up'),
+        ):
+            resp = authed_client.get('/trials/')
+        assert resp.status_code == 500

--- a/trials/api/graph_view.py
+++ b/trials/api/graph_view.py
@@ -11,7 +11,6 @@ from trials.api.graph_serializers import GraphTrialNodeSerializer
 from trials.api.patient_info_serializers import PatientInfoSerializer
 from trials.api.trials_views import TrialsViewSet
 from trials.services.attribute_names import AttributeNames
-from trials.services.patient_info.resolve import resolve_patient_info
 from trials.services.trial_details.trial_templates import TrialTemplates
 
 
@@ -66,7 +65,7 @@ class TrialsGraphViewSet(TrialsViewSet):
 
     @action(methods=["get"], detail=False, url_path="graph", url_name="graph")
     def graph(self, request, *args, **kwargs):
-        patient_info = resolve_patient_info(request)
+        patient_info = self._resolve_patient_info()
         if patient_info is None:
             return Response(
                 {"detail": "Graph view requires patient context "

--- a/trials/api/trials_views.py
+++ b/trials/api/trials_views.py
@@ -1,3 +1,4 @@
+import logging
 from typing import TYPE_CHECKING, Optional
 
 from django.db.models import F, Prefetch, QuerySet
@@ -14,6 +15,8 @@ from trials.services.blank_attribute_records_count import BlankAttributeRecordsC
 from trials.services.patient_info.resolve import resolve_patient_info
 from trials.services.study_preferences import StudyPreferences, study_preferences_from_query_params
 from trials.services.value_options import ValueOptions
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from trials.services.patient_info.patient_info import PatientInfo
@@ -58,10 +61,31 @@ class TrialsViewSet(viewsets.ReadOnlyModelViewSet):
     pagination_class = TrialsPagination
 
     def _resolve_patient_info(self) -> Optional['PatientInfo']:
+        # Resolve at most once per request: get_queryset and
+        # get_serializer_context both call this, and `search` can hit it
+        # several times. Re-resolving re-runs the CTOMOP round-trip, so a
+        # slow upstream multiplies per request (#159, #160). The holder is a
+        # 1-tuple so a legitimately-resolved None is still cached.
+        holder = getattr(self.request, '_exact_patient_info', None)
+        if holder is not None:
+            return holder[0]
+
         try:
-            return resolve_patient_info(self.request)
-        except Exception:
-            return None
+            patient_info = resolve_patient_info(self.request)
+        except Exception as exc:
+            # Don't swallow into a silent None: that would run the matcher
+            # with no patient context and return an unfiltered/unscored trial
+            # list that looks valid — dangerous in a clinical matcher (#156).
+            # The CTOMOP path returns None on failure (handled in CtomopClient),
+            # so an exception here means the supplied inline payload couldn't
+            # be built — i.e. bad client input.
+            logger.exception('Failed to build patient_info from request payload')
+            raise serializers.ValidationError(
+                {'patient_info': f'Could not build patient context from the request: {exc}'}
+            )
+
+        self.request._exact_patient_info = (patient_info,)
+        return patient_info
 
     def _resolve_study_preferences(self) -> StudyPreferences:
         return study_preferences_from_query_params(self.request.query_params)

--- a/trials/api/trials_views.py
+++ b/trials/api/trials_views.py
@@ -70,19 +70,26 @@ class TrialsViewSet(viewsets.ReadOnlyModelViewSet):
         if holder is not None:
             return holder[0]
 
+        data = getattr(self.request, 'data', None)
+        has_inline = isinstance(data, dict) and bool(data.get('patient_info'))
+
         try:
             patient_info = resolve_patient_info(self.request)
-        except Exception as exc:
-            # Don't swallow into a silent None: that would run the matcher
-            # with no patient context and return an unfiltered/unscored trial
-            # list that looks valid — dangerous in a clinical matcher (#156).
-            # The CTOMOP path returns None on failure (handled in CtomopClient),
-            # so an exception here means the supplied inline payload couldn't
-            # be built — i.e. bad client input.
+        except Exception:
+            # Don't swallow into a silent None: that would run the matcher with
+            # no patient context and return an unfiltered/unscored trial list
+            # that looks valid — dangerous in a clinical matcher (#156).
             logger.exception('Failed to build patient_info from request payload')
-            raise serializers.ValidationError(
-                {'patient_info': f'Could not build patient context from the request: {exc}'}
-            )
+            # Only a supplied inline payload that fails to build is client error
+            # (400). The CTOMOP fetch returns None on network failure (handled in
+            # CtomopClient), so an exception on the person_id path is a real
+            # server/upstream bug — let it propagate as a 500 rather than masking
+            # it as a misleading 400.
+            if has_inline:
+                raise serializers.ValidationError(
+                    {'patient_info': 'Could not build patient context from the supplied payload.'}
+                )
+            raise
 
         self.request._exact_patient_info = (patient_info,)
         return patient_info

--- a/trials/querysets/trial.py
+++ b/trials/querysets/trial.py
@@ -605,38 +605,6 @@ class TrialQuerySet(models.QuerySet):
 
         return self
 
-    def with_distance_optimized_old(self, geo_point, max_distance=None):
-        if not geo_point:
-            return self
-
-        from trials.models import LocationTrial
-        from django.db.models import Subquery, OuterRef, Value, Case, When, IntegerField
-        from django.contrib.gis.db.models.functions import Distance
-
-        location_qs = LocationTrial.objects.filter(
-            trial=OuterRef('pk')
-        )
-
-        if max_distance is not None:
-            location_qs = location_qs.filter(
-                location__geo_point__dwithin=(geo_point, max_distance)
-            )
-
-        location_qs = location_qs.annotate(
-            dist=Distance('location__geo_point', geo_point)
-        ).order_by('dist')
-
-        qs = self.annotate(
-            distance=Subquery(location_qs.values('dist')[:1]),
-            is_null_distance=Case(
-                When(distance__isnull=True, then=Value(1)),
-                default=Value(0),
-                output_field=IntegerField()
-            )
-        ).distinct()
-
-        return qs
-
     def with_distance_optimized(self, geo_point, max_distance=None, recruitment_status=None):
         if not geo_point:
             return self


### PR DESCRIPTION
## Summary
> ⚠️ Stacked on #162 (`fix/input-validation-500s`). Base auto-retargets to `main` once #162 merges. Review only the top commit.

- **#156**: replace the bare `except Exception: return None` in `_resolve_patient_info` with logging + a 400 `ValidationError`. A supplied-but-unbuildable inline payload no longer silently yields no-patient context (which made the matcher return an unfiltered/unscored list that looked valid). CTOMOP failures still resolve to `None` by design in `CtomopClient`.
- **#159/#160**: memoize `patient_info` on the request so `get_queryset`, `get_serializer_context`, and the graph action resolve it **at most once per request** instead of re-running the CTOMOP round-trip 2–4×. (Circuit breaker / bulkhead from #160 tracked as a separate resilience follow-up.)
- **#159 dead code**: remove unused `CsrfExemptSessionAuthentication` (CSRF-bypass footgun), dead `with_distance_optimized_old`, and the deprecated `coreapi` schema class + dependency.

## Review
- Codex review (vs base): no regressions found.
- Claude fresh-context review: memoization holder + 400 propagation verified.

## Test plan
- [ ] `POST /trials/match/` with `patient_info: "not-a-dict"` → 400
- [ ] A single `/trials/` request resolves patient_info once (test asserts call_count==1)
- [ ] swagger/redoc still render without `coreapi`

🤖 Generated with [Claude Code](https://claude.com/claude-code)