### PR TITLE
fix(mcl): MIPI WBC term uses cells/µL not ×10⁹/L (port CB #4421)

### DIFF
--- a/tests/services/patient_info/test_mcl_derivations.py
+++ b/tests/services/patient_info/test_mcl_derivations.py
@@ -17,11 +17,11 @@ def _mcl_patient(**kwargs):
     only the field under test."""
     defaults = dict(
         disease='mantle cell lymphoma',
-        patient_age=70,
+        patient_age=50,
         ecog_performance_status=0,
-        white_blood_cell_count=8e9,
-        white_blood_cell_count_units='CELLS/L',
-        lactate_dehydrogenase_level=250,
+        white_blood_cell_count=5000,
+        white_blood_cell_count_units='CELLS/UL',
+        lactate_dehydrogenase_level=200,
         ki67_proliferation_index=15,
     )
     defaults.update(kwargs)
@@ -32,22 +32,34 @@ class TestMipiRiskBuckets:
     """Hoster 2008 MIPI cutoffs: low < 5.7, intermediate < 6.5, high >= 6.5."""
 
     def test_low_for_healthy_inputs(self):
-        # score ≈ 3.32 — well below 5.7
-        pi = _mcl_patient(patient_age=70, ecog_performance_status=0,
-                          white_blood_cell_count=8e9, lactate_dehydrogenase_level=250)
+        # WBC as cells/µL (Hoster 2008). score ≈ 4.41 — below 5.7
+        pi = _mcl_patient(patient_age=35, ecog_performance_status=0,
+                          white_blood_cell_count=5000, white_blood_cell_count_units='CELLS/UL',
+                          lactate_dehydrogenase_level=150)
         assert PatientInfoAttributes(pi).mipi_risk == 'low'
 
     def test_intermediate_for_moderate_disease(self):
         # score ≈ 5.91 — in [5.7, 6.5)
-        pi = _mcl_patient(patient_age=85, ecog_performance_status=2,
-                          white_blood_cell_count=50e9, lactate_dehydrogenase_level=700)
+        pi = _mcl_patient(patient_age=65, ecog_performance_status=0,
+                          white_blood_cell_count=7000, white_blood_cell_count_units='CELLS/UL',
+                          lactate_dehydrogenase_level=250)
         assert PatientInfoAttributes(pi).mipi_risk == 'intermediate'
 
     def test_high_for_aggressive_disease(self):
-        # score ≈ 7.10 — well above 6.5
-        pi = _mcl_patient(patient_age=90, ecog_performance_status=2,
-                          white_blood_cell_count=200e9, lactate_dehydrogenase_level=1500)
+        # score well above 6.5
+        pi = _mcl_patient(patient_age=75, ecog_performance_status=3,
+                          white_blood_cell_count=100000, white_blood_cell_count_units='CELLS/UL',
+                          lactate_dehydrogenase_level=3000)
         assert PatientInfoAttributes(pi).mipi_risk == 'high'
+
+    def test_wbc_uses_per_microliter_magnitude_4421(self):
+        # Regression guard for CB #4421: WBC must be read as cells/µL. A median
+        # 7000/µL patient is 'intermediate'; the old ×10⁹/L reading (log10(7))
+        # scored ~2.82 lower and wrongly returned 'low'.
+        pi = _mcl_patient(patient_age=65, ecog_performance_status=0,
+                          white_blood_cell_count=7000, white_blood_cell_count_units='CELLS/UL',
+                          lactate_dehydrogenase_level=250)
+        assert PatientInfoAttributes(pi).mipi_risk == 'intermediate'
 
     def test_ecog_zero_does_not_add_penalty(self):
         # ECOG 0 and 1 both contribute 0 (predicate is ecog >= 2)
@@ -101,26 +113,26 @@ class TestMipiCRiskMatrix:
         assert PatientInfoAttributes(pi).mipi_c_risk == 'low_intermediate'
 
     def test_intermediate_mipi_plus_low_ki67_is_low_intermediate(self):
-        pi = _mcl_patient(patient_age=85, ecog_performance_status=2,
-                          white_blood_cell_count=50e9, lactate_dehydrogenase_level=700,
-                          ki67_proliferation_index=20)
+        pi = _mcl_patient(patient_age=65, ecog_performance_status=0,
+                          white_blood_cell_count=7000, white_blood_cell_count_units='CELLS/UL',
+                          lactate_dehydrogenase_level=250, ki67_proliferation_index=20)
         assert PatientInfoAttributes(pi).mipi_c_risk == 'low_intermediate'
 
     def test_intermediate_mipi_plus_high_ki67_is_high_intermediate(self):
-        pi = _mcl_patient(patient_age=85, ecog_performance_status=2,
-                          white_blood_cell_count=50e9, lactate_dehydrogenase_level=700,
-                          ki67_proliferation_index=50)
+        pi = _mcl_patient(patient_age=65, ecog_performance_status=0,
+                          white_blood_cell_count=7000, white_blood_cell_count_units='CELLS/UL',
+                          lactate_dehydrogenase_level=250, ki67_proliferation_index=35)
         assert PatientInfoAttributes(pi).mipi_c_risk == 'high_intermediate'
 
     def test_high_mipi_plus_low_ki67_is_high_intermediate(self):
         pi = _mcl_patient(patient_age=90, ecog_performance_status=2,
-                          white_blood_cell_count=200e9, lactate_dehydrogenase_level=1500,
+                          white_blood_cell_count=100000, white_blood_cell_count_units='CELLS/UL', lactate_dehydrogenase_level=1500,
                           ki67_proliferation_index=20)
         assert PatientInfoAttributes(pi).mipi_c_risk == 'high_intermediate'
 
     def test_high_mipi_plus_high_ki67_is_high(self):
         pi = _mcl_patient(patient_age=90, ecog_performance_status=2,
-                          white_blood_cell_count=200e9, lactate_dehydrogenase_level=1500,
+                          white_blood_cell_count=100000, white_blood_cell_count_units='CELLS/UL', lactate_dehydrogenase_level=1500,
                           ki67_proliferation_index=60)
         assert PatientInfoAttributes(pi).mipi_c_risk == 'high'
 
@@ -281,13 +293,13 @@ class TestHighRiskMclCriteriaDerivation:
     def test_high_mipi_code(self):
         # Aggressive inputs -> mipi high.
         pi = _mcl_patient(patient_age=90, ecog_performance_status=2,
-                          white_blood_cell_count=200e9, lactate_dehydrogenase_level=1500)
+                          white_blood_cell_count=100000, white_blood_cell_count_units='CELLS/UL', lactate_dehydrogenase_level=1500)
         assert 'high_mipi' in _high_risk_codes(pi)
 
     def test_mipi_c_high(self):
         # mipi high + ki67 >= 30 -> mipi_c high.
         pi = _mcl_patient(patient_age=90, ecog_performance_status=2,
-                          white_blood_cell_count=200e9, lactate_dehydrogenase_level=1500,
+                          white_blood_cell_count=100000, white_blood_cell_count_units='CELLS/UL', lactate_dehydrogenase_level=1500,
                           ki67_proliferation_index=40)
         assert 'mipi_c_high' in _high_risk_codes(pi)
 

--- a/trials/services/patient_info/patient_info_attributes.py
+++ b/trials/services/patient_info/patient_info_attributes.py
@@ -640,16 +640,20 @@ class PatientInfoAttributes:
         if float(wbc) <= 0 or float(ldh) <= 0:
             return None
 
-        wbc_in_cells_per_l = float(BaseConvertor.call(
-            wbc, pi.white_blood_cell_count_units or 'CELLS/L', 'CELLS/L'
-        ))
-        # MIPI = 0.03535*age + 0.6978*[ECOG>=2] + 1.367*log10(LDH/ULN) + 0.9393*log10(WBC[10^9/L])
+        # The MIPI formula takes WBC as the absolute count per microliter (e.g.
+        # 7000 -> log10(7000)), per Hoster et al. 2008. The previous code
+        # converted to cells/L and divided by 1e9, i.e. used the x10^9/L value
+        # (7 -> log10(7)), under-scoring this term by log10(1000) = 3 (~2.82
+        # points) and systematically under-classifying MCL risk (CB #4421).
         # ULN proxy 250 mirrors CB; revisit if a per-lab ULN becomes available.
+        wbc_per_ul = float(BaseConvertor.call(
+            wbc, pi.white_blood_cell_count_units or 'CELLS/L', 'CELLS/UL'
+        ))
         score = (
             0.03535 * age
             + 0.6978 * (1 if ecog >= 2 else 0)
             + 1.367 * log10(float(ldh) / 250)
-            + 0.9393 * log10(wbc_in_cells_per_l / 1e9)
+            + 0.9393 * log10(wbc_per_ul)
         )
 
         if score < 5.7:


### PR DESCRIPTION
## Fix MIPI WBC term — cells/µL, not ×10⁹/L (port CB #4421)

CB→EXACT drift port. The MIPI score (Hoster 2008, drives MCL risk) takes WBC as
the absolute count per microliter (`log10(7000)`). EXACT converted to cells/L and
divided by 1e9 (`log10(7)`), under-scoring the WBC term by ~2.82 and
systematically under-classifying MCL risk — feeding `mipi_risk`, `mipi_c_risk`,
and every high-risk MCL criterion derived from them.

- `mipi_risk`: convert WBC to `CELLS/UL` and use `log10(wbc_per_ul)` — verbatim
  from CB (formula, coefficients, thresholds, MIPI-C matrix all match).
- MIPI/MIPI-C bucket tests realigned to cells/µL inputs (mirroring CB's
  `test_patient_info_attributes` low/intermediate/high recipes) + an explicit
  `#4421` regression guard.

### Verification
- Full suite green: **766 passed, 5 skipped**.
- Self-reviewed (Claude fresh-context subagent + `codex review --base 2omop`):
  Claude [MEDIUM] test-hygiene (4 tests inheriting the new µL default for `200e9`
  inputs) — **fixed** (now `100000 CELLS/UL`).

### Known / not changed (CB-parity)
- codex [P2]: the missing-units fallback is `units or 'CELLS/L'` (then →µL). This
  is **verbatim CB** and consistent with the PatientInfo default unit `CELLS/L`
  (callers send /L-scale values with that default). Not diverged per the porting
  rules; any change belongs upstream in CB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
