### PR TITLE
fix(auth): gate DRF token auth + token endpoint to non-prod (#153)

### DIFF
--- a/exact/settings.py
+++ b/exact/settings.py
@@ -214,10 +214,10 @@ DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 # House API auth standard (OIDC shared-Identity model)
 # PartnerAuthentication verifies a Firebase ID token (the only
 # browser-appropriate credential); ServiceTokenAuthentication compares a shared
-# bearer against SERVICE_AUTH_TOKEN for server-to-server calls. TokenAuth +
-# Session remain as a transitional credential for the local dev harness
-# (`/api-token-auth/`) and existing tests; production callers use Firebase or
-# the service token. Default-deny stays (IsAuthenticated).
+# bearer against SERVICE_AUTH_TOKEN for server-to-server calls. DRF TokenAuth is
+# gated behind ENABLE_DRF_TOKEN_AUTH (on for local/dev/tests, off in prod — see
+# below); SessionAuthentication stays for the browsable API/admin. Production
+# callers use Firebase or the service token. Default-deny stays (IsAuthenticated).
 # ---------------------------------------------------------------------------
 PARTNER_AUTH_PROVIDERS = [
     'accounts.providers.firebase.FirebaseTokenProvider',
@@ -229,13 +229,26 @@ FIREBASE_SKIP_REVOCATION_CHECK = os.environ.get(
 AUTH_TOKEN_CACHE_TTL = int(os.environ.get('AUTH_TOKEN_CACHE_TTL', '60'))
 SERVICE_AUTH_TOKEN = os.environ.get('SERVICE_AUTH_TOKEN', '')
 
+# Persistent DRF tokens (username/password -> never-expiring bearer, no scope,
+# audience, tenant binding, or rotation) are unacceptable for a PHI service in
+# production. Keep them only as a transitional credential for the local dev
+# harness and tests; deployed environments must use Firebase / the service
+# token. The `/api-token-auth/` endpoint is registered only when this is on
+# (see exact/urls.py) (#153).
+ENABLE_DRF_TOKEN_AUTH = os.environ.get(
+    'ENABLE_DRF_TOKEN_AUTH', 'true' if (DEBUG or ENVIRONMENT == 'local') else 'false'
+).lower() in ('1', 'true')
+
+_AUTH_CLASSES = [
+    'accounts.authentication.ServiceTokenAuthentication',
+    'accounts.authentication.PartnerAuthentication',
+]
+if ENABLE_DRF_TOKEN_AUTH:
+    _AUTH_CLASSES.append('rest_framework.authentication.TokenAuthentication')
+_AUTH_CLASSES.append('rest_framework.authentication.SessionAuthentication')
+
 REST_FRAMEWORK = {
-    'DEFAULT_AUTHENTICATION_CLASSES': [
-        'accounts.authentication.ServiceTokenAuthentication',
-        'accounts.authentication.PartnerAuthentication',
-        'rest_framework.authentication.TokenAuthentication',
-        'rest_framework.authentication.SessionAuthentication',
-    ],
+    'DEFAULT_AUTHENTICATION_CLASSES': _AUTH_CLASSES,
     'DEFAULT_PERMISSION_CLASSES': [
         'rest_framework.permissions.IsAuthenticated',
     ],

--- a/exact/settings.py
+++ b/exact/settings.py
@@ -235,8 +235,16 @@ SERVICE_AUTH_TOKEN = os.environ.get('SERVICE_AUTH_TOKEN', '')
 # harness and tests; deployed environments must use Firebase / the service
 # token. The `/api-token-auth/` endpoint is registered only when this is on
 # (see exact/urls.py) (#153).
+#
+# Fail closed: the default enables tokens only for DEBUG or an EXPLICIT
+# `ENVIRONMENT=local`. A deployed env that forgets to set ENVIRONMENT (the
+# module-level default would otherwise read as 'local') gets tokens OFF, not
+# ON — so a misconfigured prod can't silently expose persistent tokens.
+_token_auth_default = (
+    'true' if (DEBUG or os.environ.get('ENVIRONMENT') == 'local') else 'false'
+)
 ENABLE_DRF_TOKEN_AUTH = os.environ.get(
-    'ENABLE_DRF_TOKEN_AUTH', 'true' if (DEBUG or ENVIRONMENT == 'local') else 'false'
+    'ENABLE_DRF_TOKEN_AUTH', _token_auth_default
 ).lower() in ('1', 'true')
 
 _AUTH_CLASSES = [

--- a/exact/test_settings.py
+++ b/exact/test_settings.py
@@ -1,0 +1,14 @@
+"""Test settings shim.
+
+Sets ENVIRONMENT=local BEFORE importing the real settings, so security controls
+that fail closed on an *unset* ENVIRONMENT — e.g. ENABLE_DRF_TOKEN_AUTH (#153) —
+enable their dev/test behavior. This must run before exact.settings executes,
+which a conftest can't guarantee (pytest-django sets up Django during
+pytest_load_initial_conftests, before conftest import). pytest.ini points
+DJANGO_SETTINGS_MODULE here.
+"""
+import os
+
+os.environ.setdefault("ENVIRONMENT", "local")
+
+from exact.settings import *  # noqa: E402,F401,F403

--- a/exact/urls.py
+++ b/exact/urls.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.contrib import admin
 from django.urls import path, include
 from rest_framework.authtoken.serializers import AuthTokenSerializer
@@ -21,6 +22,15 @@ class ObtainAuthToken(APIView):
 
 urlpatterns = [
     path('admin/', admin.site.urls),
-    path('api-token-auth/', ObtainAuthToken.as_view(), name='api-token-auth'),
+]
+
+# Persistent DRF tokens are a dev/test-only credential; don't expose the
+# username/password -> token endpoint in production (#153).
+if getattr(settings, 'ENABLE_DRF_TOKEN_AUTH', False):
+    urlpatterns.append(
+        path('api-token-auth/', ObtainAuthToken.as_view(), name='api-token-auth')
+    )
+
+urlpatterns += [
     path('', include('trials.urls', namespace='trials')),
 ]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,4 @@
 [pytest]
-DJANGO_SETTINGS_MODULE = exact.settings
+DJANGO_SETTINGS_MODULE = exact.test_settings
 python_files = tests/test_*.py tests/**/test_*.py
 addopts = --reuse-db

--- a/tests/test_security_hardening.py
+++ b/tests/test_security_hardening.py
@@ -125,12 +125,26 @@ class TestDrfTokenAuthGated:
 
     def test_token_auth_flag_defaults_off_outside_local(self):
         source = _settings_source()
-        # The default expression must be local/DEBUG-gated, not a bare 'true'.
+        # The default must fail closed: gated on DEBUG or an EXPLICIT
+        # os.environ ENVIRONMENT=='local' (NOT the module-level ENVIRONMENT,
+        # which defaults to 'local' when unset and would fail open in prod).
         assert re.search(
-            r"ENABLE_DRF_TOKEN_AUTH\s*=\s*os\.environ\.get\(\s*['\"]ENABLE_DRF_TOKEN_AUTH['\"]\s*,\s*"
-            r"'true'\s+if\s*\(?\s*DEBUG\s+or\s+ENVIRONMENT\s*==\s*['\"]local['\"]",
+            r"_token_auth_default\s*=\s*\(?\s*\n?\s*'true'\s+if\s+\(?\s*DEBUG\s+or\s+"
+            r"os\.environ\.get\(\s*['\"]ENVIRONMENT['\"]\s*\)\s*==\s*['\"]local['\"]",
             source,
-        ), "ENABLE_DRF_TOKEN_AUTH must default off outside local/DEBUG (#153)."
+        ), "ENABLE_DRF_TOKEN_AUTH default must fail closed on an unset ENVIRONMENT (#153)."
+
+    def test_token_auth_default_rule_fails_closed(self):
+        # Lock the truth table of the default-enable rule, including the
+        # security-critical fail-closed case: ENVIRONMENT unset -> tokens OFF.
+        def enabled(debug, environ):
+            return debug or environ.get('ENVIRONMENT') == 'local'
+
+        assert enabled(True, {}) is True                      # DEBUG
+        assert enabled(False, {'ENVIRONMENT': 'local'}) is True   # explicit local
+        assert enabled(False, {'ENVIRONMENT': 'prod'}) is False   # prod
+        assert enabled(False, {'ENVIRONMENT': 'staging'}) is False
+        assert enabled(False, {}) is False                    # unset -> fail closed
 
     def test_token_authentication_not_unconditional(self):
         source = _settings_source()
@@ -150,8 +164,8 @@ class TestDrfTokenAuthGated:
         ), "/api-token-auth/ must be registered only when ENABLE_DRF_TOKEN_AUTH (#153)."
 
     def test_token_auth_enabled_in_test_env(self):
-        # In the test env (ENVIRONMENT unset -> 'local') the dev harness keeps
-        # working: flag on, TokenAuthentication active, endpoint routed.
+        # The test env sets ENVIRONMENT=local (exact/test_settings.py shim), so
+        # the dev harness keeps working: flag on, TokenAuthentication active.
         from django.conf import settings
         from django.urls import reverse
 

--- a/tests/test_security_hardening.py
+++ b/tests/test_security_hardening.py
@@ -14,6 +14,7 @@ from pathlib import Path
 _ROOT = Path(__file__).resolve().parents[1]
 SETTINGS_PATH = _ROOT / 'exact' / 'settings.py'
 URLS_PATH = _ROOT / 'trials' / 'urls.py'
+EXACT_URLS_PATH = _ROOT / 'exact' / 'urls.py'
 
 
 def _settings_source():
@@ -22,6 +23,10 @@ def _settings_source():
 
 def _urls_source():
     return URLS_PATH.read_text()
+
+
+def _exact_urls_source():
+    return EXACT_URLS_PATH.read_text()
 
 
 class TestSecretKey:
@@ -109,3 +114,48 @@ class TestSwaggerGated:
         source = _urls_source()
         assert re.search(r"public\s*=\s*False", source), \
             "schema_view should be public=False so the schema is access-scoped (#127)."
+
+
+class TestDrfTokenAuthGated:
+    """Persistent DRF tokens (never-expiring, unscoped bearers minted from
+    username/password) must not be enabled in production for a PHI service.
+    They're gated behind ENABLE_DRF_TOKEN_AUTH, defaulting off outside
+    local/DEBUG, and the `/api-token-auth/` endpoint is only registered when
+    the flag is on (#153)."""
+
+    def test_token_auth_flag_defaults_off_outside_local(self):
+        source = _settings_source()
+        # The default expression must be local/DEBUG-gated, not a bare 'true'.
+        assert re.search(
+            r"ENABLE_DRF_TOKEN_AUTH\s*=\s*os\.environ\.get\(\s*['\"]ENABLE_DRF_TOKEN_AUTH['\"]\s*,\s*"
+            r"'true'\s+if\s*\(?\s*DEBUG\s+or\s+ENVIRONMENT\s*==\s*['\"]local['\"]",
+            source,
+        ), "ENABLE_DRF_TOKEN_AUTH must default off outside local/DEBUG (#153)."
+
+    def test_token_authentication_not_unconditional(self):
+        source = _settings_source()
+        # TokenAuthentication must be appended conditionally, never hard-listed
+        # in DEFAULT_AUTHENTICATION_CLASSES.
+        assert re.search(
+            r"if\s+ENABLE_DRF_TOKEN_AUTH\s*:\s*\n\s*_AUTH_CLASSES\.append\(\s*"
+            r"['\"]rest_framework\.authentication\.TokenAuthentication['\"]",
+            source,
+        ), "TokenAuthentication must be appended only when ENABLE_DRF_TOKEN_AUTH (#153)."
+
+    def test_token_endpoint_is_flag_guarded(self):
+        source = _exact_urls_source()
+        assert re.search(
+            r"if\s+getattr\(\s*settings,\s*['\"]ENABLE_DRF_TOKEN_AUTH['\"]",
+            source,
+        ), "/api-token-auth/ must be registered only when ENABLE_DRF_TOKEN_AUTH (#153)."
+
+    def test_token_auth_enabled_in_test_env(self):
+        # In the test env (ENVIRONMENT unset -> 'local') the dev harness keeps
+        # working: flag on, TokenAuthentication active, endpoint routed.
+        from django.conf import settings
+        from django.urls import reverse
+
+        assert settings.ENABLE_DRF_TOKEN_AUTH is True
+        assert 'rest_framework.authentication.TokenAuthentication' in \
+            settings.REST_FRAMEWORK['DEFAULT_AUTHENTICATION_CLASSES']
+        assert reverse('api-token-auth')  # resolves without raising


### PR DESCRIPTION
## Summary
- Persistent DRF tokens (username/password → never-expiring, unscoped bearer, no rotation) are unacceptable for a PHI service in production.
- Add `ENABLE_DRF_TOKEN_AUTH` (defaults **on** for local/DEBUG, **off** in prod): `TokenAuthentication` is only added to `DEFAULT_AUTHENTICATION_CLASSES` and `/api-token-auth/` is only routed when the flag is on. Deployed callers use Firebase / the service token.
- Source-level + behavioral guard tests added.

## Review
- Codex review: no regressions in modified paths.

## Test plan
- [ ] In test/local env: token auth works, `/api-token-auth/` resolves (existing token-auth tests pass)
- [ ] With `ENVIRONMENT=prod` (no override): `TokenAuthentication` absent, `/api-token-auth/` unrouted

🤖 Generated with [Claude Code](https://claude.com/claude-code)