### PR TITLE
refactor(omop): port TherapyMatchProfile seam (cutover phase 1)

### DIFF
--- a/tests/services/test_therapy_match_profile.py
+++ b/tests/services/test_therapy_match_profile.py
@@ -1,0 +1,56 @@
+"""
+TherapyMatchProfile seam (OMOP cutover, port of CB epic #4447).
+
+The matcher + queryset read trial therapy column names from this single profile.
+These tests pin the active (legacy) names so flipping to the OMOP columns is an
+intentional, reviewed change — not an accident.
+"""
+import pytest
+
+from trials.services.therapy_match_profile import (
+    THERAPY_MATCH_PROFILE,
+    TherapyMatchProfile,
+)
+
+# Pure-logic tests, but the session-scoped DB-seed fixture (tests/conftest.py)
+# only initializes correctly when the session has a django_db test; mark so the
+# file is runnable standalone.
+pytestmark = pytest.mark.django_db
+
+
+def test_active_profile_targets_legacy_columns():
+    assert THERAPY_MATCH_PROFILE.therapies_required == 'therapies_required'
+    assert THERAPY_MATCH_PROFILE.therapies_excluded == 'therapies_excluded'
+    assert THERAPY_MATCH_PROFILE.therapy_components_required == 'therapy_components_required'
+    assert THERAPY_MATCH_PROFILE.therapy_components_excluded == 'therapy_components_excluded'
+    assert THERAPY_MATCH_PROFILE.therapy_types_required == 'therapy_types_required'
+    assert THERAPY_MATCH_PROFILE.therapy_types_excluded == 'therapy_types_excluded'
+    assert THERAPY_MATCH_PROFILE.planned_therapies_required == 'planned_therapies_required'
+    assert THERAPY_MATCH_PROFILE.planned_therapies_excluded == 'planned_therapies_excluded'
+    assert THERAPY_MATCH_PROFILE.supportive_therapies_required == 'supportive_therapies_required'
+    assert THERAPY_MATCH_PROFILE.supportive_therapies_excluded == 'supportive_therapies_excluded'
+
+
+def test_profile_is_frozen():
+    # Swapping the seam must be a deliberate module-level override, not a mutation.
+    import dataclasses
+    import pytest
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        THERAPY_MATCH_PROFILE.therapies_required = 'omop_therapies_required'
+
+
+def test_an_omop_profile_can_be_constructed():
+    # The cutover overrides the profile with omop_* column names in one place.
+    omop = TherapyMatchProfile(
+        therapies_required='omop_therapies_required',
+        therapies_excluded='omop_therapies_excluded',
+        therapy_components_required='omop_therapy_components_required',
+        therapy_components_excluded='omop_therapy_components_excluded',
+        therapy_types_required='omop_therapy_types_required',
+        therapy_types_excluded='omop_therapy_types_excluded',
+        planned_therapies_required='omop_planned_therapies_required',
+        planned_therapies_excluded='omop_planned_therapies_excluded',
+        supportive_therapies_required='omop_supportive_therapies_required',
+        supportive_therapies_excluded='omop_supportive_therapies_excluded',
+    )
+    assert omop.therapies_required == 'omop_therapies_required'

--- a/trials/querysets/trial.py
+++ b/trials/querysets/trial.py
@@ -26,6 +26,7 @@ from trials.services.patient_info.configs import (
     sct_value_is_none,
 )
 from trials.services.receptor_hierarchy import expand_values as expand_receptor_values
+from trials.services.therapy_match_profile import THERAPY_MATCH_PROFILE
 from trials.services.patient_info.genetic_mutations import GeneticMutations
 from trials.services.patient_info.patient_info_flipi_score import PatientInfoFlipyScore
 from trials.services.trial_details.configs import PHASE_CODE_MAPPING
@@ -1036,7 +1037,11 @@ class TrialQuerySet(models.QuerySet):
 
     def eligible_for_therapy_related_things_from_lines(self, therapy_codes: list[str], has_no_prior_therapy=False) -> models.QuerySet:
         if has_no_prior_therapy:
-            return self.filter(therapies_required__exact=[], therapy_components_required__exact=[], therapy_types_required__exact=[])
+            return self.filter(**{
+                f'{THERAPY_MATCH_PROFILE.therapies_required}__exact': [],
+                f'{THERAPY_MATCH_PROFILE.therapy_components_required}__exact': [],
+                f'{THERAPY_MATCH_PROFILE.therapy_types_required}__exact': [],
+            })
 
         if therapy_codes is None or therapy_codes == []:
             return self
@@ -1062,22 +1067,22 @@ class TrialQuerySet(models.QuerySet):
     def eligible_for_therapy_from_lines(self, therapy_codes: list[str]) -> models.QuerySet:
         return self.eligible_for_required_and_excluded_lists(
             values=therapy_codes,
-            required_attr_name='therapies_required',
-            excluded_attr_name='therapies_excluded'
+            required_attr_name=THERAPY_MATCH_PROFILE.therapies_required,
+            excluded_attr_name=THERAPY_MATCH_PROFILE.therapies_excluded
         )
 
     def eligible_for_therapy_components(self, therapy_component_codes: list[str]) -> models.QuerySet:
         return self.eligible_for_required_and_excluded_lists(
             values=therapy_component_codes,
-            required_attr_name='therapy_components_required',
-            excluded_attr_name='therapy_components_excluded'
+            required_attr_name=THERAPY_MATCH_PROFILE.therapy_components_required,
+            excluded_attr_name=THERAPY_MATCH_PROFILE.therapy_components_excluded
         )
 
     def eligible_for_therapy_types(self, therapy_type_codes: list[str]) -> models.QuerySet:
         return self.eligible_for_required_and_excluded_lists(
             values=therapy_type_codes,
-            required_attr_name='therapy_types_required',
-            excluded_attr_name='therapy_types_excluded'
+            required_attr_name=THERAPY_MATCH_PROFILE.therapy_types_required,
+            excluded_attr_name=THERAPY_MATCH_PROFILE.therapy_types_excluded
         )
 
     def eligible_for_pre_existing_condition(self, pre_existing_conditions: list[str]) -> models.QuerySet:
@@ -1144,15 +1149,15 @@ class TrialQuerySet(models.QuerySet):
     def eligible_for_planned_therapies(self, planned_therapies: list[str]) -> models.QuerySet:
         return self.eligible_for_required_and_excluded_lists(
             values=planned_therapies,
-            required_attr_name='planned_therapies_required',
-            excluded_attr_name='planned_therapies_excluded'
+            required_attr_name=THERAPY_MATCH_PROFILE.planned_therapies_required,
+            excluded_attr_name=THERAPY_MATCH_PROFILE.planned_therapies_excluded
         )
 
     def eligible_for_supportive_therapies(self, supportive_therapies: list[str]) -> models.QuerySet:
         return self.eligible_for_required_and_excluded_lists(
             values=supportive_therapies,
-            required_attr_name='supportive_therapies_required',
-            excluded_attr_name='supportive_therapies_excluded'
+            required_attr_name=THERAPY_MATCH_PROFILE.supportive_therapies_required,
+            excluded_attr_name=THERAPY_MATCH_PROFILE.supportive_therapies_excluded
         )
 
     def eligible_for_cytogenic_markers(self, cytogenic_markers: list[str]) -> models.QuerySet:

--- a/trials/services/therapy_match_profile.py
+++ b/trials/services/therapy_match_profile.py
@@ -1,0 +1,41 @@
+"""Trial-side therapy column names used by matching.
+
+The single seam for the OMOP therapy migration. The search queryset
+(`trials/querysets/trial.py`) and the per-trial matcher
+(`trials/services/user_to_trial_attr_matcher.py`) read the trial's therapy
+columns by the names defined here instead of hardcoding string literals. To flip
+matching onto the OMOP `concept_id` columns, override this profile in one place
+(behind a feature flag at cutover) — no dispatch or matching logic changes.
+
+Ported from CancerBot (CB epic #4447) to keep CB→EXACT ports cheap; CB owns the
+upstream seam. EXACT is the downstream that flips to the OMOP profile at cutover.
+
+Scope: this profile owns ONLY the trial-side column *names* read by matching. It
+deliberately does NOT change dispatch order / matching semantics (kept
+behavior-identical), the patient-side therapy code derivation, or config-driven
+surfaces (`USER_TO_TRIAL_ATTRS_MAPPING` `attr` lists, the eligibility-count
+mapper SQL) — those are a separate seam.
+"""
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class TherapyMatchProfile:
+    therapies_required: str = 'therapies_required'
+    therapies_excluded: str = 'therapies_excluded'
+    therapy_components_required: str = 'therapy_components_required'
+    therapy_components_excluded: str = 'therapy_components_excluded'
+    therapy_types_required: str = 'therapy_types_required'
+    therapy_types_excluded: str = 'therapy_types_excluded'
+    # planned/supportive: the QUERYSET filter reads these via the profile, but the
+    # per-trial matcher reads them through USER_TO_TRIAL_ATTRS_MAPPING (the
+    # config-driven seam). At OMOP cutover BOTH seams must flip together.
+    planned_therapies_required: str = 'planned_therapies_required'
+    planned_therapies_excluded: str = 'planned_therapies_excluded'
+    supportive_therapies_required: str = 'supportive_therapies_required'
+    supportive_therapies_excluded: str = 'supportive_therapies_excluded'
+
+
+# The active profile. Swap this (or its field values) to retarget matching at the
+# OMOP columns. Keep it the ONLY place that names trial therapy columns for match.
+THERAPY_MATCH_PROFILE = TherapyMatchProfile()

--- a/trials/services/user_to_trial_attr_matcher.py
+++ b/trials/services/user_to_trial_attr_matcher.py
@@ -3,6 +3,8 @@ import datetime as dt
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal, Optional
 
+from trials.services.therapy_match_profile import THERAPY_MATCH_PROFILE
+
 if TYPE_CHECKING:
     from trials.models import Trial
     from trials.services.patient_info.patient_info import PatientInfo
@@ -263,12 +265,12 @@ class UserToTrialAttrMatcher:
             }
 
         out = {
-            "therapiesRequired": match_required(self.trial.therapies_required, therapies, mismatch_status),
-            "therapiesExcluded": match_excluded(self.trial.therapies_excluded, therapies),
-            "therapyTypesRequired": match_required(self.trial.therapy_types_required, therapy_types_to_therapy, mismatch_status),
-            "therapyTypesExcluded": match_excluded(self.trial.therapy_types_excluded, therapy_types_to_therapy),
-            "therapyComponentsRequired": match_required(self.trial.therapy_components_required, therapy_components_to_therapy, mismatch_status),
-            "therapyComponentsExcluded": match_excluded(self.trial.therapy_components_excluded, therapy_components_to_therapy),
+            "therapiesRequired": match_required(getattr(self.trial, THERAPY_MATCH_PROFILE.therapies_required), therapies, mismatch_status),
+            "therapiesExcluded": match_excluded(getattr(self.trial, THERAPY_MATCH_PROFILE.therapies_excluded), therapies),
+            "therapyTypesRequired": match_required(getattr(self.trial, THERAPY_MATCH_PROFILE.therapy_types_required), therapy_types_to_therapy, mismatch_status),
+            "therapyTypesExcluded": match_excluded(getattr(self.trial, THERAPY_MATCH_PROFILE.therapy_types_excluded), therapy_types_to_therapy),
+            "therapyComponentsRequired": match_required(getattr(self.trial, THERAPY_MATCH_PROFILE.therapy_components_required), therapy_components_to_therapy, mismatch_status),
+            "therapyComponentsExcluded": match_excluded(getattr(self.trial, THERAPY_MATCH_PROFILE.therapy_components_excluded), therapy_components_to_therapy),
         }
 
         return out
@@ -338,7 +340,7 @@ class UserToTrialAttrMatcher:
 
     def _match_therapy_related_things(self, values, has_no_prior_therapy):
         results = []
-        res = self._match_therapy_things(values, self.trial.therapies_required, self.trial.therapies_excluded, has_no_prior_therapy)
+        res = self._match_therapy_things(values, getattr(self.trial, THERAPY_MATCH_PROFILE.therapies_required), getattr(self.trial, THERAPY_MATCH_PROFILE.therapies_excluded), has_no_prior_therapy)
         if res == 'not_matched':
             return res
         results.append(res)
@@ -361,12 +363,12 @@ class UserToTrialAttrMatcher:
             component_codes = None
             therapy_types = None
 
-        res = self._match_therapy_things(component_codes, self.trial.therapy_components_required, self.trial.therapy_components_excluded, has_no_prior_therapy)
+        res = self._match_therapy_things(component_codes, getattr(self.trial, THERAPY_MATCH_PROFILE.therapy_components_required), getattr(self.trial, THERAPY_MATCH_PROFILE.therapy_components_excluded), has_no_prior_therapy)
         if res == 'not_matched':
             return res
         results.append(res)
 
-        res = self._match_therapy_things(therapy_types, self.trial.therapy_types_required, self.trial.therapy_types_excluded, has_no_prior_therapy)
+        res = self._match_therapy_things(therapy_types, getattr(self.trial, THERAPY_MATCH_PROFILE.therapy_types_required), getattr(self.trial, THERAPY_MATCH_PROFILE.therapy_types_excluded), has_no_prior_therapy)
         if res == 'not_matched':
             return res
         results.append(res)


### PR DESCRIPTION
## OMOP cutover — phase 1: port the TherapyMatchProfile seam

Ports CB's `TherapyMatchProfile` (epic #4447) downstream so EXACT's queryset +
matcher read trial therapy column **names** from one profile instead of hardcoded
literals. Active profile = legacy columns → **behavior-identical** (783 passed,
makemigrations clean). At cutover, EXACT overrides the profile with the `omop_*`
column names in one place — no dispatch/matching logic changes.

- `trials/services/therapy_match_profile.py` (ported from CB).
- queryset (`has_no_prior_therapy` empty filter, `eligible_for_therapy_*` +
  `eligible_for_planned/supportive_therapies`) and matcher
  (`therapy_related_things_match_status`, `_match_therapy_things`) route through
  the profile.
- planned/supportive: queryset side via profile; matcher side stays on the
  config seam (USER_TO_TRIAL_ATTRS_MAPPING) — both flip together at cutover (noted
  in the profile).
- tests pin legacy names + frozen + omop-constructable.

First of the EXACT-side OMOP cutover phases (plan: `.gstack/omop_exact_cutover_plan.md`).
Self-reviewed (Claude fresh-context subagent + codex) — completeness fix
(planned/supportive wiring) applied from review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
