### PR TITLE
fix(trials): gate trials-DB migrations behind TRIALS_DB_MIGRATE flag

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -77,6 +77,18 @@ jobs:
           gcloud run jobs execute "$MIGRATE_JOB" \
             --region "$REGION" \
             --wait
+          # Second pass migrates the split trials DB. The migrate_trials_db
+          # command self-gates on settings.TRIALS_DB_MIGRATE inside the
+          # container: a no-op (returns before opening the 'trials' connection)
+          # unless the flag is on, so an externally-managed/read-only trials DB
+          # is never touched and its django_migrations recorder is never
+          # created. When on (a copy we own, e.g. staging) it runs
+          # `migrate --database=trials --fake-initial`, which idempotently fakes
+          # 0001 against the seeded copy and applies the rest for real.
+          gcloud run jobs execute "$MIGRATE_JOB" \
+            --region "$REGION" \
+            --wait \
+            --args=manage.py,migrate_trials_db
 
       - name: Route traffic to new revision
         run: |

--- a/exact/db_router.py
+++ b/exact/db_router.py
@@ -62,7 +62,13 @@ class TrialsDatabaseRouter:
             return None
 
         if app_label == _TRIALS_APP:
-            # External trials DB — schema is managed externally, never migrate.
+            # The trials DB is treated as an externally-managed, read-only
+            # catalog by default, so its schema is never migrated. On a copy we
+            # actually own and want to keep current (e.g. staging), set
+            # TRIALS_DB_MIGRATE=true to apply trials migrations to the 'trials'
+            # alias via `migrate --database=trials`.
+            if getattr(settings, 'TRIALS_DB_MIGRATE', False):
+                return db == _TRIALS_DB
             return False
         else:
             # Everything else only on default.

--- a/exact/settings.py
+++ b/exact/settings.py
@@ -191,6 +191,12 @@ if _trials_db_url:
         engine='django.contrib.gis.db.backends.postgis',
     )
 
+# When the trials DB is a copy we own (not the external read-only catalog),
+# enable this so `migrate --database=trials` applies trials migrations to it.
+# Default false keeps the external/prod trials DB untouched. See
+# exact.db_router.TrialsDatabaseRouter.allow_migrate.
+TRIALS_DB_MIGRATE = os.environ.get('TRIALS_DB_MIGRATE', 'false').lower() == 'true'
+
 DATABASE_ROUTERS = ['exact.db_router.TrialsDatabaseRouter']
 
 CACHES = {

--- a/trials/management/commands/migrate_trials_db.py
+++ b/trials/management/commands/migrate_trials_db.py
@@ -1,0 +1,29 @@
+"""Apply trials-app migrations to the split 'trials' database.
+
+Gated on settings.TRIALS_DB_MIGRATE so the command is a safe no-op in the
+default configuration where the trials DB is an externally-managed, read-only
+catalog. When the flag is off we return before touching the 'trials'
+connection at all — so we never open it or create a django_migrations recorder
+on a read-only / externally-owned DB. Only when the flag is on (a copy we own,
+e.g. staging) do we run `migrate --database=trials`.
+"""
+
+from django.conf import settings
+from django.core.management import call_command
+from django.core.management.base import BaseCommand
+
+
+class Command(BaseCommand):
+    help = "Migrate trials-app schema onto the 'trials' DB when TRIALS_DB_MIGRATE is enabled."
+
+    def handle(self, *args, **options):
+        if not getattr(settings, 'TRIALS_DB_MIGRATE', False):
+            self.stdout.write('TRIALS_DB_MIGRATE disabled; skipping trials DB migrate.')
+            return
+        if 'trials' not in settings.DATABASES:
+            self.stdout.write("No 'trials' database configured; skipping trials DB migrate.")
+            return
+        self.stdout.write("Migrating trials app onto the 'trials' database...")
+        # fake_initial: the trials copy is seeded with the 0001 tables already
+        # present but no migration history; fake 0001 and apply the rest.
+        call_command('migrate', 'trials', database='trials', fake_initial=True, interactive=False)


### PR DESCRIPTION
## Summary
- The split `trials` database is treated as an externally-managed, read-only catalog by default, so `TrialsDatabaseRouter.allow_migrate` blocks all `trials`-app migrations. Staging owns a **writable copy** of that DB, which left its schema stale (stuck at ~0001) and caused 500s on `/trials/match/` (missing `trials_morphologicvariant` table and `lesion_size_mcl_*` columns from migrations 0002–0007).
- Add a `TRIALS_DB_MIGRATE` env flag (default `false`). When on, the router allows `trials`-app migrations onto the `trials` alias.
- Add a gated management command `migrate_trials_db` that self-checks `settings.TRIALS_DB_MIGRATE` **inside the container** and returns early before opening the `trials` connection when the flag is off — so a read-only/external DB is never touched and its `django_migrations` recorder is never created.
- The `deploy-staging.yml` second migrate pass now calls `manage.py migrate_trials_db` instead of an unconditional `migrate --database=trials` (fixes the earlier review concern that the second pass would open the trials connection regardless of the flag).

The flag is set to `"true"` for staging via the ht-phr infra Terraform (`exact.tf` `exact_cloud_run` env_vars), which propagates to both the service and the migrate job. It stays unset/false in prod, where the trials DB is the external read-only catalog.

## Test plan
- [ ] Merge → deploy `exact-staging` → migrate job's second pass runs `migrate_trials_db`, which fakes 0001 and applies 0002–0007 onto `exact_trials`.
- [ ] Verify `/trials/match/` returns 200 (no more missing-relation/column errors).
- [ ] Confirm with flag off (default), `migrate_trials_db` is a no-op and does not open the trials connection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)