### PR TITLE
feat(mcl): high-risk MCL criteria matching (#185, #4416)

### DIFF
--- a/tests/querysets/test_mcl_filter_by_patient_info.py
+++ b/tests/querysets/test_mcl_filter_by_patient_info.py
@@ -38,7 +38,8 @@ class TestMclFilterByPatientInfoSmoke:
             extranodal_sites=['bone_marrow', 'gi_tract'],
             mipi_risk='low',
             mipi_c_risk='low',
-            bulky_disease_criteria=['bulky_lesion_5cm'],
+            bulky_disease_criteria='bulky_lesion_5cm',
+            high_risk_mcl_criteria='tp53_mutation',
         )
         # Pre-fix this would have raised
         #   Exception('type ... is not supported for user_attr "morphologic_variant"')

--- a/tests/services/patient_info/test_mcl_derivations.py
+++ b/tests/services/patient_info/test_mcl_derivations.py
@@ -145,59 +145,53 @@ class TestBulkyDiseaseCriteria:
     plus a >= 20 variant — mirrors CB so trials matching either spleen
     predicate work."""
 
-    def test_no_size_inputs_returns_empty_list(self):
+    def test_no_size_inputs_returns_none(self):
         pi = _mcl_patient()
-        assert PatientInfoAttributes(pi).bulky_disease_criteria == []
+        assert PatientInfoAttributes(pi).bulky_disease_criteria is None
 
     def test_lesion_5cm_alone(self):
         pi = _mcl_patient(largest_lesion_size=5)
-        assert PatientInfoAttributes(pi).bulky_disease_criteria == ['bulky_lesion_5cm']
+        assert PatientInfoAttributes(pi).bulky_disease_criteria == 'bulky_lesion_5cm'
 
     def test_lesion_10cm_fires_all_three_lesion_thresholds(self):
         pi = _mcl_patient(largest_lesion_size=12)
-        assert PatientInfoAttributes(pi).bulky_disease_criteria == [
-            'bulky_lesion_5cm', 'bulky_lesion_7_5cm', 'bulky_lesion_10cm',
-        ]
+        assert PatientInfoAttributes(pi).bulky_disease_criteria == \
+            'bulky_lesion_5cm,bulky_lesion_7_5cm,bulky_lesion_10cm'
 
     def test_lesion_under_5cm_does_not_fire(self):
         pi = _mcl_patient(largest_lesion_size=4.9)
-        assert PatientInfoAttributes(pi).bulky_disease_criteria == []
+        assert PatientInfoAttributes(pi).bulky_disease_criteria is None
 
     def test_node_5cm_alone(self):
         pi = _mcl_patient(largest_lymph_node_size=5)
-        assert PatientInfoAttributes(pi).bulky_disease_criteria == ['bulky_node_5cm']
+        assert PatientInfoAttributes(pi).bulky_disease_criteria == 'bulky_node_5cm'
 
     def test_node_10cm_fires_all_three_node_thresholds(self):
         pi = _mcl_patient(largest_lymph_node_size=10)
-        assert PatientInfoAttributes(pi).bulky_disease_criteria == [
-            'bulky_node_5cm', 'bulky_node_7_5cm', 'bulky_node_10cm',
-        ]
+        assert PatientInfoAttributes(pi).bulky_disease_criteria == \
+            'bulky_node_5cm,bulky_node_7_5cm,bulky_node_10cm'
 
     def test_spleen_uses_strict_gt_thresholds(self):
         # Spleen 13 itself does NOT fire bulky_spleen_13cm (predicate is > 13)
         pi_13 = _mcl_patient(spleen_size=13)
-        assert PatientInfoAttributes(pi_13).bulky_disease_criteria == []
+        assert PatientInfoAttributes(pi_13).bulky_disease_criteria is None
         pi_13_1 = _mcl_patient(spleen_size=13.1)
-        assert PatientInfoAttributes(pi_13_1).bulky_disease_criteria == ['bulky_spleen_13cm']
+        assert PatientInfoAttributes(pi_13_1).bulky_disease_criteria == 'bulky_spleen_13cm'
 
     def test_spleen_20_exactly_fires_gte_only(self):
         pi = _mcl_patient(spleen_size=20)
-        assert PatientInfoAttributes(pi).bulky_disease_criteria == [
-            'bulky_spleen_13cm', 'bulky_spleen_15cm', 'bulky_spleen_20cm_gte',
-        ]
+        assert PatientInfoAttributes(pi).bulky_disease_criteria == \
+            'bulky_spleen_13cm,bulky_spleen_15cm,bulky_spleen_20cm_gte'
 
     def test_spleen_above_20_fires_both_gt_and_gte(self):
         pi = _mcl_patient(spleen_size=21)
-        assert PatientInfoAttributes(pi).bulky_disease_criteria == [
-            'bulky_spleen_13cm', 'bulky_spleen_15cm',
-            'bulky_spleen_20cm_gt', 'bulky_spleen_20cm_gte',
-        ]
+        assert PatientInfoAttributes(pi).bulky_disease_criteria == \
+            'bulky_spleen_13cm,bulky_spleen_15cm,bulky_spleen_20cm_gt,bulky_spleen_20cm_gte'
 
     def test_multiple_anatomic_sites_combine(self):
         pi = _mcl_patient(largest_lesion_size=5, largest_lymph_node_size=5, spleen_size=14)
-        assert PatientInfoAttributes(pi).bulky_disease_criteria == [
-            'bulky_lesion_5cm', 'bulky_node_5cm', 'bulky_spleen_13cm',
-        ]
+        assert PatientInfoAttributes(pi).bulky_disease_criteria == \
+            'bulky_lesion_5cm,bulky_node_5cm,bulky_spleen_13cm'
 
 
 class TestNormalizerWiring:
@@ -209,15 +203,14 @@ class TestNormalizerWiring:
         pi = _mcl_patient(
             mipi_risk='high',  # caller-supplied; should be overwritten to 'low'
             mipi_c_risk='high',
-            bulky_disease_criteria=['caller_supplied_garbage'],
+            bulky_disease_criteria='caller_supplied_garbage',
             largest_lesion_size=12,
         )
         normalize_patient_info(pi)
         assert pi.mipi_risk == 'low'  # actual derivation for the default inputs
         assert pi.mipi_c_risk == 'low'
-        assert pi.bulky_disease_criteria == [
-            'bulky_lesion_5cm', 'bulky_lesion_7_5cm', 'bulky_lesion_10cm',
-        ]
+        assert pi.bulky_disease_criteria == \
+            'bulky_lesion_5cm,bulky_lesion_7_5cm,bulky_lesion_10cm'
 
     @pytest.mark.django_db
     def test_non_mcl_patient_mcl_fields_left_alone(self):
@@ -238,7 +231,7 @@ class TestNormalizerWiring:
         # casing the API caller sends.
         pi = _mcl_patient(disease=disease, largest_lesion_size=6)
         normalize_patient_info(pi)
-        assert pi.bulky_disease_criteria == ['bulky_lesion_5cm']
+        assert pi.bulky_disease_criteria == 'bulky_lesion_5cm'
 
 
 def _high_risk_codes(pi):

--- a/tests/services/patient_info/test_resolve_normalize_json.py
+++ b/tests/services/patient_info/test_resolve_normalize_json.py
@@ -147,7 +147,7 @@ class TestMclFieldRoundTrip:
             # normalizer (see assertions below).
             'mipi_risk': 'intermediate',
             'mipi_c_risk': 'high_intermediate',
-            'bulky_disease_criteria': ['caller_supplied_ignored'],
+            'bulky_disease_criteria': 'caller_supplied_ignored',
         }
         pi = _build_in_memory(data)
         # Non-derived fields preserved.
@@ -162,9 +162,7 @@ class TestMclFieldRoundTrip:
         # fires the 5cm and 7.5cm bulky-lesion thresholds.
         assert pi.mipi_risk is None
         assert pi.mipi_c_risk is None
-        assert pi.bulky_disease_criteria == [
-            'bulky_lesion_5cm', 'bulky_lesion_7_5cm',
-        ]
+        assert pi.bulky_disease_criteria == 'bulky_lesion_5cm,bulky_lesion_7_5cm'
 
     @pytest.mark.django_db
     def test_mcl_fields_camel_case_round_trip(self):
@@ -183,16 +181,17 @@ class TestMclFieldRoundTrip:
         assert pi.mipi_risk is None
 
     @pytest.mark.django_db
-    def test_mcl_list_fields_default_to_empty_list(self):
+    def test_mcl_extranodal_defaults_to_empty_list_bulky_to_none(self):
         data = {'disease': 'mantle cell lymphoma'}
         pi = _build_in_memory(data)
         assert pi.extranodal_sites == []
-        assert pi.bulky_disease_criteria == []
+        # bulky_disease_criteria is a derived comma-string (None when no inputs).
+        assert pi.bulky_disease_criteria is None
 
     @pytest.mark.django_db
-    def test_mcl_list_fields_none_coerced_to_empty_list(self):
-        # Caller sends explicit null — default=list contract must hold so
-        # downstream iteration (matcher overlap checks) doesn't crash.
+    def test_mcl_extranodal_none_coerced_to_empty_list(self):
+        # Caller sends explicit null — default=list contract must hold for
+        # extranodal_sites so downstream iteration doesn't crash.
         data = {
             'disease': 'mantle cell lymphoma',
             'extranodal_sites': None,
@@ -200,18 +199,17 @@ class TestMclFieldRoundTrip:
         }
         pi = _build_in_memory(data)
         assert pi.extranodal_sites == []
-        assert pi.bulky_disease_criteria == []
+        assert pi.bulky_disease_criteria is None
 
     @pytest.mark.django_db
-    def test_mcl_list_fields_drop_non_string_items(self):
+    def test_mcl_extranodal_drops_non_string_items(self):
         data = {
             'disease': 'mantle cell lymphoma',
             'extranodal_sites': ['bone_marrow', 42, None, '  gi_tract  ', ''],
-            # bulky_disease_criteria is overwritten by the normalizer (#41);
-            # exercise the resolver hardening on extranodal_sites only.
-            'bulky_disease_criteria': [{'nested': 'dict'}, 'caller_supplied_ignored'],
+            # bulky_disease_criteria is overwritten by the normalizer (#41).
+            'bulky_disease_criteria': 'caller_supplied_ignored',
         }
         pi = _build_in_memory(data)
         assert pi.extranodal_sites == ['bone_marrow', 'gi_tract']
-        # No size fields in payload, so derived bulky list is empty.
-        assert pi.bulky_disease_criteria == []
+        # No size fields in payload, so derived bulky is None.
+        assert pi.bulky_disease_criteria is None

--- a/tests/services/test_high_risk_mcl_matching.py
+++ b/tests/services/test_high_risk_mcl_matching.py
@@ -161,3 +161,51 @@ class TestHighRiskMclBreakdown:
         # excluded criterion present -> not_matched (inverse logic)
         assert excl['blastoid'] == 'not_matched'
         assert bd['aggregate'] == 'not_matched'
+
+
+class TestHighRiskMclPotentialCounting:
+    """#4416: per-criterion potential-counting. A gating trial that the patient
+    cannot definitively satisfy (unknown required criterion) must count as
+    potential, not be silently treated as eligible by the aggregate check."""
+
+    @pytest.mark.django_db
+    def test_unknown_required_adds_one_potential_vs_matched(self):
+        # Patient: tp53 known-present, cytogenic blank -> del17p undeterminable.
+        pi = _mcl_patient(molecular_markers='tp53Mutation')
+        # Two trials identical except for high-risk fields.
+        t_matched = TrialFactory(
+            disease='mantle cell lymphoma',
+            high_risk_mcl_criteria_required=['tp53_mutation'],
+        )
+        t_unknown = TrialFactory(
+            disease='mantle cell lymphoma',
+            high_risk_mcl_criteria_required=['tp53_mutation', 'del17p'],
+            high_risk_mcl_criteria_min_count=2,
+        )
+        qs = (
+            Trial.objects.filter(id__in=[t_matched.id, t_unknown.id])
+            .with_potential_attrs_count(pi)
+        )
+        counts = {t.id: t.potential_attrs_count for t in qs}
+        # Only the high-risk fields differ, so the delta is exactly the high-risk
+        # contribution: matched -> 0, unknown (1 of 2 required, min_count 2) -> 1.
+        assert counts[t_unknown.id] == counts[t_matched.id] + 1
+
+    @pytest.mark.django_db
+    def test_sufficient_any_met_is_not_potential(self):
+        pi = _mcl_patient(morphologic_variant='blastoid')  # blastoid known-present
+        t_suff = TrialFactory(
+            disease='mantle cell lymphoma',
+            high_risk_mcl_criteria_required=['tp53_mutation', 'del17p'],
+            high_risk_mcl_criteria_min_count=2,
+            high_risk_mcl_criteria_sufficient_any=['blastoid'],
+        )
+        t_plain = TrialFactory(disease='mantle cell lymphoma')
+        qs = (
+            Trial.objects.filter(id__in=[t_suff.id, t_plain.id])
+            .with_potential_attrs_count(pi)
+        )
+        counts = {t.id: t.potential_attrs_count for t in qs}
+        # sufficient_any satisfied -> high-risk contributes 0 potential, same as
+        # a trial with no high-risk gate.
+        assert counts[t_suff.id] == counts[t_plain.id]

--- a/tests/services/test_high_risk_mcl_matching.py
+++ b/tests/services/test_high_risk_mcl_matching.py
@@ -1,0 +1,163 @@
+"""
+High-risk MCL criteria MATCHING (#185, CB #4399-#4437).
+
+Covers the queryset eligibility filter, the criteria_count aggregate matcher
+(required/min_count + sufficient_any + excluded, unknown-vs-none), and the
+per-criterion breakdown.
+"""
+import pytest
+
+from trials.models import Trial
+from trials.services.patient_info.patient_info import PatientInfo
+from trials.services.patient_info.normalize import normalize_patient_info
+from trials.services.user_to_trial_attr_matcher import UserToTrialAttrMatcher
+from tests.factories import TrialFactory
+
+
+def _mcl_patient(**kwargs):
+    """MCL patient with derived high_risk_mcl_criteria computed via normalize."""
+    pi = PatientInfo(disease='mantle cell lymphoma', **kwargs)
+    normalize_patient_info(pi)
+    return pi
+
+
+def _status(trial, pi):
+    return UserToTrialAttrMatcher(trial=trial, patient_info=pi).attr_match_status('high_risk_mcl_criteria')
+
+
+class TestHighRiskMclQueryset:
+    @pytest.mark.django_db
+    def test_required_overlap_includes_and_disjoint_excludes(self):
+        t_no_gate = TrialFactory(disease='mantle cell lymphoma')
+        t_req = TrialFactory(disease='mantle cell lymphoma', high_risk_mcl_criteria_required=['tp53_mutation'])
+        t_other = TrialFactory(disease='mantle cell lymphoma', high_risk_mcl_criteria_required=['del17p'])
+
+        result = set(
+            Trial.objects.all()
+            .eligible_for_high_risk_mcl_criteria(['tp53_mutation'])
+            .values_list('id', flat=True)
+        )
+        assert t_no_gate.id in result, 'no inclusion gate -> always eligible'
+        assert t_req.id in result, 'required overlaps patient -> eligible'
+        assert t_other.id not in result, 'required disjoint from patient -> dropped'
+
+    @pytest.mark.django_db
+    def test_sufficient_any_includes(self):
+        t = TrialFactory(
+            disease='mantle cell lymphoma',
+            high_risk_mcl_criteria_required=['tp53_mutation', 'del17p'],
+            high_risk_mcl_criteria_sufficient_any=['blastoid'],
+        )
+        result = set(
+            Trial.objects.all()
+            .eligible_for_high_risk_mcl_criteria(['blastoid'])
+            .values_list('id', flat=True)
+        )
+        assert t.id in result, 'sufficient_any overlap alone qualifies'
+
+    @pytest.mark.django_db
+    def test_excluded_drops_trial(self):
+        t = TrialFactory(disease='mantle cell lymphoma', high_risk_mcl_criteria_excluded=['del17p'])
+        result = set(
+            Trial.objects.all()
+            .eligible_for_high_risk_mcl_criteria(['del17p'])
+            .values_list('id', flat=True)
+        )
+        assert t.id not in result
+
+    @pytest.mark.django_db
+    def test_empty_criteria_is_noop(self):
+        t = TrialFactory(disease='mantle cell lymphoma', high_risk_mcl_criteria_required=['tp53_mutation'])
+        result = set(Trial.objects.all().eligible_for_high_risk_mcl_criteria([]).values_list('id', flat=True))
+        assert t.id in result
+
+
+class TestHighRiskMclAggregateMatcher:
+    @pytest.mark.django_db
+    def test_matched_when_required_met(self):
+        t = TrialFactory(disease='mantle cell lymphoma', high_risk_mcl_criteria_required=['tp53_mutation'])
+        pi = _mcl_patient(molecular_markers='tp53Mutation')
+        assert _status(t, pi) == 'matched'
+
+    @pytest.mark.django_db
+    def test_not_matched_when_required_absent_but_source_known(self):
+        # molecular_markers answered (no tp53) -> tp53 confirmed absent.
+        t = TrialFactory(disease='mantle cell lymphoma', high_risk_mcl_criteria_required=['tp53_mutation'])
+        pi = _mcl_patient(molecular_markers='ccnd1Alteration')
+        assert _status(t, pi) == 'not_matched'
+
+    @pytest.mark.django_db
+    def test_unknown_when_required_source_blank(self):
+        # molecular_markers unanswered -> tp53 undeterminable.
+        t = TrialFactory(disease='mantle cell lymphoma', high_risk_mcl_criteria_required=['tp53_mutation'])
+        pi = _mcl_patient()
+        assert _status(t, pi) == 'unknown'
+
+    @pytest.mark.django_db
+    def test_min_count_gate(self):
+        t = TrialFactory(
+            disease='mantle cell lymphoma',
+            high_risk_mcl_criteria_required=['tp53_mutation', 'del17p'],
+            high_risk_mcl_criteria_min_count=2,
+        )
+        # del17p sources are molecular_markers AND cytogenic_markers; both must
+        # be answered for it to read confirmed-absent rather than unknown.
+        one = _mcl_patient(molecular_markers='tp53Mutation', cytogenic_markers='hyperdiploidy')
+        assert _status(t, one) == 'not_matched'
+        both = _mcl_patient(molecular_markers='tp53Mutation,del17p13')
+        assert _status(t, both) == 'matched'
+
+    @pytest.mark.django_db
+    def test_sufficient_any_overrides_required(self):
+        t = TrialFactory(
+            disease='mantle cell lymphoma',
+            high_risk_mcl_criteria_required=['tp53_mutation', 'del17p'],
+            high_risk_mcl_criteria_min_count=2,
+            high_risk_mcl_criteria_sufficient_any=['blastoid'],
+        )
+        pi = _mcl_patient(morphologic_variant='blastoid', molecular_markers='ccnd1Alteration')
+        assert _status(t, pi) == 'matched'
+
+    @pytest.mark.django_db
+    def test_excluded_present_is_not_matched(self):
+        t = TrialFactory(disease='mantle cell lymphoma', high_risk_mcl_criteria_excluded=['blastoid'])
+        pi = _mcl_patient(morphologic_variant='blastoid')
+        assert _status(t, pi) == 'not_matched'
+
+    @pytest.mark.django_db
+    def test_no_criteria_is_matched(self):
+        t = TrialFactory(disease='mantle cell lymphoma')
+        pi = _mcl_patient(molecular_markers='tp53Mutation')
+        assert _status(t, pi) == 'matched'
+
+
+class TestHighRiskMclBreakdown:
+    @pytest.mark.django_db
+    def test_breakdown_none_when_no_criteria(self):
+        t = TrialFactory(disease='mantle cell lymphoma')
+        pi = _mcl_patient()
+        matcher = UserToTrialAttrMatcher(trial=t, patient_info=pi)
+        assert matcher.high_risk_mcl_criteria_breakdown() is None
+
+    @pytest.mark.django_db
+    def test_breakdown_per_criterion_status(self):
+        t = TrialFactory(
+            disease='mantle cell lymphoma',
+            high_risk_mcl_criteria_required=['tp53_mutation', 'del17p'],
+            high_risk_mcl_criteria_excluded=['blastoid'],
+            high_risk_mcl_criteria_min_count=2,
+        )
+        # tp53 present; del17p known-absent (both marker sources answered);
+        # blastoid present (excluded).
+        pi = _mcl_patient(molecular_markers='tp53Mutation', cytogenic_markers='hyperdiploidy',
+                          morphologic_variant='blastoid')
+        bd = UserToTrialAttrMatcher(trial=t, patient_info=pi).high_risk_mcl_criteria_breakdown()
+        assert bd['minCount'] == 2
+        assert bd['matchedCount'] == 1
+        req = {c['code']: c['status'] for c in bd['required']}
+        assert req['tp53_mutation'] == 'matched'
+        assert req['del17p'] == 'not_matched'
+        excl = {c['code']: c['status'] for c in bd['excluded']}
+        # excluded criterion present -> not_matched (inverse logic)
+        assert excl['blastoid'] == 'not_matched'
+        assert bd['aggregate'] == 'not_matched'

--- a/trials/api/trials_views.py
+++ b/trials/api/trials_views.py
@@ -221,6 +221,21 @@ class TrialsViewSet(viewsets.ReadOnlyModelViewSet):
         serializer = self.get_serializer(queryset, many=True)
         return Response(serializer.data)
 
+    def retrieve(self, request, *args, **kwargs):
+        instance = self.get_object()
+        serializer = self.get_serializer(instance)
+        data = serializer.data
+        # #4408: per-criterion high-risk MCL explainability (detail view only;
+        # None for trials that gate on no high-risk criteria, or without a patient).
+        patient_info = self._resolve_patient_info()
+        if patient_info is not None:
+            from trials.services.user_to_trial_attr_matcher import UserToTrialAttrMatcher
+            data['highRiskMclCriteriaBreakdown'] = (
+                UserToTrialAttrMatcher(trial=instance, patient_info=patient_info)
+                .high_risk_mcl_criteria_breakdown()
+            )
+        return Response(data)
+
     def get_paginated_response(self, data, extra_keys=None):
         assert self.paginator is not None
         return self.paginator.get_paginated_response(data, extra_keys=extra_keys)

--- a/trials/querysets/trial.py
+++ b/trials/querysets/trial.py
@@ -193,7 +193,8 @@ _CUSTOM_SEARCH_DISPATCH = {
     'mipi_risk': lambda s, v, _c: s.eligible_for_mipi_risks(_csv_stripped(v)),
     'mipi_c_risk': lambda s, v, _c: s.eligible_for_mipi_c_risks(_csv_stripped(v)),
     'extranodal_sites': lambda s, v, _c: s.eligible_for_extranodal_sites(v),
-    'bulky_disease_criteria': lambda s, v, _c: s.eligible_for_bulky_disease_criteria(v),
+    'bulky_disease_criteria': lambda s, v, _c: s.eligible_for_bulky_disease_criteria(_csv_stripped(v)),
+    'high_risk_mcl_criteria': lambda s, v, _c: s.eligible_for_high_risk_mcl_criteria(_csv_stripped(v)),
 }
 
 
@@ -1296,10 +1297,11 @@ class TrialQuerySet(models.QuerySet):
         )
 
     # ------------------------------------------------------------------
-    # MCL filters (#94). The patient-side attrs land here as either a
-    # single string (variant / risk / behavior / subtype) or a list of
-    # strings (extranodal_sites / bulky_disease_criteria). All map to
-    # JSON-list trial columns checked via the shared list helpers above.
+    # MCL filters (#94). The patient-side attrs land here as a single
+    # string (variant / risk / behavior / subtype), a comma-string of
+    # derived codes (bulky_disease_criteria / high_risk_mcl_criteria,
+    # split via _csv_stripped in dispatch), or a list (extranodal_sites).
+    # All map to JSON-list trial columns checked via the shared helpers.
     # ------------------------------------------------------------------
 
     def eligible_for_morphologic_variants(self, values: list[str]) -> models.QuerySet:
@@ -1343,6 +1345,24 @@ class TrialQuerySet(models.QuerySet):
         return self.eligible_for_required_lists(
             values=values,
             required_attr_name='bulky_disease_criteria_required',
+        )
+
+    def eligible_for_high_risk_mcl_criteria(self, criteria: list[str]) -> models.QuerySet:
+        if criteria is None or criteria == []:
+            return self
+
+        values = [str(x).strip() for x in criteria]
+
+        # Inclusion is satisfied when the patient overlaps the required list, OR
+        # overlaps any "sufficient alone" criterion (#4402), OR the trial sets no
+        # inclusion gate at all (both lists empty). Then drop excluded matches.
+        no_inclusion_gate = Q(high_risk_mcl_criteria_required__exact=[]) & Q(high_risk_mcl_criteria_sufficient_any__exact=[])
+        return self.filter(
+            Q(high_risk_mcl_criteria_required__has_any_keys=values)
+            | Q(high_risk_mcl_criteria_sufficient_any__has_any_keys=values)
+            | no_inclusion_gate
+        ).exclude(
+            Q(high_risk_mcl_criteria_excluded__has_any_keys=values)
         )
 
     def eligible_for_tp53_disruption(self, tp53_disruption: bool) -> models.QuerySet:

--- a/trials/services/patient_info/configs.py
+++ b/trials/services/patient_info/configs.py
@@ -130,6 +130,9 @@ TRIAL_ATTRS_JSON_AS_A_LIST = (
     "bulky_disease_criteria_required",
     "mipi_risks_required",
     "mipi_c_risks_required",
+    "high_risk_mcl_criteria_required",
+    "high_risk_mcl_criteria_excluded",
+    "high_risk_mcl_criteria_sufficient_any",
 )
 
 USER_TO_TRIAL_ATTRS_MAPPING = {
@@ -569,6 +572,31 @@ USER_TO_TRIAL_ATTRS_MAPPING = {
         "uvalue_function": {
             "bulky_disease_criteria_required":
                 lambda patient_info: patient_info.bulky_disease_criteria,
+        }
+    },
+    "high_risk_mcl_criteria": {
+        "type": ATTR_MAPPING_TYPE_COMPUTED,
+        "custom_search": True,
+        "is_computed_value": True,
+        "computed_value_type": "str",
+        "disease": "MCL",
+        "attr": [
+            "high_risk_mcl_criteria_required",
+            "high_risk_mcl_criteria_excluded",
+            "high_risk_mcl_criteria_sufficient_any",
+        ],
+        "criteria_count_match": True,
+        "criteria_required_attr": "high_risk_mcl_criteria_required",
+        "criteria_excluded_attr": "high_risk_mcl_criteria_excluded",
+        "criteria_sufficient_any_attr": "high_risk_mcl_criteria_sufficient_any",
+        "criteria_min_count_attr": "high_risk_mcl_criteria_min_count",
+        "criteria_derived": lambda patient_info: patient_info.high_risk_mcl_criteria,
+        "criteria_unknown_codes": lambda pia, required: pia.high_risk_mcl_criteria_unknown_codes(required),
+        "criteria_all_unknown_codes": lambda pia: pia.high_risk_mcl_criteria_all_unknown_codes(),
+        "uvalue_function": {
+            "high_risk_mcl_criteria_required": lambda patient_info: patient_info.high_risk_mcl_criteria,
+            "high_risk_mcl_criteria_excluded": lambda patient_info: patient_info.high_risk_mcl_criteria,
+            "high_risk_mcl_criteria_sufficient_any": lambda patient_info: patient_info.high_risk_mcl_criteria,
         }
     },
     # MCL-specific END

--- a/trials/services/patient_info/normalize.py
+++ b/trials/services/patient_info/normalize.py
@@ -242,9 +242,7 @@ def _normalize_mcl_derivations(pi) -> None:
     attr = PatientInfoAttributes(pi)
     pi.mipi_risk = attr.mipi_risk
     pi.mipi_c_risk = attr.mipi_c_risk
-    # Defensive copy: bulky_disease_criteria is a cached_property; without
-    # copying, downstream mutation of pi.bulky_disease_criteria would also
-    # mutate the cached property's stored list.
-    pi.bulky_disease_criteria = list(attr.bulky_disease_criteria)
-    # high_risk_mcl_criteria is a comma-joined string (or None), per CB.
+    # bulky_disease_criteria and high_risk_mcl_criteria are comma-joined
+    # strings (or None), per CB.
+    pi.bulky_disease_criteria = attr.bulky_disease_criteria
     pi.high_risk_mcl_criteria = attr.high_risk_mcl_criteria

--- a/trials/services/patient_info/patient_info.py
+++ b/trials/services/patient_info/patient_info.py
@@ -224,7 +224,7 @@ _FIELDS = [
     _f(JSONField, 'extranodal_sites', default=list),
     _f(TextField, 'mipi_risk'),
     _f(TextField, 'mipi_c_risk'),
-    _f(JSONField, 'bulky_disease_criteria', default=list),
+    _f(TextField, 'bulky_disease_criteria'),
     _f(TextField, 'high_risk_mcl_criteria'),
 ]
 

--- a/trials/services/patient_info/patient_info_attributes.py
+++ b/trials/services/patient_info/patient_info_attributes.py
@@ -618,10 +618,9 @@ class PatientInfoAttributes:
 
     # ---------------------------------------------------------------------
     # MCL derivations (#41).
-    # Ported from CB patient_info_attributes.py. One remaining EXACT-local
-    # adaptation: bulky_disease_criteria returns a list (matches EXACT's
-    # JSONField); the comma-string realign lands with the high-risk matcher
-    # wiring (#185). Field names (largest_lesion_size) and codes match CB.
+    # Ported from CB patient_info_attributes.py; bulky_disease_criteria and
+    # high_risk_mcl_criteria both return a comma-joined string (or None), and
+    # field names / codes match CB exactly.
     # MIPI: Hoster et al. 2008 (Blood 111:558-565).
     # MIPI-C: categorical MIPI x Ki-67 table (Hoster et al. 2014, ASH 2014
     # abstract — full JCO 2016 publication uses a continuous variant).
@@ -677,11 +676,11 @@ class PatientInfoAttributes:
 
     @cached_property
     def bulky_disease_criteria(self):
-        """Codes for each bulky-disease criterion the patient meets.
+        """Comma-joined codes for each bulky-disease criterion the patient meets.
 
         Multiple thresholds can fire at once (e.g. a 12cm lesion produces
         bulky_lesion_5cm, _7_5cm, and _10cm) so trials requiring any one of
-        them all match. Returns [] when no inputs or no thresholds met.
+        them all match. Returns None when no inputs or no thresholds met.
         """
         pi = self.patient_info
         criteria = []
@@ -715,7 +714,7 @@ class PatientInfoAttributes:
             if spleen >= 20:
                 criteria.append('bulky_spleen_20cm_gte')
 
-        return criteria
+        return ','.join(criteria) if criteria else None
 
     @cached_property
     def high_risk_mcl_criteria(self):

--- a/trials/services/patient_info/resolve.py
+++ b/trials/services/patient_info/resolve.py
@@ -216,7 +216,9 @@ def _normalize_structured_json_fields(data: dict):
     # Coerce None / non-list / non-string items to [] so the default=list
     # contract holds when CB sends `null` or `_coerce_json_fields` falls
     # through on malformed input (which sets the value to None).
-    for key in ('extranodal_sites', 'bulky_disease_criteria'):
+    # NB: bulky_disease_criteria / high_risk_mcl_criteria are derived
+    # comma-strings (computed in normalize for MCL), not list inputs.
+    for key in ('extranodal_sites',):
         val = data.get(key)
         if key not in data:
             continue

--- a/trials/services/user_to_trial_attr_matcher.py
+++ b/trials/services/user_to_trial_attr_matcher.py
@@ -651,6 +651,11 @@ class UserToTrialAttrMatcher:
             return 'matched'
 
     def _match_computed_attr(self, ctx):
+        # "Named OR" criteria attrs (e.g. high-risk MCL) need count/sufficient/
+        # excluded semantics that the generic per-subattr overlap can't express.
+        if ctx.meta.get("criteria_count_match"):
+            return self._match_criteria_count(ctx.meta)
+
         matching_results = []
 
         for trial_subattr_name, uvalue_function in ctx.meta["uvalue_function"].items():
@@ -662,6 +667,127 @@ class UserToTrialAttrMatcher:
         if 'unknown' in matching_results:
             return 'unknown'
         return 'matched'
+
+    def _match_criteria_count(self, trial_attr_meta):
+        """Three-valued match for "named OR" criteria attributes (e.g. high-risk MCL).
+
+        Distinguishes a true unknown (source data for a required criterion was
+        never entered) from a confirmed "none" (sources entered, criterion
+        absent). See #4399. The verdict combines up to three rule sets:
+
+        - required (inclusion) with an optional per-trial minimum count; a null
+          / absent min_count means "any" (effectively 1).
+        - sufficient_any (#4402): any single one of these criteria satisfies
+          inclusion on its own, regardless of min_count. ORed with the required
+          rule.
+        - excluded (#4401): a patient with any excluded criterion is gated out;
+          an undeterminable excluded criterion keeps the trial Potential. ANDed
+          with the inclusion decision.
+
+        Each rule is evaluated three-valued; the aggregate follows the generic
+        computed matcher precedence — not_matched wins, then unknown, else
+        matched.
+        """
+        derived_csv = trial_attr_meta["criteria_derived"](self.patient_info)
+        derived = {c.strip() for c in (derived_csv or '').split(',') if c.strip()}
+
+        def rule_status(codes, threshold):
+            """Three-valued status for "patient meets >= threshold of codes"."""
+            if not codes:
+                return None
+            unknown_codes = trial_attr_meta["criteria_unknown_codes"](self.patient_info_attr, codes)
+            matched = sum(1 for c in codes if c in derived)
+            unknown = sum(1 for c in codes if c not in derived and c in unknown_codes)
+            if matched >= threshold:
+                return 'matched'
+            if matched + unknown >= threshold:
+                return 'unknown'
+            return 'not_matched'
+
+        statuses = []
+
+        # Inclusion: required (>= min_count) OR sufficient_any (>= 1).
+        min_count_attr = trial_attr_meta.get("criteria_min_count_attr")
+        min_count = getattr(self.trial, min_count_attr, None) if min_count_attr else None
+        if not min_count or min_count < 1:
+            min_count = 1
+        required = getattr(self.trial, trial_attr_meta["criteria_required_attr"], None) or []
+
+        sufficient_attr = trial_attr_meta.get("criteria_sufficient_any_attr")
+        sufficient_any = getattr(self.trial, sufficient_attr, None) or [] if sufficient_attr else []
+
+        inclusion_rules = [s for s in (rule_status(required, min_count), rule_status(sufficient_any, 1)) if s is not None]
+        if inclusion_rules:
+            if 'matched' in inclusion_rules:
+                statuses.append('matched')
+            elif 'unknown' in inclusion_rules:
+                statuses.append('unknown')
+            else:
+                statuses.append('not_matched')
+
+        # Exclusion (any one excluded criterion gates the patient out).
+        excluded_attr = trial_attr_meta.get("criteria_excluded_attr")
+        excluded = getattr(self.trial, excluded_attr, None) or [] if excluded_attr else []
+        excl_status = rule_status(excluded, 1)
+        if excl_status == 'matched':
+            statuses.append('not_matched')
+        elif excl_status == 'unknown':
+            statuses.append('unknown')
+
+        if 'not_matched' in statuses:
+            return 'not_matched'
+        if 'unknown' in statuses:
+            return 'unknown'
+        return 'matched'
+
+    def high_risk_mcl_criteria_breakdown(self):
+        """Per-criterion explainability for the high-risk MCL attribute (#4408).
+
+        Returns the aggregate verdict plus, for each of the required / excluded /
+        sufficient_any lists, the per-criterion status: 'matched' (patient has
+        it), 'unknown' (its source data is missing) or 'not_matched' (confirmed
+        absent). Titles are intentionally omitted — the UI maps codes to titles
+        via the high-risk-mcl-criteria options. Returns None for a trial that
+        gates on no high-risk criteria.
+        """
+        meta = self.mapping['high_risk_mcl_criteria']
+        required = getattr(self.trial, meta['criteria_required_attr'], None) or []
+        excluded = getattr(self.trial, meta['criteria_excluded_attr'], None) or []
+        sufficient_any = getattr(self.trial, meta['criteria_sufficient_any_attr'], None) or []
+        if not (required or excluded or sufficient_any):
+            return None
+
+        derived_csv = meta['criteria_derived'](self.patient_info)
+        derived = {c.strip() for c in (derived_csv or '').split(',') if c.strip()}
+
+        def code_status(code, is_exclude):
+            """Per-criterion status in eligibility terms (consistent with the
+            aggregate verdict). For an excluded criterion, presence is
+            disqualifying so it reads not_matched, and confirmed absence reads
+            matched — the inverse of an inclusion criterion."""
+            if code in derived:
+                return 'not_matched' if is_exclude else 'matched'
+            unknown = meta['criteria_unknown_codes'](self.patient_info_attr, [code])
+            if code in unknown:
+                return 'unknown'
+            return 'matched' if is_exclude else 'not_matched'
+
+        def breakdown(codes, is_exclude=False):
+            return [{'code': c, 'status': code_status(c, is_exclude)} for c in codes]
+
+        min_count_attr = meta.get('criteria_min_count_attr')
+        min_count = getattr(self.trial, min_count_attr, None) if min_count_attr else None
+        if not min_count or min_count < 1:
+            min_count = 1
+
+        return {
+            'aggregate': self.attr_match_status('high_risk_mcl_criteria'),
+            'minCount': min_count,
+            'matchedCount': sum(1 for c in required if c in derived),
+            'required': breakdown(required),
+            'excluded': breakdown(excluded, is_exclude=True),
+            'sufficientAny': breakdown(sufficient_any),
+        }
 
     def _match_computed_subattr(self, trial_subattr_name, uvalue_func, is_blank):
         # Naming convention: trial attrs ending in `_excluded` are

--- a/trials/services/user_to_trial_attrs_mapper.py
+++ b/trials/services/user_to_trial_attrs_mapper.py
@@ -1,3 +1,5 @@
+import re
+
 import inflection
 from django.db import models
 from django.db.models import Q
@@ -106,6 +108,75 @@ class UserToTrialAttrsMapper:
         out = sorted(out, key=lambda d: -d['count'])
         return out
 
+    @staticmethod
+    def _jsonb_intersect_count(column, codes):
+        """SQL counting how many elements of a jsonb-array column are in `codes`.
+
+        `codes` is a fixed (patient-derived) set of controlled-vocabulary codes,
+        so it is inlined safely after stripping anything outside [a-zA-Z0-9_].
+        """
+        safe = [c for c in codes if re.fullmatch(r'[a-zA-Z0-9_]+', c or '')]
+        if not safe:
+            return '0'
+        in_list = ', '.join(f"'{c}'" for c in sorted(set(safe)))
+        return (
+            f"(SELECT COUNT(*) FROM jsonb_array_elements_text(COALESCE({column}, '[]'::jsonb)) "
+            f"AS _e(code) WHERE _e.code IN ({in_list}))"
+        )
+
+    def _criteria_count_match_expressions(self, trial_attr_meta, service):
+        """SQL booleans ``(gating, matched)`` for a per-criterion attribute.
+
+        ``gating`` is true when the trial actually constrains this attribute
+        (any of required / sufficient_any / excluded is non-empty); ``matched``
+        is true when the per-criterion matcher verdict equals `matched`.
+
+        Replicates `UserToTrialAttrMatcher._match_criteria_count` (#4399/#4401) at
+        the per-criterion granularity the aggregate `is_attr_blank` + `'[]'`
+        checks lacked (#4416). The patient is fixed, so its derived (known) codes
+        D and blank-source (undeterminable) codes U are constants; only the
+        trial's required / excluded / sufficient_any / min_count vary per row.
+
+        Verdict is `matched` (eligible) iff inclusion is satisfied AND no excluded
+        criterion is present-or-undeterminable. Inclusion only needs the matched
+        (D-intersection) counts; the unknown counts only distinguish unknown from
+        not_matched, and not_matched trials are filtered out before counting.
+        """
+        derived_csv = trial_attr_meta['criteria_derived'](service.patient_info)
+        derived = {c.strip() for c in (derived_csv or '').split(',') if c.strip()}
+        unknown = set(trial_attr_meta['criteria_all_unknown_codes'](service))
+
+        required_attr = trial_attr_meta.get('criteria_required_attr')
+        sufficient_attr = trial_attr_meta.get('criteria_sufficient_any_attr')
+        excluded_attr = trial_attr_meta.get('criteria_excluded_attr')
+        min_count_attr = trial_attr_meta.get('criteria_min_count_attr')
+
+        def length(attr):
+            return f"jsonb_array_length(COALESCE({attr}, '[]'::jsonb))" if attr else '0'
+
+        required_len = length(required_attr)
+        sufficient_len = length(sufficient_attr)
+        excluded_len = length(excluded_attr)
+        required_matched = self._jsonb_intersect_count(required_attr, derived) if required_attr else '0'
+        sufficient_matched = self._jsonb_intersect_count(sufficient_attr, derived) if sufficient_attr else '0'
+        excluded_matched = self._jsonb_intersect_count(excluded_attr, derived) if excluded_attr else '0'
+        excluded_unknown = self._jsonb_intersect_count(excluded_attr, unknown) if excluded_attr else '0'
+
+        if min_count_attr:
+            min_count = f"(CASE WHEN {min_count_attr} IS NULL OR {min_count_attr} < 1 THEN 1 ELSE {min_count_attr} END)"
+        else:
+            min_count = '1'
+
+        inclusion = (
+            f"(({required_len} = 0 AND {sufficient_len} = 0)"
+            f" OR ({required_len} > 0 AND {required_matched} >= {min_count})"
+            f" OR ({sufficient_len} > 0 AND {sufficient_matched} >= 1))"
+        )
+        exclusion_clear = f"({excluded_len} = 0 OR ({excluded_matched} = 0 AND {excluded_unknown} = 0))"
+        gating = f"({required_len} > 0 OR {sufficient_len} > 0 OR {excluded_len} > 0)"
+        matched = f"({inclusion} AND {exclusion_clear})"
+        return gating, matched
+
     def potential_attrs_to_check(self, patient_info, counts=None, with_eligible=False):
         attrs2check = {}
         eligible_attrs2check = {}
@@ -147,6 +218,30 @@ class UserToTrialAttrsMapper:
                 if not is_blank:
                     is_filled_by_user = True
                     # continue
+
+                # Per-criterion "named OR" attrs (high-risk MCL): replicate the
+                # three-valued matcher per trial instead of the aggregate
+                # is_attr_blank + '[]' checks (#4416). Patient-side only; the
+                # counts-only profit path (patient_info=None) keeps the aggregate
+                # SQL below.
+                if trial_attr_meta.get("criteria_count_match"):
+                    gating, matched_cond = self._criteria_count_match_expressions(trial_attr_meta, service)
+                    # matched (incl. a non-gating trial) -> NULL (eligible / not
+                    # potential); a gating trial that isn't matched -> 1 (potential).
+                    # This collapses matcher `unknown` and `not_matched` to potential.
+                    # Excluding `not_matched` rows from the list entirely is the job
+                    # of the coarse eligible_for_high_risk_mcl_criteria filter
+                    # (has_any_keys), which today keeps a min_count>=2 trial a patient
+                    # overlaps but can't satisfy, and can drop unknown-only-required
+                    # trials; making that filter per-criterion is follow-up work
+                    # (issue #186; CB #4419). Net vs the old aggregate path: these
+                    # now read potential instead of eligible.
+                    attrs2check[user_attr] = f'(CASE WHEN {matched_cond} THEN NULL ELSE 1 END)'
+                    # Match-score numerator: count only a gate the trial actually has
+                    # and the patient definitively satisfies. A non-gating trial is
+                    # neutral (NULL), matching the old aggregate SQL.
+                    eligible_attrs2check[user_attr] = f'(CASE WHEN {gating} AND {matched_cond} THEN 1 ELSE NULL END)'
+                    continue
 
             then_value = 'NULL ELSE 1'
             count_value = 0


### PR DESCRIPTION
## Port: high-risk MCL criteria matching (CB #4399–#4437)

Part of the MCL high-risk epic **#182**. Catch-up port of CancerBot's high-risk
MCL criteria **matching** layer into EXACT (the patient-side derivation + Trial
fields landed earlier on `2omop`). Base branch: **`2omop`** (not `main`).

### What's included
- **Eligibility filter** — `eligible_for_high_risk_mcl_criteria` (required |
  sufficient_any | no-inclusion-gate, minus excluded) + dispatch wiring.
- **Aggregate match status** — `_match_criteria_count` (required+min_count OR
  sufficient_any, ANDed with excluded; three-valued unknown-vs-none), routed from
  `_match_computed_attr`.
- **Per-criterion breakdown** — `high_risk_mcl_criteria_breakdown`, surfaced on
  the trial detail response (`highRiskMclCriteriaBreakdown`, detail only).
- **Potential-counting (#4416)** — `_criteria_count_match_expressions` so a
  gating trial the patient can't definitively satisfy classifies **Potential**
  instead of being treated as eligible by the aggregate check.
- **bulky_disease_criteria realign** — derived value flipped from list to
  comma-string (TextField), aligned with CB across attributes/normalize/resolve/
  dispatch/config.
- **Config** — `high_risk_mcl_criteria` (criteria_* protocol) + TRIAL_ATTRS list.
- **Tests** — aggregate (min_count/sufficient_any/excluded/unknown-vs-none),
  queryset filter, breakdown, potential-counting, bulky string-form.

### Verification
- Full suite green: **766 passed, 5 skipped**; `makemigrations --check` clean.
- Verbatim port from CB (parity confirmed); **reviewed with Claude (fresh
  context) + codex** at each step.

### Known follow-up (tracked)
- **#186** — the coarse `has_any_keys` filter doesn't honor `min_count` or the
  patient's unknown-code set, so it can keep a `min_count>=2` trial the patient
  can't satisfy and can drop unknown-only-required trials. This is **CB-parity**
  (CB #4419); the fix belongs upstream in CB then ported, per
  `docs/porting-from-cancerbot.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
