### PR TITLE
feat(omop): phase 3a — therapy concept loader + trial backfill + shadow-compare

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ scripts/*.zip
 scripts/cache/
 *.csv
 !scripts/evaluator/ground_truth.csv
+!docs/omop/mapping/therapy_omop_mapping.csv
 
 # Local-only management commands and tests
 trials/management/commands/evaluate_ethalon_live.py

--- a/docs/omop/mapping/therapy_omop_mapping.csv
+++ b/docs/omop/mapping/therapy_omop_mapping.csv
@@ -1,0 +1,329 @@
+level,cb_code,cb_title,omop_concept_id,omop_name,omop_vocab,match
+component,st._john's_wort,St. John's Wort,,,,needs_review
+component,liposomal_doxorubicin,Liposomal Doxorubicin,1338512,doxorubicin,RxNorm,llm
+component,thalidomide,Thalidomide,19137042,thalidomide,RxNorm,auto
+component,elranatamab,Elranatamab (Elrexfio),746391,elranatamab,RxNorm,auto
+component,talquetamab,Talquetamab (Talvey),746340,talquetamab,RxNorm,auto
+component,belantamab_mafodotin,Belantamab Mafodotin (Blenrep),37002419,belantamab mafodotin,RxNorm,auto
+component,idecabtagene_vicleucel,Idecabtagene vicleucel (Abecma),36026868,idecabtagene vicleucel,RxNorm,auto
+component,ciltacabtagene_autoleucel,Ciltacabtagene autoleucel (Carvykti),779144,ciltacabtagene autoleucel,RxNorm,auto
+component,panobinostat,Panobinostat (Farydak),46221435,panobinostat,RxNorm,auto
+component,asct,Autologous Stem Cell Transplant (ASCT),,,,no_omop
+component,agsct,Allogeneic Stem Cell Transplant,,,,no_omop
+component,esas,Erythropoiesis-Stimulating Agents (ESAs),,,,needs_review
+component,selinexor,Selinexor,1361191,selinexor,RxNorm,auto
+component,dexamethasone,Dexamethasone,1518254,dexamethasone,RxNorm,auto
+component,idecabtagene_vicleucel_(abecma),Idecabtagene vicleucel (Abecma),36026868,idecabtagene vicleucel,RxNorm,auto
+component,breyanzi_(lisocabtagene_maraleucel),Breyanzi (lisocabtagene maraleucel),739856,lisocabtagene maraleucel,RxNorm,llm
+component,tecartus_(brexucabtagene_autoleucel),Tecartus (brexucabtagene autoleucel),37002369,brexucabtagene autoleucel,RxNorm,llm
+component,ciltacabtagene_autoleucel_(carvykti),Ciltacabtagene autoleucel (Carvykti),779144,ciltacabtagene autoleucel,RxNorm,auto
+component,catumaxomab,Catumaxomab,35802946,Catumaxomab,HemOnc,auto
+component,blinatumomab,Blinatumomab,45892531,blinatumomab,RxNorm,auto
+component,mosunetuzumab,Mosunetuzumab,1301307,mosunetuzumab,RxNorm,auto
+component,tebentafusp,Tebentafusp,1758886,tebentafusp,RxNorm,auto
+component,amivantamab,Amivantamab,1536935,amivantamab,RxNorm,auto
+component,cadonilimab,Cadonilimab,37561559,Cadonilimab,HemOnc,auto
+component,glofitamab,Glofitamab,1201501,glofitamab,RxNorm,auto
+component,doxorubicin,Doxorubicin,1338512,doxorubicin,RxNorm,auto
+component,vincristine,Vincristine,1308290,vincristine,RxNorm,auto
+component,prednisone,Prednisone,1551099,prednisone,RxNorm,auto
+component,umbralisib,Umbralisib,739804,umbralisib,RxNorm,auto
+component,daratumumab,Daratumumab,35605744,daratumumab,RxNorm,auto
+component,carfilzomib,Carfilzomib,42873638,carfilzomib,RxNorm,auto
+component,pomalidomide,Pomalidomide,43014237,pomalidomide,RxNorm,auto
+component,isatuximab,Isatuximab,37498969,isatuximab,RxNorm,auto
+component,elotuzumab,Elotuzumab,35604032,elotuzumab,RxNorm,auto
+component,axicabtagene_ciloleucel_(yescarta),Axicabtagene Ciloleucel (Yescarta),792844,axicabtagene ciloleucel,RxNorm,auto
+component,teclistamab,Teclistamab,741578,teclistamab,RxNorm,auto
+component,cyclophosphamide,Cyclophosphamide,1310317,cyclophosphamide,RxNorm,auto
+component,tisagenlecleucel_(kymriah),Tisagenlecleucel (Kymriah),792737,tisagenlecleucel,RxNorm,auto
+component,genomic_testing,Genomic Testing,,,,no_omop
+component,sacituzumab_govitecan,Sacituzumab Govitecan,35803306,Sacituzumab govitecan,HemOnc,auto
+component,eribulin,Eribulin,40230712,eribulin,RxNorm,auto
+component,vinorelbine,Vinorelbine,1343346,vinorelbine,RxNorm,auto
+component,gemcitabine,Gemcitabine,1314924,gemcitabine,RxNorm,auto
+component,paclitaxel,Paclitaxel,1378382,paclitaxel,RxNorm,auto
+component,docetaxel,Docetaxel,1315942,docetaxel,RxNorm,auto
+component,tucatinib,Tucatinib,1145571,tucatinib,RxNorm,auto
+component,capecitabine,Capecitabine,1337620,capecitabine,RxNorm,auto
+component,lapatinib,Lapatinib,1359548,lapatinib,RxNorm,auto
+component,neratinib,Neratinib,793846,neratinib,RxNorm,auto
+component,margetuximab,Margetuximab,739518,margetuximab,RxNorm,auto
+component,trastuzumab_emtansine,Trastuzumab Emtansine,35802866,Trastuzumab emtansine,HemOnc,auto
+component,atezolizumab,Atezolizumab,42629079,atezolizumab,RxNorm,auto
+component,nab_paclitaxel,Nab-Paclitaxel,1378382,paclitaxel,RxNorm,curated
+component,pembrolizumab,Pembrolizumab,45775965,pembrolizumab,RxNorm,auto
+component,olaparib,Olaparib,45892579,olaparib,RxNorm,auto
+component,talazoparib,Talazoparib,35201068,talazoparib,RxNorm,auto
+component,carboplatin,Carboplatin,1344905,carboplatin,RxNorm,auto
+component,cisplatin,Cisplatin,1397599,cisplatin,RxNorm,auto
+component,alpelisib,Alpelisib,1396423,alpelisib,RxNorm,auto
+component,capivasertib,Capivasertib,747200,capivasertib,RxNorm,auto
+component,larotrectinib,Larotrectinib,1355705,larotrectinib,RxNorm,auto
+component,entrectinib,Entrectinib,37496447,entrectinib,RxNorm,auto
+component,posaconazole,Posaconazole,1704139,posaconazole,RxNorm,auto
+component,fluoxetine,Fluoxetine,755695,fluoxetine,RxNorm,auto
+component,paroxetine,Paroxetine,722031,paroxetine,RxNorm,auto
+component,fluvoxamine,Fluvoxamine,751412,fluvoxamine,RxNorm,auto
+component,sertraline,Sertraline,739138,sertraline,RxNorm,auto
+component,bupropion,Bupropion,750982,bupropion,RxNorm,auto
+component,carbamazepine,Carbamazepine,740275,carbamazepine,RxNorm,auto
+component,phenytoin,Phenytoin,740910,phenytoin,RxNorm,auto
+component,phenobarbital,Phenobarbital,734275,phenobarbital,RxNorm,auto
+component,topiramate,Topiramate,742267,topiramate,RxNorm,auto
+component,grapefruit_juice,Grapefruit juice,43533099,grapefruit juice,RxNorm,auto
+component,pamidronate,Pamidronate,1511646,pamidronate,RxNorm,auto
+component,zoledronic_acid,Zoledronic Acid,1524674,zoledronic acid,RxNorm,auto
+component,denosumab,Denosumab,40222444,denosumab,RxNorm,auto
+component,growth_factor,Growth Factor,,,,needs_review
+component,palbociclib,Palbociclib,45892075,palbociclib,RxNorm,auto
+component,ribociclib,Ribociclib,1592911,ribociclib,RxNorm,auto
+component,abemaciclib,Abemaciclib,792649,abemaciclib,RxNorm,auto
+component,estrogen,Estrogen,21603814,Estrogens,ATC,llm
+component,tamoxifen,Tamoxifen,1436678,tamoxifen,RxNorm,auto
+component,anastrozole,Anastrozole,1348265,anastrozole,RxNorm,auto
+component,letrozole,Letrozole,1315946,letrozole,RxNorm,auto
+component,ibritumomab_tiuxetan,Ibritumomab tiuxetan,19068830,ibritumomab tiuxetan,RxNorm,auto
+component,plasmapheresis,Plasmapheresis,,,,no_omop
+component,bortezomib,Bortezomib,1336825,bortezomib,RxNorm,auto
+component,ixazomib,Ixazomib,35606214,ixazomib,RxNorm,auto
+component,tazemetostat,Tazemetostat,37498602,tazemetostat,RxNorm,auto
+component,venetoclax,Venetoclax,35604205,venetoclax,RxNorm,auto
+component,obinutuzumab,Obinutuzumab,44507676,obinutuzumab,RxNorm,auto
+component,bendamustine,Bendamustine,19015523,bendamustine,RxNorm,auto
+component,polatuzumab_vedotin,Polatuzumab Vedotin,1396729,polatuzumab vedotin,RxNorm,auto
+component,idelalisib,Idelalisib,45776944,idelalisib,RxNorm,auto
+component,copanlisib,Copanlisib,792499,copanlisib,RxNorm,auto
+component,duvelisib,Duvelisib,35200763,duvelisib,RxNorm,auto
+component,ide_cel,Ide-cel,36026868,idecabtagene vicleucel,RxNorm,curated
+component,cilta_cel,Cilta-cel,779144,ciltacabtagene autoleucel,RxNorm,curated
+component,belantamab_mafodotin_(blenrep),Belantamab Mafodotin (Blenrep),37002419,belantamab mafodotin,RxNorm,auto
+component,melphalan,Melphalan,1301267,melphalan,RxNorm,auto
+component,lumpectomy,Lumpectomy,,,,no_omop
+component,mastectomy,Mastectomy,,,,no_omop
+component,aromatase_inhibitor,Aromatase Inhibitor,35807245,Aromatase inhibitor,HemOnc,llm
+component,pertuzumab,Pertuzumab,42801287,pertuzumab,RxNorm,auto
+component,everolimus,Everolimus,19011440,everolimus,RxNorm,auto
+component,capisertib,Capisertib,747200,capivasertib,RxNorm,llm
+component,platinum_based_chemotherapy,Platinum-Based Chemotherapy,35807315,Platinum agent,HemOnc,llm
+component,parp_inhibitors,PARP Inhibitors,35807419,PARP inhibitor,HemOnc,llm
+component,other_chemotherapy,Other Chemotherapy,,,,needs_review
+component,surgery,surgery,,,,no_omop
+component,fulvestrant,Fulvestrant,1304044,fulvestrant,RxNorm,auto
+component,elacestrant,Elacestrant,1301646,elacestrant,RxNorm,auto
+component,megestrol_acetate,Megestrol acetate,1300978,megestrol,RxNorm,curated
+component,trastuzumab_deruxtecan,Trastuzumab Deruxtecan,42542260,Trastuzumab deruxtecan,HemOnc,auto
+component,trastuzumab,Trastuzumab,1387104,trastuzumab,RxNorm,auto
+component,chemotherapy,Chemotherapy,,,,needs_review
+component,immune_checkpoint_inhibitor,Immune Checkpoint Inhibitor,,,,needs_review
+component,radiotherapy,Radiotherapy,,,,no_omop
+component,clarithromycin,Clarithromycin,1750500,clarithromycin,RxNorm,auto
+component,erythromycin,Erythromycin,1746940,erythromycin,RxNorm,auto
+component,ciprofloxacin,Ciprofloxacin,1797513,ciprofloxacin,RxNorm,auto
+component,rifampin,Rifampin,1763204,rifampin,RxNorm,auto
+component,rifabutin,Rifabutin,1777417,rifabutin,RxNorm,auto
+component,itraconazole,Itraconazole,1703653,itraconazole,RxNorm,auto
+component,ketoconazole,Ketoconazole,985708,ketoconazole,RxNorm,auto
+component,fluconazole,Fluconazole,1754994,fluconazole,RxNorm,auto
+component,voriconazole,Voriconazole,1714277,voriconazole,RxNorm,auto
+component,st._john_s_wort,St. John's Wort,,,,needs_review
+component,exemestane,Exemestane,1398399,exemestane,RxNorm,auto
+component,rituximab,Rituximab,1314273,rituximab,RxNorm,auto
+component,lenalidomide,Lenalidomide,19026972,lenalidomide,RxNorm,auto
+category,anti_cd20_monoclonal_antibodies,Anti-CD20 Monoclonal Antibodies,35807389,Anti-CD20 antibody,HemOnc,curated
+category,pi3k_inhibitors,PI3K Inhibitors,35807303,PI3K inhibitor,HemOnc,curated
+category,chemotherapy_(alkylating_agent),Chemotherapy (Alkylating Agent),35807238,Alkylating agent,HemOnc,curated
+category,chemotherapy_(anthracycline),Chemotherapy (Anthracycline),35807214,Anthracycline,HemOnc,curated
+category,immunomodulatory_drug_(imid),Immunomodulatory Drug (IMiD),35807403,Immunomodulatory drugs (IMiDs),HemOnc,curated
+category,proteasome_inhibitor,Proteasome Inhibitor,35807295,Proteasome inhibitor,HemOnc,curated
+category,monoclonal_antibody_(anti_cd38),Monoclonal Antibody (Anti-CD38),35807345,Anti-CD38 antibody,HemOnc,curated
+category,monoclonal_antibody_(anti_slamf7),Monoclonal Antibody (Anti-SLAMF7),35807363,Anti-SLAMF7 antibody,HemOnc,curated
+category,bispecific_antibody,Bispecific Antibody,35807364,Bispecific antibody medication,HemOnc,curated
+category,antibody_drug_conjugate_(adc),Antibody-Drug Conjugate (ADC),35807221,Antibody-drug conjugate,HemOnc,curated
+category,corticosteroid,Corticosteroid,,,,needs_review
+category,car_t_cell_therapy,CAR-T Cell Therapy,35807448,Chimeric antigen receptor T-cell,HemOnc,curated
+category,hdac_inhibitor,HDAC Inhibitor,947794,Histone deacetylase (HDAC) inhibitors,ATC,curated
+category,targeted_therapy_(bcl_2_inhibitor),Targeted Therapy (BCL-2 Inhibitor),35807456,Bcl-2 inhibitor,HemOnc,curated
+category,targeted_therapy_(xpo1_inhibitor),Targeted Therapy (XPO1 Inhibitor),35807438,XPO1 inhibitor,HemOnc,curated
+category,stem_cell_transplant,Stem Cell Transplant,,,,no_omop
+category,radiotherapy,Radiotherapy,,,,no_omop
+category,supportive_therapy_(bisphosphonate),Supportive Therapy (Bisphosphonate),35807233,Bisphosphonate,HemOnc,curated
+category,supportive_therapy_(rankl_inhibitor),Supportive Therapy (RANKL Inhibitor),35807351,RANK ligand inhibitor,HemOnc,curated
+category,supportive_therapy,Supportive Therapy,,,,needs_review
+category,treatment_for_high_risk_smoldering_multiple_myeloma,Treatment for High-Risk Smoldering Multiple Myeloma,,,,needs_review
+category,diagnostic_tool,Diagnostic Tool,,,,no_omop
+category,mtor_inhibitor,mTOR Inhibitor,35807369,MTOR inhibitor,HemOnc,curated
+category,surgery,Surgery,,,,no_omop
+category,hormonal_therapy,Hormonal Therapy,,,,needs_review
+category,tyrosine_kinase_inhibitor,Tyrosine Kinase Inhibitor,912198,Tyrosine kinase inhibitor,HemOnc,curated
+category,monoclonal_antibody,Monoclonal Antibody,21603754,Monoclonal antibodies,ATC,auto
+category,antibody_drug_conjugate,Antibody-Drug Conjugate,35807221,Antibody-drug conjugate,HemOnc,curated
+category,chemotherapy,Chemotherapy,,,,needs_review
+category,targeted_therapy,Targeted Therapy,912163,Targeted therapeutic,HemOnc,curated
+category,immunotherapy,Immunotherapy,35807189,Immunotherapeutic,HemOnc,curated
+regimen,vrd,VRd,35806260,RVD,HemOnc,curated
+regimen,dara_vrd,Dara-VRd,911993,Dara-RVd,HemOnc,curated
+regimen,dara_rd,Dara-Rd,35806311,Dara-Rd,HemOnc,auto
+regimen,vrd_lite,VRd Lite,,,,needs_review
+regimen,krd,KRd,35806284,KRd,HemOnc,auto
+regimen,isa_vrd,Isa-VRd,37557069,Isa-RVd,HemOnc,curated
+regimen,isa_krd,Isa-KRd,,,,needs_review
+regimen,kpd,KPd,35806324,KPD,HemOnc,auto
+regimen,epd,EPd,,,,needs_review
+regimen,svd,SVd,905768,SVd,HemOnc,auto
+regimen,cy_bor_d,CyBorD,,,,needs_review
+regimen,car_t,CAR-T Cell Therapy,35807448,Chimeric antigen receptor T-cell,HemOnc,llm
+regimen,ba,Bispecific Antibodies,35807364,Bispecific antibody medication,HemOnc,llm
+regimen,ww,Watchful Waiting (Active Surveillance),37561232,Watchful waiting,HemOnc,auto
+regimen,rm,Rituximab Monotherapy,35803432,Rituximab monotherapy,HemOnc,auto
+regimen,r_chop,R-CHOP,35805028,R-CHOP,HemOnc,auto
+regimen,r_cvp,R-CVP,35805630,R-CVP,HemOnc,auto
+regimen,br,R-Bendamustine (BR),,,,needs_review
+regimen,ifrt,Involved-Field Radiotherapy (IFRT),,,,needs_review
+regimen,obr,Obinutuzumab-Based Regimens,44507676,obinutuzumab,RxNorm,llm
+regimen,rm_rt,Rituximab Maintenance or Re-Treatment,1314273,rituximab,RxNorm,llm
+regimen,pi3k,PI3K Inhibitors,35807303,PI3K inhibitor,HemOnc,llm
+regimen,tazemetostat,Tazemetostat (Tazverik),37498602,tazemetostat,RxNorm,auto
+regimen,hdc_asct,High-Dose Chemotherapy with Autologous Stem Cell Transplant (ASCT),,,,needs_review
+regimen,lbr,Lenalidomide-Based Regimens,19026972,lenalidomide,RxNorm,llm
+regimen,ldr,Low-Dose Radiotherapy,,,,needs_review
+regimen,daratumumab,Daratumumab (Darzalex/Darzalex Faspro) Monotherapy,35806063,Daratumumab monotherapy,HemOnc,auto
+regimen,carfilzomib,Carfilzomib (Kyprolis) Monotherapy,35806280,Carfilzomib monotherapy,HemOnc,auto
+regimen,lenalidomide,Lenalidomide (Revlimid) Monotherapy,35803596,Lenalidomide monotherapy,HemOnc,auto
+regimen,pomalidomide,Pomalidomide (Pomalyst) Monotherapy,35806317,Pomalidomide monotherapy,HemOnc,auto
+regimen,bortezomib,Bortezomib (Velcade) Monotherapy,35804520,Bortezomib monotherapy,HemOnc,auto
+regimen,isatuximab,Isatuximab (Sarclisa) Monotherapy,37498969,isatuximab,RxNorm,auto
+regimen,elotuzumab,Elotuzumab (Empliciti) Monotherapy,35604032,elotuzumab,RxNorm,auto
+regimen,cyclophosphamide,Cyclophosphamide Monotherapy,35803690,Cyclophosphamide monotherapy,HemOnc,auto
+regimen,venetoclax,Venetoclax Monotherapy,35804617,Venetoclax monotherapy,HemOnc,auto
+regimen,obinutuzumab,Obinutuzumab (Gazyva) Monotherapy,35804583,Obinutuzumab monotherapy,HemOnc,auto
+regimen,rituximab,Rituximab (Rituxan) Monotherapy,35803432,Rituximab monotherapy,HemOnc,auto
+regimen,lr,Lenalidomide (Revlimid) + Rituximab (R2),,,,needs_review
+regimen,bendamustine,Bendamustine Monotherapy,35804017,Bendamustine monotherapy,HemOnc,auto
+regimen,polatuzumab_vedotin,Polatuzumab Vedotin Monotherapy,1396729,polatuzumab vedotin,RxNorm,auto
+regimen,idelalisib,Idelalisib (Zydelig) Monotherapy,35804613,Idelalisib monotherapy,HemOnc,auto
+regimen,copanlisib,Copanlisib (Aliqopa) Monotherapy,35805647,Copanlisib monotherapy,HemOnc,auto
+regimen,duvelisib,Duvelisib (Copiktra) Monotherapy,35804603,Duvelisib monotherapy,HemOnc,auto
+regimen,axicabtagene_ciloleucel,Axicabtagene Ciloleucel (Yescarta) Monotherapy,35805074,Axicabtagene ciloleucel monotherapy,HemOnc,auto
+regimen,clinical_trials,Clinical Trials,,,,needs_review
+regimen,teclistamab,Teclistamab (Tecvayli) Monotherapy,37557075,Teclistamab monotherapy,HemOnc,auto
+regimen,ide_cel,Ide-cel (Abecma) Monotherapy,36026868,idecabtagene vicleucel,RxNorm,llm
+regimen,cilta_cel,Cilta-cel (Carvykti) Monotherapy,779144,ciltacabtagene autoleucel,RxNorm,llm
+regimen,belantamab_mafodotin,Belantamab Mafodotin (Blenrep) Monotherapy,911956,Belantamab mafodotin monotherapy,HemOnc,auto
+regimen,radiotherapy,Radiotherapy,,,,no_omop
+regimen,lumpectomy,Lumpectomy,,,,no_omop
+regimen,mastectomy,Mastectomy,,,,no_omop
+regimen,aromatase_inhibitors,Aromatase Inhibitors,35807245,Aromatase inhibitor,HemOnc,llm
+regimen,chemotherapy,Chemotherapy,35803401,Chemotherapy,HemOnc,auto
+regimen,trastuzumab,Trastuzumab,1387104,trastuzumab,RxNorm,auto
+regimen,pertuzumab,Pertuzumab,42801287,pertuzumab,RxNorm,auto
+regimen,genomic_testing,Genomic Testing,,,,no_omop
+regimen,fulvestrant,Fulvestrant,1304044,fulvestrant,RxNorm,auto
+regimen,exemestane_everolimus,Exemestane + Everolimus,,,,needs_review
+regimen,capisertib,Capisertib,747200,capivasertib,RxNorm,llm
+regimen,atezolizumab,Atezolizumab,42629079,atezolizumab,RxNorm,auto
+regimen,sacituzumab_govitecan,Sacituzumab Govitecan,35803306,Sacituzumab govitecan,HemOnc,auto
+regimen,platinum_based_chemotherapy,Platinum-Based Chemotherapy,35807315,Platinum agent,HemOnc,llm
+regimen,parp_inhibitors,PARP Inhibitors,35807419,PARP inhibitor,HemOnc,llm
+regimen,other_chemotherapy,Other Chemotherapy,,,,needs_review
+regimen,surgery,surgery,,,,no_omop
+regimen,alpelisib_fulvestrant,Alpelisib + Fulvestrant,,,,needs_review
+regimen,capivasertib_fulvestrant,Capivasertib + Fulvestrant,,,,needs_review
+regimen,elacestrant,Elacestrant,1301646,elacestrant,RxNorm,auto
+regimen,tamoxifen,Tamoxifen,1436678,tamoxifen,RxNorm,auto
+regimen,megestrol_acetate,Megestrol acetate,1300978,megestrol,RxNorm,llm
+regimen,capecitabine,Capecitabine,1337620,capecitabine,RxNorm,auto
+regimen,eribulin,Eribulin,40230712,eribulin,RxNorm,auto
+regimen,vinorelbine,Vinorelbine,1343346,vinorelbine,RxNorm,auto
+regimen,gemcitabine,Gemcitabine,1314924,gemcitabine,RxNorm,auto
+regimen,paclitaxel,Paclitaxel,1378382,paclitaxel,RxNorm,auto
+regimen,docetaxel,Docetaxel,1315942,docetaxel,RxNorm,auto
+regimen,trastuzumab_deruxtecan,Trastuzumab Deruxtecan,42542260,Trastuzumab deruxtecan,HemOnc,auto
+regimen,tucatinib_trastuzumab_capecitabine,Tucatinib + Trastuzumab + Capecitabine,,,,needs_review
+regimen,lapatinib,Lapatinib,1359548,lapatinib,RxNorm,auto
+regimen,neratinib,Neratinib,793846,neratinib,RxNorm,auto
+regimen,margetuximab,Margetuximab,739518,margetuximab,RxNorm,auto
+regimen,trastuzumab_emtansine,Trastuzumab Emtansine,35802866,Trastuzumab emtansine,HemOnc,auto
+regimen,atezolizumab_nab_paclitaxel,Atezolizumab + Nab-Paclitaxel,,,,needs_review
+regimen,pembrolizumab_chemotherapy,Pembrolizumab + Chemotherapy,,,,needs_review
+regimen,olaparib,Olaparib,45892579,olaparib,RxNorm,auto
+regimen,talazoparib,Talazoparib,35201068,talazoparib,RxNorm,auto
+regimen,carboplatin,Carboplatin,1344905,carboplatin,RxNorm,auto
+regimen,cisplatin,Cisplatin,1397599,cisplatin,RxNorm,auto
+regimen,alpelisib,Alpelisib,1396423,alpelisib,RxNorm,auto
+regimen,capivasertib,Capivasertib,747200,capivasertib,RxNorm,auto
+regimen,larotrectinib,Larotrectinib,1355705,larotrectinib,RxNorm,auto
+regimen,entrectinib,Entrectinib,37496447,entrectinib,RxNorm,auto
+regimen,immune_checkpoint_inhibitors,Immune Checkpoint Inhibitors,,,,needs_review
+regimen,systemic_corticosteroids_lt_5_mg_day,"systemic corticosteroids (e.g., prednisone) =< 5 mg/day",,,,needs_review
+regimen,systemic_corticosteroids_gt_5_mg_day,"systemic corticosteroids (e.g., prednisone) > 5 mg/day",,,,needs_review
+regimen,systemic_corticosteroids_gt_10_mg_day,"systemic corticosteroids (e.g., prednisone) > 10 mg/day",,,,needs_review
+regimen,systemic_corticosteroids_gt_20_mg_day,"systemic corticosteroids (e.g., prednisone) > 20 mg/day",,,,needs_review
+regimen,mineralocorticoids,"mineralocorticoids (e.g., fludrocortisone)",,,,needs_review
+regimen,inhaled_corticosteroids,Inhaled corticosteroids,,,,needs_review
+regimen,topical_corticosteroids,Topical corticosteroids,,,,needs_review
+regimen,intranasal_corticosteroids,Intranasal corticosteroid,,,,needs_review
+regimen,immunosuppressant,Immunosuppressant,21603890,IMMUNOSUPPRESSANTS,ATC,llm
+regimen,hormonal_therapy,Hormonal therapy,,,,needs_review
+regimen,immunoglobulin_replacement_therapy,Immunoglobulin replacement therapy,19119921,Immunoglobulins,RxNorm,llm
+regimen,antiviral,antiviral,,,,needs_review
+regimen,warfarin_anticoagulant,warfarin - anticoagulant,1310149,warfarin,RxNorm,auto
+regimen,heparin_anticoagulant,heparin - anticoagulant,1367571,heparin,RxNorm,auto
+regimen,aspirin_lt_81mg_daily,Aspirin =< 81mg daily,1112807,aspirin,RxNorm,llm
+regimen,aspirin_gt_81mg_daily,Aspirin > 81mg daily,1112807,aspirin,RxNorm,llm
+regimen,chronic_opioid_therapy,Chronic opioid therapy,,,,needs_review
+regimen,nsaids,NSAIDs,,,,needs_review
+regimen,herbal_supplements,"Herbal supplements (e.g., echinacea, ginseng, ginkgo biloba, high-dose turmeric)",,,,needs_review
+regimen,local_palliative_radiotherapy,Local palliative radiotherapy,,,,needs_review
+regimen,clarithromycin,Clarithromycin (Biaxin) - antibiotic,1750500,clarithromycin,RxNorm,auto
+regimen,erythromycin,Erythromycin - antibiotic,1746940,erythromycin,RxNorm,auto
+regimen,ciprofloxacin,Ciprofloxacin (Cipro) - antibiotic,1797513,ciprofloxacin,RxNorm,auto
+regimen,rifampin,"Rifampin (Rifadin, Rimactane) - antibiotic",1763204,rifampin,RxNorm,auto
+regimen,rifabutin,Rifabutin (Mycobutin) - antibiotic,1777417,rifabutin,RxNorm,auto
+regimen,itraconazole,Itraconazole (Sporanox) - antifungal,1703653,itraconazole,RxNorm,auto
+regimen,ketoconazole,Ketoconazole - antifungal,985708,ketoconazole,RxNorm,auto
+regimen,fluconazole,Fluconazole (Diflucan) - antifungal,1754994,fluconazole,RxNorm,auto
+regimen,voriconazole,Voriconazole (Vfend) - antifungal,1714277,voriconazole,RxNorm,auto
+regimen,posaconazole,Posaconazole (Noxafil) - antifungal,1704139,posaconazole,RxNorm,auto
+regimen,asct,Autologous Stem Cell Transplant (ASCT),,,,no_omop
+regimen,selinexor,Selinexor (Xpovio),1361191,selinexor,RxNorm,auto
+regimen,ixazomib,Ixazomib (Ninlaro),35606214,ixazomib,RxNorm,auto
+regimen,cyclophosphamide_or_melphalan,Cyclophosphamide or Melphalan Monotherapy,,,,needs_review
+regimen,tisagenlecleucel,Tisagenlecleucel Monotherapy,35804066,Tisagenlecleucel monotherapy,HemOnc,auto
+regimen,agsct,Allogeneic Stem Cell Transplant,,,,no_omop
+regimen,hiv_antiretroviral_therapy,HIV antiretroviral therapy,,,,needs_review
+regimen,fluoxetine,Fluoxetine (Prozac) - antidepressant,755695,fluoxetine,RxNorm,auto
+regimen,paroxetine,Paroxetine (Paxil) - antidepressant,722031,paroxetine,RxNorm,auto
+regimen,fluvoxamine,Fluvoxamine (Luvox) - antidepressant,751412,fluvoxamine,RxNorm,auto
+regimen,sertraline,Sertraline (Zoloft) - antidepressant,739138,sertraline,RxNorm,auto
+regimen,bupropion,Bupropion (Wellbutrin) - antidepressant,750982,bupropion,RxNorm,auto
+regimen,carbamazepine,Carbamazepine (Tegretol) - anticonvulsant,740275,carbamazepine,RxNorm,auto
+regimen,phenytoin,Phenytoin (Dilantin) - anticonvulsant,740910,phenytoin,RxNorm,auto
+regimen,phenobarbital,Phenobarbital - anticonvulsant,734275,phenobarbital,RxNorm,auto
+regimen,topiramate,Topiramate (Topamax) - anticonvulsant,742267,topiramate,RxNorm,auto
+regimen,st_john_s_wort,St. John's Wort,,,,needs_review
+regimen,grapefruit_juice,Grapefruit juice,43533099,grapefruit juice,RxNorm,auto
+regimen,pamidronate,Pamidronate,1511646,pamidronate,RxNorm,auto
+regimen,zoledronic_acid,Zoledronic Acid,1524674,zoledronic acid,RxNorm,auto
+regimen,denosumab,Denosumab (Xgeva),40222444,denosumab,RxNorm,auto
+regimen,g_csf,Granulocyte-Colony Stimulating factor (G-CSFs),35807374,Granulocyte colony-stimulating factor,HemOnc,llm
+regimen,gm_csf,Granulocyte–Macrophage Colony-Stimulating Factor (GM-CSF),35807436,Granulocyte macrophage colony-stimulating factor,HemOnc,llm
+regimen,esa,Erythropoiesis-Stimulating Agent (ESA),,,,needs_review
+regimen,her2_targeted_therapies,HER2-targeted therapies,35807402,Anti-HER2 medication,HemOnc,llm
+regimen,lhrh_gnrh_agonists,"LHRH/GnRH agonists (e.g., goserelin, leuprolide, triptorelin, buserelin)",21603823,Gonadotropin releasing hormone analogues,ATC,llm
+regimen,palbociclib,Palbociclib (Ibrance),45892075,palbociclib,RxNorm,auto
+regimen,ribociclib,Ribociclib (Kisqali),1592911,ribociclib,RxNorm,auto
+regimen,abemaciclib,Abemaciclib (Verzenio),792649,abemaciclib,RxNorm,auto
+regimen,hrt,HRT (Estrogen-containing medication),21603814,Estrogens,ATC,llm
+regimen,contraceptives,contraceptives (Estrogen-containing medication),,,,needs_review
+regimen,tamoxifen_maintenance,Tamoxifen Maintenance,1436678,tamoxifen,RxNorm,auto
+regimen,anastrozole_maintenance,Anastrozole Maintenance,1348265,anastrozole,RxNorm,auto
+regimen,letrozole_maintenance,Letrozole Maintenance,1315946,letrozole,RxNorm,auto
+regimen,exemestane_maintenance,Exemestane Maintenance,1398399,exemestane,RxNorm,auto
+regimen,rituximab_maintenance_therapy,Rituximab maintenance therapy,1314273,rituximab,RxNorm,llm
+regimen,lenalidomide_maintenance,Lenalidomide maintenance,19026972,lenalidomide,RxNorm,auto
+regimen,ibritumomab_tiuxetan_radioimmunotherapy,Ibritumomab tiuxetan radioimmunotherapy,19068830,ibritumomab tiuxetan,RxNorm,llm
+regimen,ivig,IVIG (intravenous immunoglobulin),,,,needs_review
+regimen,plasmapheresis,Plasmapheresis,,,,no_omop
+regimen,bortezomib_maintenance,Bortezomib (maintenance),1336825,bortezomib,RxNorm,auto
+regimen,ixazomib_maintenance,Ixazomib (maintenance),35606214,ixazomib,RxNorm,auto

--- a/tests/test_omop_backfill.py
+++ b/tests/test_omop_backfill.py
@@ -1,0 +1,144 @@
+"""OMOP cutover phase 3a: vocab loader + trial backfill + shadow-compare.
+
+Ported machinery (CB epic #4447): map legacy therapy codes -> OMOP concept_id
+strings via the vocab models' omop_concept_id, populate the trial omop_* columns,
+and report drift / cutover-divergence. Nothing reads the omop columns for matching
+yet (that is gated behind the feature flag in a later phase).
+"""
+import csv
+from io import StringIO
+
+import pytest
+from django.core.management import call_command
+
+from trials.models import Therapy, TherapyComponent, TherapyComponentCategory
+from trials.services.omop.therapy_concept_mapper import (
+    build_omop_columns,
+    map_codes_to_concept_ids,
+)
+from trials.services.omop.therapy_sync import sync_trial_omop_columns
+from trials.services.omop.shadow_compare import compare_corpus, compare_trial
+from tests.factories import TrialFactory
+
+pytestmark = pytest.mark.django_db
+
+
+def test_map_codes_to_concept_ids_strings_dedup_sorted_and_unmapped():
+    # Fake zz_* codes so they never collide with the session-seeded reference data.
+    Therapy.objects.create(code='zz_td', title='zz Td', omop_concept_id=222)
+    Therapy.objects.create(code='zz_vrd', title='zz VRd', omop_concept_id=111)
+    Therapy.objects.create(code='zz_no_map', title='zz Unmapped', omop_concept_id=None)
+    concept_ids, unmapped = map_codes_to_concept_ids(
+        Therapy, ['zz_vrd', 'zz_td', 'zz_vrd', 'zz_no_map', 'zz_unknown_code']
+    )
+    # stringified, de-duplicated, sorted
+    assert concept_ids == ['111', '222']
+    # null omop_concept_id and unknown code both reported as unmapped, sorted
+    assert unmapped == ['zz_no_map', 'zz_unknown_code']
+
+
+def test_map_codes_to_concept_ids_empty():
+    assert map_codes_to_concept_ids(Therapy, []) == ([], [])
+
+
+def test_build_omop_columns_all_six_levels():
+    Therapy.objects.create(code='reg_r', title='reg r', omop_concept_id=1)
+    Therapy.objects.create(code='reg_x', title='reg x', omop_concept_id=2)
+    TherapyComponent.objects.create(code='comp_r', title='comp r', omop_concept_id=3)
+    TherapyComponentCategory.objects.create(code='cat_r', title='cat r', omop_concept_id=4)
+    trial = TrialFactory(
+        therapies_required=['reg_r'],
+        therapies_excluded=['reg_x'],
+        therapy_components_required=['comp_r'],
+        therapy_types_required=['cat_r'],
+    )
+    values, unmapped = build_omop_columns(trial)
+    assert values['omop_therapies_required'] == ['1']
+    assert values['omop_therapies_excluded'] == ['2']
+    assert values['omop_therapy_components_required'] == ['3']
+    assert values['omop_therapy_types_required'] == ['4']
+    # untouched legacy columns map to empty
+    assert values['omop_therapy_components_excluded'] == []
+    assert unmapped == {}
+
+
+def test_sync_trial_omop_columns_persists_and_is_idempotent():
+    Therapy.objects.create(code='reg_r', title='reg r', omop_concept_id=1)
+    trial = TrialFactory(therapies_required=['reg_r'])
+    values, unmapped, changed = sync_trial_omop_columns(trial.id)
+    assert changed is True
+    trial.refresh_from_db()
+    assert trial.omop_therapies_required == ['1']
+    # second run: nothing to do
+    _, _, changed2 = sync_trial_omop_columns(trial.id)
+    assert changed2 is False
+
+
+def test_sync_trial_omop_columns_missing_trial():
+    assert sync_trial_omop_columns(999_999) == (None, None, False)
+
+
+def test_shadow_compare_reports_unmapped_divergence():
+    Therapy.objects.create(code='mapped', title='mapped', omop_concept_id=1)
+    Therapy.objects.create(code='nomap', title='nomap', omop_concept_id=None)
+    trial = TrialFactory(therapies_required=['mapped', 'nomap'])
+    sync_trial_omop_columns(trial.id)
+    trial.refresh_from_db()
+    drift, unmapped = compare_trial(trial)
+    assert drift == {}  # stored matches the mapping (we just synced)
+    assert unmapped == {'therapies_required': ['nomap']}
+
+
+def test_shadow_compare_detects_drift_when_not_synced():
+    Therapy.objects.create(code='mapped', title='mapped', omop_concept_id=1)
+    trial = TrialFactory(therapies_required=['mapped'])  # omop columns left empty
+    report = compare_corpus(trial.__class__.objects.filter(pk=trial.pk))
+    assert report['drifted_trials'] == 1
+    assert 'omop_therapies_required' in report['drift_by_col']
+
+
+def test_load_therapy_omop_concept_ids_command(tmp_path):
+    # Fake zz_* codes so the test owns the rows (no collision with seeded vocab).
+    Therapy.objects.create(code='zz_thalidomide', title='zz Thalidomide', omop_concept_id=None)
+    TherapyComponent.objects.create(code='zz_lipodox', title='zz Liposomal Doxorubicin')
+    csv_path = tmp_path / 'm.csv'
+    with open(csv_path, 'w', newline='') as f:
+        w = csv.writer(f)
+        w.writerow(['level', 'cb_code', 'cb_title', 'omop_concept_id', 'omop_name', 'omop_vocab', 'match'])
+        w.writerow(['regimen', 'zz_thalidomide', 'zz Thalidomide', '19137042', 'thalidomide', 'RxNorm', 'auto'])
+        w.writerow(['component', 'zz_lipodox', 'zz Liposomal Doxorubicin', '1338512', 'doxorubicin', 'RxNorm', 'llm'])
+        w.writerow(['regimen', 'zz_skip_me', 'Skip', '', '', '', 'needs_review'])
+    out = StringIO()
+    call_command('load_therapy_omop_concept_ids', csv=str(csv_path), stdout=out)
+    assert Therapy.objects.get(code='zz_thalidomide').omop_concept_id == 19137042
+    assert TherapyComponent.objects.get(code='zz_lipodox').omop_concept_id == 1338512
+
+
+def test_load_therapy_omop_concept_ids_exclude_llm(tmp_path):
+    TherapyComponent.objects.create(code='zz_lipodox2', title='zz Liposomal Doxorubicin 2')
+    csv_path = tmp_path / 'm.csv'
+    with open(csv_path, 'w', newline='') as f:
+        w = csv.writer(f)
+        w.writerow(['level', 'cb_code', 'cb_title', 'omop_concept_id', 'omop_name', 'omop_vocab', 'match'])
+        w.writerow(['component', 'zz_lipodox2', 'zz Liposomal Doxorubicin 2', '1338512', 'doxorubicin', 'RxNorm', 'llm'])
+    call_command('load_therapy_omop_concept_ids', csv=str(csv_path), include_llm=False, stdout=StringIO())
+    # llm row skipped when --exclude-llm
+    assert TherapyComponent.objects.get(code='zz_lipodox2').omop_concept_id is None
+
+
+def test_backfill_command_populates_trial_columns():
+    Therapy.objects.create(code='reg_r', title='reg r', omop_concept_id=42)
+    trial = TrialFactory(therapies_required=['reg_r'])
+    call_command('backfill_omop_therapy_columns', stdout=StringIO())
+    trial.refresh_from_db()
+    assert trial.omop_therapies_required == ['42']
+
+
+def test_vendored_mapping_csv_is_well_formed():
+    """The CSV vendored from CB must keep the columns the loader reads."""
+    from trials.management.commands.load_therapy_omop_concept_ids import DEFAULT_CSV
+    with open(DEFAULT_CSV) as f:
+        reader = csv.DictReader(f)
+        assert set(reader.fieldnames) >= {'level', 'cb_code', 'omop_concept_id', 'match'}
+        levels = {row['level'] for row in reader}
+    assert levels <= {'regimen', 'component', 'category'}

--- a/trials/management/commands/backfill_omop_therapy_columns.py
+++ b/trials/management/commands/backfill_omop_therapy_columns.py
@@ -1,0 +1,82 @@
+"""Backfill the trial OMOP therapy columns from the vocab concept_ids (#4455).
+
+Idempotent batch fill of the trial ``omop_*`` therapy columns (#4453) from the
+vocab ``omop_concept_id`` mapping (#4451), using the shared conversion service.
+Until the CTOMOP release is pinned and vocab concept_ids are populated this runs
+cleanly but writes empty arrays.
+
+Ported from CancerBot (CB epic #4447). In split-DB production CB owns the trials
+table and ships the populated columns; EXACT runs this in single-DB / local mode.
+
+    python manage.py backfill_omop_therapy_columns [--dry-run] [--limit N]
+"""
+from collections import Counter
+
+from django.core.management.base import BaseCommand
+
+from trials.models import Trial
+from trials.services.omop.therapy_concept_mapper import build_omop_columns, OMOP_COLUMNS
+from trials.services.omop.therapy_sync import sync_trial_omop_columns
+
+
+class Command(BaseCommand):
+    help = "Backfill trial omop_* therapy columns from vocab omop_concept_id mappings."
+
+    @staticmethod
+    def _accumulate(values, unmapped, mapped_concepts, unmapped_codes):
+        for col, concept_ids in values.items():
+            mapped_concepts[col] += len(concept_ids)
+        for col, codes in unmapped.items():
+            unmapped_codes[col] += len(codes)
+
+    def add_arguments(self, parser):
+        parser.add_argument('--dry-run', action='store_true',
+                            help="Compute and report changes without writing.")
+        parser.add_argument('--limit', type=int, default=None,
+                            help="Only process the first N trials (by id).")
+
+    def handle(self, *args, **options):
+        dry_run = options['dry_run']
+        limit = options['limit']
+
+        qs = Trial.objects.all().order_by('id')
+        if limit is not None:
+            qs = qs[:limit]
+
+        scanned = 0
+        updated = 0
+        mapped_concepts = Counter()   # omop_column -> count of concept_ids written
+        unmapped_codes = Counter()    # legacy_column -> count of dropped codes
+
+        if dry_run:
+            for trial in qs.iterator():
+                scanned += 1
+                values, unmapped = build_omop_columns(trial)
+                self._accumulate(values, unmapped, mapped_concepts, unmapped_codes)
+                if any(getattr(trial, col) != values[col] for col in OMOP_COLUMNS):
+                    updated += 1
+        else:
+            # Write through the shared locked helper (select_for_update per trial)
+            # so the backfill serializes with concurrent saves — neither can clobber
+            # the other with a stale result. Fetch ids first so the per-trial
+            # transactions don't fight a streaming cursor.
+            for trial_id in list(qs.values_list('id', flat=True)):
+                scanned += 1
+                values, unmapped, changed = sync_trial_omop_columns(trial_id)
+                if values is None:  # trial deleted mid-run
+                    continue
+                self._accumulate(values, unmapped, mapped_concepts, unmapped_codes)
+                if changed:
+                    updated += 1
+
+        prefix = '[dry-run] ' if dry_run else ''
+        self.stdout.write(f"{prefix}scanned {scanned} trial(s); {updated} would change" if dry_run
+                          else f"scanned {scanned} trial(s); updated {updated}")
+
+        total_mapped = sum(mapped_concepts.values())
+        total_unmapped = sum(unmapped_codes.values())
+        self.stdout.write(f"  concept_ids written: {total_mapped}")
+        if total_unmapped:
+            self.stdout.write(f"  unmapped codes dropped: {total_unmapped}")
+            for col in sorted(unmapped_codes):
+                self.stdout.write(f"    {col}: {unmapped_codes[col]}")

--- a/trials/management/commands/load_therapy_omop_concept_ids.py
+++ b/trials/management/commands/load_therapy_omop_concept_ids.py
@@ -1,0 +1,83 @@
+"""Load OMOP concept_ids onto the therapy vocab models from the curated mapping.
+
+Reads docs/omop/mapping/therapy_omop_mapping.csv (CB code -> OMOP concept_id,
+produced + curated against CTOMOP, see that dir) and sets omop_concept_id on
+Therapy / TherapyComponent / TherapyComponentCategory (#4451).
+
+Only rows with a concept_id and an accepted match type are loaded; `no_omop`
+(procedures / non-drug) and `needs_review` rows are skipped.
+
+Ported from CancerBot (CB epic #4447). The mapping CSV is vendored from CB so
+EXACT can populate vocab concept_ids in single-DB / local runs.
+
+    python manage.py load_therapy_omop_concept_ids [--dry-run] [--include-llm]
+"""
+import csv
+import os
+from collections import Counter
+
+from django.conf import settings
+from django.core.management.base import BaseCommand
+
+from trials.models import Therapy, TherapyComponent, TherapyComponentCategory
+
+LEVEL_MODEL = {
+    'regimen': Therapy,
+    'component': TherapyComponent,
+    'category': TherapyComponentCategory,
+}
+DEFAULT_CSV = os.path.join(settings.BASE_DIR, 'docs', 'omop', 'mapping', 'therapy_omop_mapping.csv')
+# match types that carry a CTOMOP-verified concept_id
+ACCEPTED = {'auto', 'curated', 'llm'}
+
+
+class Command(BaseCommand):
+    help = "Set omop_concept_id on therapy vocab models from the curated mapping CSV."
+
+    def add_arguments(self, parser):
+        parser.add_argument('--dry-run', action='store_true', help="Report without writing.")
+        parser.add_argument('--csv', default=DEFAULT_CSV, help="Mapping CSV path.")
+        parser.add_argument('--include-llm', dest='include_llm', action='store_true', default=True,
+                            help="Load DB-verified LLM-proposed matches (default on).")
+        parser.add_argument('--exclude-llm', dest='include_llm', action='store_false',
+                            help="Load only exact/curated matches (skip llm).")
+
+    def handle(self, *args, **opts):
+        dry_run = opts['dry_run']
+        accepted = set(ACCEPTED) if opts['include_llm'] else (ACCEPTED - {'llm'})
+
+        updated = Counter()      # level -> rows set
+        unchanged = Counter()    # already had the value
+        missing_code = Counter()  # code not found in vocab table
+        skipped = 0
+
+        with open(opts['csv']) as f:
+            for row in csv.DictReader(f):
+                if row['match'] not in accepted or not row['omop_concept_id']:
+                    skipped += 1
+                    continue
+                model = LEVEL_MODEL[row['level']]
+                obj = model.objects.filter(code=row['cb_code']).first()
+                if obj is None:
+                    missing_code[row['level']] += 1
+                    continue
+                cid = int(row['omop_concept_id'])
+                if obj.omop_concept_id == cid:
+                    unchanged[row['level']] += 1
+                    continue
+                updated[row['level']] += 1
+                if not dry_run:
+                    # Plain bulk write via QuerySet.update(): EXACT has no signal on
+                    # these vocab models, and this load only touches omop_concept_id,
+                    # so a full model save would be pointless overhead. (CB uses
+                    # .update() here to skip a value-options-cache post_save signal
+                    # it has; EXACT keeps the same write for consistency.)
+                    model.objects.filter(pk=obj.pk).update(omop_concept_id=cid)
+
+        prefix = '[dry-run] ' if dry_run else ''
+        for level in ('regimen', 'component', 'category'):
+            self.stdout.write(
+                f"{prefix}{level:10s} set={updated[level]:3d} unchanged={unchanged[level]:3d} "
+                f"code_not_found={missing_code[level]:3d}"
+            )
+        self.stdout.write(f"{prefix}total set={sum(updated.values())} skipped(no-concept/review)={skipped}")

--- a/trials/management/commands/omop_shadow_compare.py
+++ b/trials/management/commands/omop_shadow_compare.py
@@ -1,0 +1,49 @@
+"""Shadow-compare legacy vs OMOP therapy mapping (#4446).
+
+Read-only cutover-readiness report. Run after the vocab loader + backfill in an
+env to see (a) backfill/sync drift and (b) how much legacy matching can't yet be
+reproduced on the omop_* columns (unmapped codes).
+
+Ported from CancerBot (CB epic #4447); therapy-only (EXACT has not yet ported the
+demographics OMOP machinery — see trials/services/omop/shadow_compare.py).
+
+    python manage.py omop_shadow_compare [--limit N] [--disease NAME]
+"""
+from django.core.management.base import BaseCommand
+
+from trials.models import Trial
+from trials.services.omop.shadow_compare import compare_corpus
+
+
+class Command(BaseCommand):
+    help = "Report drift + cutover-divergence between legacy and omop therapy columns."
+
+    def add_arguments(self, parser):
+        parser.add_argument('--limit', type=int, default=None, help="Only the first N trials (by id).")
+        parser.add_argument('--disease', default=None, help="Restrict to a disease (icontains).")
+
+    def handle(self, *args, **options):
+        qs = Trial.objects.all().order_by('id')
+        if options['disease']:
+            qs = qs.filter(disease__icontains=options['disease'])
+        if options['limit'] is not None:
+            qs = qs[:options['limit']]
+
+        r = compare_corpus(qs)
+
+        self.stdout.write(f"scanned {r['scanned']} trial(s)")
+        self.stdout.write("")
+        self.stdout.write(f"BACKFILL DRIFT: {r['drifted_trials']} trial(s) have stored omop_* != computed-from-legacy")
+        for col, n in sorted(r['drift_by_col'].items()):
+            self.stdout.write(f"    {col}: {n}")
+        if not r['drift_by_col']:
+            self.stdout.write("    (none — stored omop_* matches the mapping)")
+        self.stdout.write("")
+        self.stdout.write(f"CUTOVER DIVERGENCE: {r['divergent_trials']} trial(s) have legacy codes with no OMOP concept")
+        self.stdout.write("  (these would match differently once reads flip to the omop columns)")
+        for col, n in sorted(r['unmapped_by_col'].items()):
+            self.stdout.write(f"    {col}: {n} trial(s) affected")
+        if r['top_unmapped_codes']:
+            self.stdout.write("  top unmapped codes (by trial frequency):")
+            for code, freq in r['top_unmapped_codes']:
+                self.stdout.write(f"    {code}: {freq}")

--- a/trials/services/omop/shadow_compare.py
+++ b/trials/services/omop/shadow_compare.py
@@ -1,0 +1,83 @@
+"""Shadow comparison: legacy therapy vs its OMOP mapping (#4446).
+
+A read-only safety gate for the OMOP cutover. For each trial it:
+  1. re-derives the expected omop_* values from the LEGACY columns (the same
+     conversion the backfill uses) and compares them to the STORED omop_* columns
+     -> "drift" (backfill/write-sync is stale or never ran), and
+  2. counts LEGACY codes that don't map to any OMOP concept -> "divergence risk":
+     a trial whose legacy required column has an unmapped code would match
+     differently once reads flip to the (empty-for-that-code) omop column.
+
+Output feeds both cutover-readiness and the SME mapping review (top unmapped codes
+by trial frequency). No writes; no schema change.
+
+Ported from CancerBot (CB epic #4447). DIVERGENCE FROM CB: the CB version also
+shadow-compares the OMOP demographics columns (ethnicity/gender). EXACT has not
+yet ported the demographics OMOP machinery (a separate, later phase), so this
+copy is therapy-only. Re-add the demographics branch when EXACT ports it.
+"""
+from collections import Counter
+
+from trials.services.omop.therapy_concept_mapper import build_omop_columns
+
+
+def _differs(stored, computed):
+    # computed is the source of truth shape: list columns -> order-insensitive and
+    # None (a NULLed list column) treated as the empty list; scalars -> direct.
+    if isinstance(computed, list):
+        return sorted(stored or []) != sorted(computed)
+    return stored != computed
+
+
+def compare_trial(trial):
+    """Return (drift, unmapped) for one trial.
+
+    drift: {omop_column: (stored, computed)} where the stored column differs from
+        what the mapping computes from the current legacy values.
+    unmapped: {legacy_column: [codes]} legacy codes with no OMOP concept.
+    """
+    t_values, t_unmapped = build_omop_columns(trial)
+
+    drift = {}
+    for col, computed in t_values.items():
+        stored = getattr(trial, col)
+        if _differs(stored, computed):
+            drift[col] = (stored, computed)
+
+    return drift, dict(t_unmapped)
+
+
+def compare_corpus(queryset):
+    """Aggregate compare_trial over a queryset. Returns a report dict."""
+    scanned = 0
+    drift_by_col = Counter()        # omop column -> # trials with stale stored value
+    drifted_trials = 0
+    unmapped_by_col = Counter()     # legacy column -> # trials with >=1 unmapped code
+    unmapped_codes = Counter()      # legacy code -> trial frequency
+    divergent_trials = 0            # trials with any unmapped code (cutover would differ)
+
+    for trial in queryset.iterator():
+        scanned += 1
+        drift, unmapped = compare_trial(trial)
+        if drift:
+            drifted_trials += 1
+            for col in drift:
+                drift_by_col[col] += 1
+        if unmapped:
+            divergent_trials += 1
+            trial_codes = set()
+            for col, codes in unmapped.items():
+                unmapped_by_col[col] += 1
+                trial_codes.update(codes)
+            # count each unmapped code once per trial (it's a trial-frequency metric)
+            for code in trial_codes:
+                unmapped_codes[code] += 1
+
+    return {
+        'scanned': scanned,
+        'drifted_trials': drifted_trials,
+        'drift_by_col': dict(drift_by_col),
+        'divergent_trials': divergent_trials,
+        'unmapped_by_col': dict(unmapped_by_col),
+        'top_unmapped_codes': unmapped_codes.most_common(25),
+    }

--- a/trials/services/omop/therapy_concept_mapper.py
+++ b/trials/services/omop/therapy_concept_mapper.py
@@ -1,0 +1,82 @@
+"""Map a trial's legacy therapy codes to OMOP concept_id strings (epic #4447, Phase 3).
+
+Source of truth: the vocab models' ``omop_concept_id`` (#4451). Destination: the
+trial ``omop_*`` columns (#4453). This module is the pure conversion logic shared
+by the batch backfill command (and the shadow-comparison harness #4446).
+
+Ported from CancerBot (CB epic #4447); CB owns the upstream conversion. EXACT is
+the downstream that runs the backfill locally / against CB's read-only trials DB.
+
+Scope: the three therapy levels whose vocab has ``omop_concept_id`` today —
+regimen (``Therapy``), drug component (``TherapyComponent``), drug class
+(``TherapyComponentCategory``). ``planned_*`` / ``supportive_*`` are excluded
+until their vocabs gain ``omop_concept_id``.
+
+Conventions (per the plan review): concept_ids are stored as STRINGS; output
+arrays are de-duplicated and stably sorted; unknown or unmapped (null
+``omop_concept_id``) codes are dropped and reported; the mapping is idempotent.
+"""
+from trials.models import Therapy, TherapyComponent, TherapyComponentCategory
+
+# (vocab model, legacy required col, legacy excluded col, omop required col, omop excluded col)
+THERAPY_LEVELS = [
+    (Therapy,
+     'therapies_required', 'therapies_excluded',
+     'omop_therapies_required', 'omop_therapies_excluded'),
+    (TherapyComponent,
+     'therapy_components_required', 'therapy_components_excluded',
+     'omop_therapy_components_required', 'omop_therapy_components_excluded'),
+    (TherapyComponentCategory,
+     'therapy_types_required', 'therapy_types_excluded',
+     'omop_therapy_types_required', 'omop_therapy_types_excluded'),
+]
+
+
+def map_codes_to_concept_ids(model, codes):
+    """Map vocab codes to OMOP concept_id strings.
+
+    Returns ``(concept_ids, unmapped)`` where ``concept_ids`` is a sorted,
+    de-duplicated list of stringified concept_ids and ``unmapped`` is the sorted,
+    de-duplicated list of input codes that are unknown to the vocab or whose
+    ``omop_concept_id`` is null.
+    """
+    if not codes:
+        return [], []
+
+    code_to_cid = dict(
+        model.objects.filter(code__in=codes).values_list('code', 'omop_concept_id')
+    )
+    concept_ids = set()
+    unmapped = set()
+    for code in codes:
+        cid = code_to_cid.get(code)
+        if cid is None:  # unknown code OR null omop_concept_id
+            unmapped.add(code)
+        else:
+            concept_ids.add(str(cid))
+    return sorted(concept_ids), sorted(unmapped)
+
+
+def build_omop_columns(trial):
+    """Compute the trial's OMOP therapy column values from its legacy codes.
+
+    Returns ``(values, unmapped)``:
+    - ``values``: ``{omop_column_name: [concept_id_str, ...]}`` for all 6 mapped
+      columns (3 levels x required/excluded).
+    - ``unmapped``: ``{legacy_column_name: [code, ...]}`` for codes that could not
+      be mapped (only non-empty entries included).
+    """
+    values = {}
+    unmapped = {}
+    for model, legacy_req, legacy_exc, omop_req, omop_exc in THERAPY_LEVELS:
+        for legacy_col, omop_col in ((legacy_req, omop_req), (legacy_exc, omop_exc)):
+            concept_ids, missing = map_codes_to_concept_ids(model, getattr(trial, legacy_col))
+            values[omop_col] = concept_ids
+            if missing:
+                unmapped[legacy_col] = missing
+    return values, unmapped
+
+
+# Columns this mapper owns, in a stable order — used by the backfill command's
+# change detection.
+OMOP_COLUMNS = [omop_col for _, _, _, r, e in THERAPY_LEVELS for omop_col in (r, e)]

--- a/trials/services/omop/therapy_sync.py
+++ b/trials/services/omop/therapy_sync.py
@@ -1,0 +1,35 @@
+"""Locked write of a trial's OMOP therapy columns (#4457).
+
+Single place that performs the read-compute-write under a per-trial row lock, so
+every writer (here, the batch backfill command) serializes on the same trial.id
+and a stale snapshot can never overwrite a newer one. Keeps the conversion logic
+itself pure (see therapy_concept_mapper.build_omop_columns).
+
+Ported from CancerBot (CB epic #4447). EXACT has no live post_save sync task —
+in production CB owns the trials table and ships the populated omop_* columns;
+EXACT only runs this from the backfill command (local single-DB mode).
+"""
+from django.db import transaction
+
+from trials.models import Trial
+from trials.services.omop.therapy_concept_mapper import build_omop_columns
+
+
+def sync_trial_omop_columns(trial_id):
+    """Recompute and persist a trial's omop_* therapy columns under a row lock.
+
+    Returns ``(values, unmapped, changed)`` — the computed column values, the
+    dropped (unknown/unmapped) legacy codes, and whether anything was written.
+    Returns ``(None, None, False)`` if the trial no longer exists. Writes via
+    QuerySet.update() (no signal re-fire) and only when values change.
+    """
+    with transaction.atomic():
+        trial = Trial.objects.select_for_update().filter(id=trial_id).first()
+        if trial is None:
+            return None, None, False
+
+        values, unmapped = build_omop_columns(trial)
+        changed = {col: val for col, val in values.items() if getattr(trial, col) != val}
+        if changed:
+            Trial.objects.filter(id=trial_id).update(**changed)
+        return values, unmapped, bool(changed)


### PR DESCRIPTION
## Phase 3a of the EXACT-side OMOP therapy cutover

Port of CB epic #4447. Adds the machinery that **populates** the phase-2 `omop_*` columns from the vocab `omop_concept_id` mappings. **Nothing reads the omop columns for matching yet** — that flips behind a feature flag in phase 3b. Schema-unchanged.

### What changes (all ported from CB, which owns the upstream conversion)
- `trials/services/omop/therapy_concept_mapper.py` — pure legacy-code → concept_id **string** conversion across the 3 mapped levels (regimen / component / class); dedup + stable sort; unknown/null codes dropped and reported.
- `trials/services/omop/therapy_sync.py` — per-trial `select_for_update` read-compute-write; writes only the changed subset; idempotent.
- `trials/services/omop/shadow_compare.py` — drift + cutover-divergence report. **Divergence from CB:** therapy-only (CB also compares the demographics OMOP columns, which EXACT hasn't ported — a separate later phase).
- Management commands: `load_therapy_omop_concept_ids`, `backfill_omop_therapy_columns`, `omop_shadow_compare`.
- `docs/omop/mapping/therapy_omop_mapping.csv` — vendored from CB (328 rows: auto=198, curated=28, llm=32; needs_review=50 / no_omop=20 skipped by the loader). Force-added past the `*.csv` gitignore with an explicit `!` negation rule.
- `tests/test_omop_backfill.py` — 11 tests.

### Self-review (per rule)
- ✅ Claude fresh-context review (separate subagent): no blockers. Fixed a stale CB-ism comment (post_save signal EXACT doesn't have) + a `update_fields` doc inaccuracy. Optional NITs (int() guard, extra dry-run/counter assertions) deferred — current CSV is clean.
- ✅ `codex review --base 2omop`: no actionable correctness issues.

### Test
Full suite: 798 passed, 5 skipped. `makemigrations --check`: No changes detected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)