### PR TITLE
fix(db): parse TRIALS_DATABASE_URL with dj_database_url for Cloud SQL socket

### DIFF
--- a/exact/settings.py
+++ b/exact/settings.py
@@ -181,16 +181,15 @@ else:
 # Set TRIALS_DATABASE_URL to enable (e.g. postgresql://user:pass@host:5432/dbname).
 _trials_db_url = os.environ.get('TRIALS_DATABASE_URL')
 if _trials_db_url:
-    from urllib.parse import urlparse
-    _parsed = urlparse(_trials_db_url)
-    DATABASES['trials'] = {
-        'ENGINE': 'django.contrib.gis.db.backends.postgis',
-        'NAME': _parsed.path.lstrip('/'),
-        'USER': _parsed.username or 'exact',
-        'PASSWORD': _parsed.password or '',
-        'HOST': _parsed.hostname or 'localhost',
-        'PORT': str(_parsed.port or 5432),
-    }
+    # Parse with dj_database_url (like 'default' above), not a hand-rolled
+    # urlparse: the Cloud SQL socket form (postgis://user:pw@/db?host=/cloudsql/
+    # INSTANCE) has an empty netloc host, so urlparse().hostname is None and the
+    # ?host= socket param is dropped — the trials alias then fell back to
+    # localhost:5432 and every trials-app read 500'd with "connection refused".
+    DATABASES['trials'] = dj_database_url.parse(
+        _trials_db_url,
+        engine='django.contrib.gis.db.backends.postgis',
+    )
 
 DATABASE_ROUTERS = ['exact.db_router.TrialsDatabaseRouter']
 


### PR DESCRIPTION
## Problem
`/normalize-ctomop-row/` (and any trials-app DB read) 500s on exact-staging with:

```
django.db.utils.OperationalError: connection to server at "localhost" (127.0.0.1), port 5432 failed: Connection refused
```

Root cause: the `trials` DB alias is built with a hand-rolled `urlparse` (settings.py:182-193) that cannot read the Cloud SQL **unix-socket** URL form used in staging:

```
postgis://exact:<pw>@/exact_trials?host=/cloudsql/ht-phr:us-central1:ht-phr-staging-db
```

Here the netloc host is empty, so `urlparse().hostname` is `None` → `HOST` falls back to `localhost`, and the `?host=/cloudsql/...` socket param is silently dropped. The alias then tries TCP `localhost:5432` → connection refused. `_build_code_lookup` (ctomop adapter, code resolution for `Ethnicity` etc.) reads trials-app models → routed to the broken alias → 500.

The `default` alias never hit this because it parses with `dj_database_url`, which moves `?host=` into `OPTIONS` correctly.

## Fix
Parse `TRIALS_DATABASE_URL` with `dj_database_url.parse(..., engine=postgis)` exactly like `default`.

Verified both URL forms:
- `postgis://u:p@/db?host=/cloudsql/INSTANCE` → `HOST=''`, `OPTIONS={'host': '/cloudsql/INSTANCE'}` (socket — staging)
- `postgresql://u:p@host:5432/db` → `HOST='host'`, `PORT=5432` (TCP — local dev, unchanged)

## Review
- Self-review (fresh context): clean — parity with `default`, local-dev TCP path preserved, `urlparse` import removed (only referenced in comment now).
- `codex review --uncommitted`: clean — confirmed socket-param preservation and no introduced issues.

## Test plan
- [ ] Merge + redeploy exact-staging.
- [ ] `POST /normalize-ctomop-row/` returns 200 (not 500).
- [ ] Find Trials page in ht-phr loads matches end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)