### PR TITLE
fix(security): gate ?person_id= CTOMOP resolver off by default (PHI IDOR #150/#108)

### DIFF
--- a/exact/settings.py
+++ b/exact/settings.py
@@ -256,6 +256,23 @@ ENABLE_DRF_TOKEN_AUTH = os.environ.get(
     'ENABLE_DRF_TOKEN_AUTH', _token_auth_default
 ).lower() in ('1', 'true')
 
+# The server-side `?person_id=` resolver fetches a patient from CTOMOP using a
+# STATIC service token with no binding to the authenticated caller, and CTOMOP
+# does not enforce row-level authz for that token — so any authenticated caller
+# can enumerate person_ids and read other patients' PHI (IDOR, #150/#108).
+# No production caller uses this path (the federation host fetches the patient
+# via CTOMOP `/patient-info/me/` under the end-user's own token and forwards it
+# inline), so gate it off by default outside local/DEBUG. Re-enable only once
+# caller-identity is forwarded to CTOMOP and CTOMOP enforces per-user authz.
+# Same fail-closed shape as ENABLE_DRF_TOKEN_AUTH: an unset ENVIRONMENT in a
+# deploy yields OFF, not ON.
+_person_id_lookup_default = (
+    'true' if (DEBUG or os.environ.get('ENVIRONMENT') == 'local') else 'false'
+)
+EXACT_ALLOW_PERSON_ID_LOOKUP = os.environ.get(
+    'EXACT_ALLOW_PERSON_ID_LOOKUP', _person_id_lookup_default
+).lower() in ('1', 'true')
+
 _AUTH_CLASSES = [
     'accounts.authentication.ServiceTokenAuthentication',
     'accounts.authentication.PartnerAuthentication',

--- a/tests/services/patient_info/test_resolve_ctomop.py
+++ b/tests/services/patient_info/test_resolve_ctomop.py
@@ -9,6 +9,8 @@ Resolution order under test:
 from unittest.mock import MagicMock, patch
 
 import pytest
+from django.test import override_settings
+from rest_framework.exceptions import PermissionDenied
 
 from trials.services.patient_info.resolve import resolve_patient_info
 
@@ -143,3 +145,49 @@ class TestResolvePatientInfoDispatch:
             assert resolve_patient_info(req) is None
             # Adapter not invoked on missing row.
             mock_build.assert_not_called()
+
+
+class TestPersonIdLookupGate:
+    """The `?person_id=` path is an IDOR (CTOMOP service token isn't bound to
+    the caller). It's gated behind EXACT_ALLOW_PERSON_ID_LOOKUP — off in prod.
+    When off, a person_id request is rejected (403) rather than silently
+    ignored; the inline path is unaffected. (#150/#108)"""
+
+    @override_settings(EXACT_ALLOW_PERSON_ID_LOOKUP=False)
+    def test_query_param_person_id_rejected_when_gate_off(self):
+        req = _mock_request(query_params={'person_id': '9001'})
+        with patch(
+            'trials.services.patient_info.ctomop_client.CtomopClient', autospec=True,
+        ) as MockClient:
+            with pytest.raises(PermissionDenied):
+                resolve_patient_info(req)
+            MockClient.return_value.fetch_patient.assert_not_called()
+
+    @override_settings(EXACT_ALLOW_PERSON_ID_LOOKUP=False)
+    def test_body_person_id_rejected_when_gate_off(self):
+        req = _mock_request(data={'person_id': 9003})
+        with pytest.raises(PermissionDenied):
+            resolve_patient_info(req)
+
+    @override_settings(EXACT_ALLOW_PERSON_ID_LOOKUP=False)
+    def test_inline_payload_unaffected_when_gate_off(self):
+        req = _mock_request(data={'patient_info': {'disease': 'multiple myeloma'}})
+        with patch('trials.services.patient_info.resolve._build_in_memory') as mock_inline:
+            mock_inline.return_value = 'inline_pi'
+            assert resolve_patient_info(req) == 'inline_pi'
+
+    @override_settings(EXACT_ALLOW_PERSON_ID_LOOKUP=False)
+    def test_no_patient_context_still_returns_none_when_gate_off(self):
+        assert resolve_patient_info(_mock_request()) is None
+
+    @override_settings(EXACT_ALLOW_PERSON_ID_LOOKUP=True)
+    def test_person_id_allowed_when_gate_on(self):
+        req = _mock_request(query_params={'person_id': '9001'})
+        with patch(
+            'trials.services.patient_info.ctomop_client.CtomopClient', autospec=True,
+        ) as MockClient, patch(
+            'trials.services.patient_info.ctomop_adapter.build_patient_info_from_ctomop_row',
+        ) as mock_build:
+            MockClient.return_value.fetch_patient.return_value = {'person_id': 9001}
+            mock_build.return_value = 'pi'
+            assert resolve_patient_info(req) == 'pi'

--- a/tests/test_security_hardening.py
+++ b/tests/test_security_hardening.py
@@ -173,3 +173,28 @@ class TestDrfTokenAuthGated:
         assert 'rest_framework.authentication.TokenAuthentication' in \
             settings.REST_FRAMEWORK['DEFAULT_AUTHENTICATION_CLASSES']
         assert reverse('api-token-auth')  # resolves without raising
+
+
+class TestPersonIdLookupGated:
+    """The server-side `?person_id=` resolver is a PHI IDOR (CTOMOP service
+    token unbound to the caller, no row-level authz). It's gated behind
+    EXACT_ALLOW_PERSON_ID_LOOKUP, defaulting OFF outside local/DEBUG and
+    failing closed on an unset ENVIRONMENT (#150/#108)."""
+
+    def test_person_id_flag_defaults_off_outside_local(self):
+        source = _settings_source()
+        assert re.search(
+            r"_person_id_lookup_default\s*=\s*\(?\s*\n?\s*'true'\s+if\s+\(?\s*DEBUG\s+or\s+"
+            r"os\.environ\.get\(\s*['\"]ENVIRONMENT['\"]\s*\)\s*==\s*['\"]local['\"]",
+            source,
+        ), "EXACT_ALLOW_PERSON_ID_LOOKUP default must fail closed on an unset ENVIRONMENT (#150)."
+
+    def test_person_id_default_rule_fails_closed(self):
+        def enabled(debug, environ):
+            return debug or environ.get('ENVIRONMENT') == 'local'
+
+        assert enabled(True, {}) is True                          # DEBUG
+        assert enabled(False, {'ENVIRONMENT': 'local'}) is True   # explicit local
+        assert enabled(False, {'ENVIRONMENT': 'prod'}) is False   # prod
+        assert enabled(False, {'ENVIRONMENT': 'staging'}) is False
+        assert enabled(False, {}) is False                        # unset -> fail closed

--- a/tests/views/test_patient_resolve_errors.py
+++ b/tests/views/test_patient_resolve_errors.py
@@ -10,6 +10,7 @@ though both get_queryset and get_serializer_context need it.
 import pytest
 from unittest.mock import patch
 
+from django.test import override_settings
 from rest_framework.authtoken.models import Token
 from rest_framework.test import APIClient
 
@@ -57,3 +58,20 @@ class TestPatientResolveErrors:
         ):
             resp = authed_client.get('/trials/')
         assert resp.status_code == 500
+
+    @override_settings(EXACT_ALLOW_PERSON_ID_LOOKUP=False)
+    def test_person_id_lookup_returns_403_when_gate_off(self, authed_client):
+        # IDOR gate (#150): with the person_id path disabled, a ?person_id=
+        # request is rejected (403), not silently served as a no-patient list.
+        TrialFactory(disease='Multiple Myeloma')
+        resp = authed_client.get('/trials/?person_id=123')
+        assert resp.status_code == 403
+
+    @override_settings(EXACT_ALLOW_PERSON_ID_LOOKUP=False)
+    def test_inline_match_still_works_when_person_id_gate_off(self, authed_client):
+        # The gate must not affect the inline path the real host uses.
+        TrialFactory(disease='Multiple Myeloma')
+        resp = authed_client.post(
+            '/trials/match/', {'patient_info': {'disease': 'multiple myeloma'}}, format='json'
+        )
+        assert resp.status_code == 200

--- a/trials/api/trials_views.py
+++ b/trials/api/trials_views.py
@@ -6,6 +6,7 @@ from rest_framework import viewsets, filters, permissions, status
 from rest_framework.decorators import action
 from rest_framework.response import Response
 from rest_framework import serializers
+from rest_framework.exceptions import APIException
 from rest_framework.views import APIView
 
 from trials.api.pagination import TrialsPagination
@@ -75,6 +76,10 @@ class TrialsViewSet(viewsets.ReadOnlyModelViewSet):
 
         try:
             patient_info = resolve_patient_info(self.request)
+        except APIException:
+            # Already an HTTP-meaningful response (e.g. PermissionDenied from
+            # the person_id IDOR gate, #150) — let DRF render it as-is.
+            raise
         except Exception:
             # Don't swallow into a silent None: that would run the matcher with
             # no patient context and return an unfiltered/unscored trial list

--- a/trials/services/patient_info/resolve.py
+++ b/trials/services/patient_info/resolve.py
@@ -6,7 +6,9 @@ PatientInfo resolver — supports two contract shapes.
    depends on this contract — do not change.
 2. CTOMOP fetch: `?person_id=` query param or `person_id` in the body.
    Looks up the patient from CTOMOP via `CtomopClient` and feeds the
-   row through `build_patient_info_from_ctomop_row` (#102).
+   row through `build_patient_info_from_ctomop_row` (#102). Gated behind
+   `EXACT_ALLOW_PERSON_ID_LOOKUP` (off by default outside local/DEBUG) —
+   see the authorization boundary below.
 
 The inline path takes precedence — if both `patient_info` and
 `person_id` are present, the inline payload wins (lets callers stage
@@ -14,22 +16,28 @@ the migration without breaking).
 
 ## Authorization boundary
 
-The CTOMOP path currently relies on **CTOMOP-side row-level authz**:
-EXACT calls the endpoint with a static service token from
-`CTOMOP_SERVICE_TOKEN` and does not bind `person_id` to the
-authenticated caller. The DRF views above ensure the request is
-authenticated, but EXACT has no model linking users to patients (the
-service is stateless for patient data — see project memory
-`feedback_exact_no_own_db.md`), so there's no in-tree relationship
-to verify against. Production deployments MUST either:
+The CTOMOP `person_id` path calls CTOMOP with a static service token
+(`CTOMOP_SERVICE_TOKEN`) that is NOT bound to the authenticated caller,
+and CTOMOP does not enforce row-level authz for that token — so honoring
+an arbitrary `person_id` lets any authenticated caller enumerate other
+patients' PHI (IDOR, #150/#108). EXACT also has no model linking users to
+patients (it's stateless for patient data — see project memory
+`feedback_exact_no_own_db.md`), so there's nothing in-tree to verify
+against.
 
-- enforce per-user authz at the CTOMOP layer (preferred), or
-- swap the static service token for caller-identity forwarding once
-  the parent federation track (#101) defines its identity flow.
+Because no production caller uses this path (the federation host fetches
+the patient from CTOMOP `/patient-info/me/` under the end-user's own token
+and forwards it inline), the path is gated OFF by default outside
+local/DEBUG via `EXACT_ALLOW_PERSON_ID_LOOKUP`. A request carrying
+`person_id` while the gate is off gets a 403.
 
-This is a deliberate design pin, not an oversight — adding fake
-EXACT-side authz would be worse than nothing. Tracked as #108
-alongside #101's identity flow.
+Re-enabling it in production requires BOTH:
+- forwarding the caller's identity to CTOMOP (token exchange / pass-through
+  bearer or actor_iss/actor_sub — see hk-labs `ctomop_client.py`), AND
+- CTOMOP enforcing per-user authz (its `PatientUser`/consent models), or
+  using the self-scoped `/patient-info/me/` route.
+
+Tracked as #150/#108.
 """
 import ast
 import datetime as dt
@@ -61,6 +69,18 @@ def resolve_patient_info(request) -> Optional['PatientInfo']:
 
     person_id = _extract_person_id(request)
     if person_id:
+        # IDOR gate (#150/#108): the CTOMOP fetch uses a static service token
+        # not bound to the caller, and CTOMOP doesn't enforce row-level authz
+        # for it — so honoring an arbitrary person_id leaks other patients'
+        # PHI. Off by default outside local/DEBUG; reject rather than silently
+        # ignore so the disabled path can't masquerade as a no-patient search.
+        from django.conf import settings
+        if not getattr(settings, 'EXACT_ALLOW_PERSON_ID_LOOKUP', False):
+            from rest_framework.exceptions import PermissionDenied
+            raise PermissionDenied(
+                'person_id lookup is disabled. Provide an inline patient_info '
+                'payload instead.'
+            )
         return _resolve_from_ctomop(person_id)
 
     return None


### PR DESCRIPTION
## Summary
Interim mitigation for the **PHI IDOR** on the server-side `?person_id=` resolver (#150 / #108).

- The `?person_id=` path fetches a patient from CTOMOP with a **static service token not bound to the caller**, and CTOMOP enforces **no row-level authz** for that token → any authenticated caller can enumerate `person_id`s and read other patients' PHI.
- **Cross-repo investigation (ctomop / ht-phr / hk-labs / soc) confirmed no production caller uses this path**: the federation host fetches the patient via CTOMOP `/patient-info/me/` under the **end-user's own token** and forwards it **inline**. So gating the path closes the IDOR without breaking the live feature.
- New setting `EXACT_ALLOW_PERSON_ID_LOOKUP`, **fail-closed** (off outside local/DEBUG, off on an unset `ENVIRONMENT`) — same shape as `ENABLE_DRF_TOKEN_AUTH`.
- When off, a request carrying `person_id` gets a **403** (not silently served as a no-patient list, per #156). The inline `patient_info` path is unaffected.

## Scope
This is the **interim mitigation** — it closes the exposure (#150). It does **not** implement the proper "bind the resolver to the caller" fix, which is tracked by **#108 (kept open)**: re-enabling `?person_id=` in prod requires BOTH caller-identity forwarding to CTOMOP (token exchange / pass-through bearer or `actor_iss`/`actor_sub`, see hk-labs `ctomop_client.py`) **and** CTOMOP-side per-user authz (its `PatientUser`/consent models) or the self-scoped `/patient-info/me/` route.

## Review
- Codex review: no issues.
- Fresh-context Claude review: gate is unbypassable, fail-closed, well-tested — merge.

## Test plan
- [ ] `GET /trials/?person_id=123` with gate off → 403
- [ ] `POST /trials/match/` with inline `patient_info` (gate off) → 200
- [ ] resolver unit tests: off→`PermissionDenied` (query+body), inline unaffected, on→fetches
- [ ] fail-closed default truth table

Closes #150

🤖 Generated with [Claude Code](https://claude.com/claude-code)