### PR TITLE
fix(celery): verify rediss TLS certificates outside local/DEBUG (#157)

### DIFF
--- a/exact/settings.py
+++ b/exact/settings.py
@@ -271,8 +271,19 @@ redis_url = os.environ.get('REDIS_URL', 'redis://localhost:6379')
 CELERY_BROKER_URL = redis_url
 CELERY_RESULT_BACKEND = redis_url
 if CELERY_BROKER_URL.startswith('rediss://'):
-    CELERY_BROKER_USE_SSL = {'ssl_cert_reqs': ssl.CERT_NONE}
-    CELERY_REDIS_BACKEND_USE_SSL = {'ssl_cert_reqs': ssl.CERT_NONE}
+    # Verify the broker's TLS certificate in any deployed environment. Only
+    # local/DEBUG may fall back to CERT_NONE (self-signed dev Redis); using it
+    # in prod/staging would permit MITM on Redis traffic that can carry
+    # patient-derived task results (#157). REDIS_SSL_CA_CERTS lets a deploy
+    # point at a private CA bundle.
+    _redis_ssl_local = DEBUG or ENVIRONMENT == 'local'
+    _redis_ssl = {
+        'ssl_cert_reqs': ssl.CERT_NONE if _redis_ssl_local else ssl.CERT_REQUIRED,
+    }
+    if _redis_ca := os.environ.get('REDIS_SSL_CA_CERTS'):
+        _redis_ssl['ssl_ca_certs'] = _redis_ca
+    CELERY_BROKER_USE_SSL = _redis_ssl
+    CELERY_REDIS_BACKEND_USE_SSL = dict(_redis_ssl)
 CELERY_TASK_ACKS_LATE = True
 CELERY_WORKER_PREFETCH_MULTIPLIER = 1
 

--- a/tests/test_settings_security.py
+++ b/tests/test_settings_security.py
@@ -69,3 +69,25 @@ class TestCorsAllowAllDefault:
             r"CORS_ALLOWED_ORIGINS\s*=\s*\[?\s*[\s\S]*?os\.environ\.get\(\s*['\"]CORS_ALLOWED_ORIGINS['\"]",
             source,
         ), 'CORS_ALLOWED_ORIGINS must resolve from the env var.'
+
+
+class TestRedisTlsCertVerification:
+    """rediss:// Celery SSL must not disable cert verification unconditionally.
+
+    Pre-#157 both broker and backend pinned ssl.CERT_NONE, permitting MITM on
+    Redis traffic that can carry patient-derived task results. CERT_NONE is now
+    gated to local/DEBUG only; deployed envs use CERT_REQUIRED."""
+
+    def test_cert_none_not_used_unconditionally(self):
+        source = _settings_source()
+        # The only CERT_NONE occurrence must be the local/DEBUG-gated ternary,
+        # never a bare `ssl_cert_reqs': ssl.CERT_NONE` assignment as the value.
+        assert not re.search(
+            r"ssl_cert_reqs['\"]\s*:\s*ssl\.CERT_NONE\s*[,}]",
+            source,
+        ), 'rediss SSL must not hard-code CERT_NONE (#157).'
+
+    def test_cert_required_is_present(self):
+        source = _settings_source()
+        assert 'ssl.CERT_REQUIRED' in source, \
+            'Deployed rediss SSL must verify certs with CERT_REQUIRED (#157).'


### PR DESCRIPTION
## Summary
- The `rediss://` Celery broker and result backend pinned `ssl.CERT_NONE`, disabling certificate verification and permitting MITM on Redis traffic that can carry patient-derived task results.
- Use `CERT_REQUIRED` in deployed environments (`CERT_NONE` only for local/DEBUG self-signed dev), with `REDIS_SSL_CA_CERTS` to point at a private CA bundle.
- Source-level guard tests added.

## Review
- Codex review: no regressions; preserves local/DEBUG behavior.

## Test plan
- [ ] `manage.py check` passes
- [ ] With `rediss://` + non-local ENVIRONMENT, broker/result SSL uses `CERT_REQUIRED`

🤖 Generated with [Claude Code](https://claude.com/claude-code)