### PR TITLE
feat(omop): phase 3b — flag-gated OMOP therapy matching + patient code translation

### DIFF
--- a/exact/settings.py
+++ b/exact/settings.py
@@ -353,6 +353,19 @@ CTOMOP_SERVICE_TOKEN = os.environ.get('CTOMOP_SERVICE_TOKEN', '')
 
 
 # ---------------------------------------------------------------------------
+# OMOP therapy matching (epic #4447 cutover).
+# When True, trial therapy matching reads the omop_* concept_id columns instead
+# of the legacy internal-code columns, and patient therapy codes are translated
+# to OMOP concept_ids before comparison. OFF by default — capability-gated: only
+# flip once the vocab omop_concept_id mappings are loaded and the trial omop_*
+# columns are backfilled (see trials/services/omop/ + the shadow-compare report).
+# Only the three mapped levels (regimen/component/class) flip; planned/supportive
+# stay on the legacy columns until their vocabs gain concept_ids.
+# ---------------------------------------------------------------------------
+EXACT_OMOP_THERAPY = os.environ.get('EXACT_OMOP_THERAPY', '').lower() in ('1', 'true', 'yes', 'on')
+
+
+# ---------------------------------------------------------------------------
 # Firebase Admin SDK — backs FirebaseTokenProvider (verify_id_token).
 # Credential resolution order: an auth emulator (local dev) → the
 # FIREBASE_CREDENTIALS_JSON secret injected by infra (Secret Manager) →

--- a/tests/services/test_therapy_match_profile.py
+++ b/tests/services/test_therapy_match_profile.py
@@ -1,15 +1,23 @@
 """
 TherapyMatchProfile seam (OMOP cutover, port of CB epic #4447).
 
-The matcher + queryset read trial therapy column names from this single profile.
-These tests pin the active (legacy) names so flipping to the OMOP columns is an
-intentional, reviewed change — not an accident.
+The matcher + queryset read trial therapy column names from this single profile,
+which flips between the legacy internal-code columns and the OMOP concept_id
+columns based on the EXACT_OMOP_THERAPY setting. These tests pin both profiles and
+the flag-driven switch so a cutover is an intentional, reviewed change.
 """
+import dataclasses
+
 import pytest
+from django.test import override_settings
 
 from trials.services.therapy_match_profile import (
     THERAPY_MATCH_PROFILE,
+    LEGACY_THERAPY_MATCH_PROFILE,
+    OMOP_THERAPY_MATCH_PROFILE,
     TherapyMatchProfile,
+    get_therapy_match_profile,
+    omop_therapy_enabled,
 )
 
 # Pure-logic tests, but the session-scoped DB-seed fixture (tests/conftest.py)
@@ -18,7 +26,9 @@ from trials.services.therapy_match_profile import (
 pytestmark = pytest.mark.django_db
 
 
-def test_active_profile_targets_legacy_columns():
+def test_active_profile_defaults_to_legacy_columns():
+    # EXACT_OMOP_THERAPY defaults off -> legacy internal-code columns.
+    assert omop_therapy_enabled() is False
     assert THERAPY_MATCH_PROFILE.therapies_required == 'therapies_required'
     assert THERAPY_MATCH_PROFILE.therapies_excluded == 'therapies_excluded'
     assert THERAPY_MATCH_PROFILE.therapy_components_required == 'therapy_components_required'
@@ -26,31 +36,50 @@ def test_active_profile_targets_legacy_columns():
     assert THERAPY_MATCH_PROFILE.therapy_types_required == 'therapy_types_required'
     assert THERAPY_MATCH_PROFILE.therapy_types_excluded == 'therapy_types_excluded'
     assert THERAPY_MATCH_PROFILE.planned_therapies_required == 'planned_therapies_required'
+    assert THERAPY_MATCH_PROFILE.supportive_therapies_required == 'supportive_therapies_required'
+
+
+@override_settings(EXACT_OMOP_THERAPY=True)
+def test_active_profile_flips_mapped_levels_when_flag_on():
+    assert omop_therapy_enabled() is True
+    # the three mapped levels flip to the omop_* columns...
+    assert THERAPY_MATCH_PROFILE.therapies_required == 'omop_therapies_required'
+    assert THERAPY_MATCH_PROFILE.therapies_excluded == 'omop_therapies_excluded'
+    assert THERAPY_MATCH_PROFILE.therapy_components_required == 'omop_therapy_components_required'
+    assert THERAPY_MATCH_PROFILE.therapy_components_excluded == 'omop_therapy_components_excluded'
+    assert THERAPY_MATCH_PROFILE.therapy_types_required == 'omop_therapy_types_required'
+    assert THERAPY_MATCH_PROFILE.therapy_types_excluded == 'omop_therapy_types_excluded'
+    # ...but planned/supportive stay legacy (their vocabs have no concept_ids yet).
+    assert THERAPY_MATCH_PROFILE.planned_therapies_required == 'planned_therapies_required'
     assert THERAPY_MATCH_PROFILE.planned_therapies_excluded == 'planned_therapies_excluded'
     assert THERAPY_MATCH_PROFILE.supportive_therapies_required == 'supportive_therapies_required'
     assert THERAPY_MATCH_PROFILE.supportive_therapies_excluded == 'supportive_therapies_excluded'
 
 
-def test_profile_is_frozen():
-    # Swapping the seam must be a deliberate module-level override, not a mutation.
-    import dataclasses
-    import pytest
+def test_get_therapy_match_profile_switches_on_flag():
+    assert get_therapy_match_profile() is LEGACY_THERAPY_MATCH_PROFILE
+    with override_settings(EXACT_OMOP_THERAPY=True):
+        assert get_therapy_match_profile() is OMOP_THERAPY_MATCH_PROFILE
+
+
+def test_underlying_profiles_are_frozen():
+    # Swapping the seam must be a settings change, not a dataclass mutation.
     with pytest.raises(dataclasses.FrozenInstanceError):
+        LEGACY_THERAPY_MATCH_PROFILE.therapies_required = 'omop_therapies_required'
+
+
+def test_active_profile_view_is_read_only():
+    # The settings-aware view refuses writes — flip via EXACT_OMOP_THERAPY instead.
+    with pytest.raises(AttributeError):
         THERAPY_MATCH_PROFILE.therapies_required = 'omop_therapies_required'
 
 
 def test_an_omop_profile_can_be_constructed():
-    # The cutover overrides the profile with omop_* column names in one place.
     omop = TherapyMatchProfile(
         therapies_required='omop_therapies_required',
         therapies_excluded='omop_therapies_excluded',
-        therapy_components_required='omop_therapy_components_required',
-        therapy_components_excluded='omop_therapy_components_excluded',
-        therapy_types_required='omop_therapy_types_required',
-        therapy_types_excluded='omop_therapy_types_excluded',
-        planned_therapies_required='omop_planned_therapies_required',
-        planned_therapies_excluded='omop_planned_therapies_excluded',
-        supportive_therapies_required='omop_supportive_therapies_required',
-        supportive_therapies_excluded='omop_supportive_therapies_excluded',
     )
     assert omop.therapies_required == 'omop_therapies_required'
+    # the shipped OMOP profile flips exactly the three mapped levels
+    assert OMOP_THERAPY_MATCH_PROFILE.therapies_required == 'omop_therapies_required'
+    assert OMOP_THERAPY_MATCH_PROFILE.planned_therapies_required == 'planned_therapies_required'

--- a/tests/test_omop_matching.py
+++ b/tests/test_omop_matching.py
@@ -11,6 +11,8 @@ from django.test import override_settings
 
 from trials.models import Trial, Therapy, TherapyComponent, TherapyComponentCategory
 from trials.services.omop.patient_therapy_codes import to_match_codes, to_match_value_map
+from trials.services.patient_info.patient_info import PatientInfo
+from trials.services.user_to_trial_attr_matcher import UserToTrialAttrMatcher
 from tests.factories import TrialFactory
 
 pytestmark = pytest.mark.django_db
@@ -92,3 +94,31 @@ def test_queryset_excludes_via_omop_excluded_column():
         excluded_attr_name='omop_therapies_excluded',
     )
     assert excl.id not in set(qs.values_list('id', flat=True))
+
+
+# ── matcher decision parity (the riskiest path: derive-then-translate) ─
+
+def _matcher_trials():
+    Therapy.objects.create(code='zz_vrd', title='zz VRd', omop_concept_id=111)
+    # legacy + omop columns populated consistently, as a correct backfill leaves them
+    match = TrialFactory(therapies_required=['zz_vrd'], omop_therapies_required=['111'])
+    other = TrialFactory(therapies_required=['zz_other'], omop_therapies_required=['999'])
+    return match, other
+
+
+def test_matcher_decision_on_legacy_codes_when_flag_off():
+    match, other = _matcher_trials()
+    pi = PatientInfo(disease='multiple myeloma')
+    assert UserToTrialAttrMatcher(match, pi)._match_therapy_related_things(['zz_vrd'], False) == 'matched'
+    assert UserToTrialAttrMatcher(other, pi)._match_therapy_related_things(['zz_vrd'], False) == 'not_matched'
+
+
+@override_settings(EXACT_OMOP_THERAPY=True)
+def test_matcher_decision_on_omop_concept_ids_when_flag_on():
+    # Same patient internal code, same matched/not_matched outcome as legacy —
+    # the matcher translates ['zz_vrd'] -> ['111'] and compares against the
+    # trial's omop_therapies_required. Proves derive-then-translate parity.
+    match, other = _matcher_trials()
+    pi = PatientInfo(disease='multiple myeloma')
+    assert UserToTrialAttrMatcher(match, pi)._match_therapy_related_things(['zz_vrd'], False) == 'matched'
+    assert UserToTrialAttrMatcher(other, pi)._match_therapy_related_things(['zz_vrd'], False) == 'not_matched'

--- a/tests/test_omop_matching.py
+++ b/tests/test_omop_matching.py
@@ -1,0 +1,94 @@
+"""OMOP cutover phase 3b: matching reads OMOP concept_id columns behind the flag.
+
+With EXACT_OMOP_THERAPY on, the trial therapy columns the matcher/queryset read
+flip to the omop_* concept_id columns AND the patient's internal therapy codes are
+translated to the same concept_ids — so matching produces the same result it would
+on the legacy columns, given a correct backfill. With the flag off everything is a
+pass-through (covered by the rest of the suite staying green).
+"""
+import pytest
+from django.test import override_settings
+
+from trials.models import Trial, Therapy, TherapyComponent, TherapyComponentCategory
+from trials.services.omop.patient_therapy_codes import to_match_codes, to_match_value_map
+from tests.factories import TrialFactory
+
+pytestmark = pytest.mark.django_db
+
+
+# ── patient-code translation helper ──────────────────────────────────
+
+def test_to_match_codes_passthrough_when_flag_off():
+    Therapy.objects.create(code='zz_vrd', title='zz VRd', omop_concept_id=111)
+    assert to_match_codes(Therapy, ['zz_vrd']) == ['zz_vrd']
+
+
+@override_settings(EXACT_OMOP_THERAPY=True)
+def test_to_match_codes_translates_when_flag_on():
+    Therapy.objects.create(code='zz_vrd', title='zz VRd', omop_concept_id=111)
+    Therapy.objects.create(code='zz_td', title='zz Td', omop_concept_id=222)
+    Therapy.objects.create(code='zz_unmapped', title='zz Unmapped', omop_concept_id=None)
+    # mapped -> concept_id strings (sorted, deduped); unmapped dropped
+    assert to_match_codes(Therapy, ['zz_td', 'zz_vrd', 'zz_unmapped']) == ['111', '222']
+
+
+@override_settings(EXACT_OMOP_THERAPY=True)
+def test_to_match_codes_preserves_none_and_empty():
+    # None (unknown) and [] (no codes) must pass through so the matcher's
+    # unknown-vs-no-match logic is preserved.
+    assert to_match_codes(Therapy, None) is None
+    assert to_match_codes(Therapy, []) == []
+
+
+@override_settings(EXACT_OMOP_THERAPY=True)
+def test_to_match_value_map_rekeys_to_concept_ids():
+    TherapyComponent.objects.create(code='zz_bort', title='Bortezomib', omop_concept_id=333)
+    TherapyComponent.objects.create(code='zz_nomap', title='Unmapped', omop_concept_id=None)
+    out = to_match_value_map(TherapyComponent, {'zz_bort': 'Bortezomib', 'zz_nomap': 'Unmapped'})
+    assert out == {'333': 'Bortezomib'}  # unmapped dropped, key is concept_id
+
+
+def test_to_match_value_map_passthrough_when_flag_off():
+    m = {'zz_bort': 'Bortezomib'}
+    assert to_match_value_map(TherapyComponent, m) == m
+
+
+# ── queryset matching parity (legacy vs OMOP columns) ────────────────
+
+def _two_trials():
+    Therapy.objects.create(code='zz_vrd', title='zz VRd', omop_concept_id=111)
+    Therapy.objects.create(code='zz_other', title='zz Other', omop_concept_id=999)
+    # A requires the patient's therapy; B requires a different one. Both legacy and
+    # omop columns populated consistently (as a correct backfill would leave them).
+    a = TrialFactory(therapies_required=['zz_vrd'], omop_therapies_required=['111'])
+    b = TrialFactory(therapies_required=['zz_other'], omop_therapies_required=['999'])
+    return a, b
+
+
+def test_queryset_matches_on_legacy_codes_when_flag_off():
+    a, b = _two_trials()
+    ids = set(Trial.objects.eligible_for_therapy_from_lines(['zz_vrd']).values_list('id', flat=True))
+    assert a.id in ids
+    assert b.id not in ids
+
+
+@override_settings(EXACT_OMOP_THERAPY=True)
+def test_queryset_matches_on_omop_concept_ids_when_flag_on():
+    a, b = _two_trials()
+    # Patient passes the INTERNAL code; the queryset translates it to concept_id
+    # 111 and overlaps against omop_therapies_required. Same selection as legacy.
+    ids = set(Trial.objects.eligible_for_therapy_from_lines(['zz_vrd']).values_list('id', flat=True))
+    assert a.id in ids
+    assert b.id not in ids
+
+
+@override_settings(EXACT_OMOP_THERAPY=True)
+def test_queryset_excludes_via_omop_excluded_column():
+    Therapy.objects.create(code='zz_vrd', title='zz VRd', omop_concept_id=111)
+    excl = TrialFactory(therapies_excluded=['zz_vrd'], omop_therapies_excluded=['111'])
+    qs = Trial.objects.eligible_for_required_and_excluded_lists(
+        values=['111'],
+        required_attr_name='omop_therapies_required',
+        excluded_attr_name='omop_therapies_excluded',
+    )
+    assert excl.id not in set(qs.values_list('id', flat=True))

--- a/trials/querysets/trial.py
+++ b/trials/querysets/trial.py
@@ -27,6 +27,7 @@ from trials.services.patient_info.configs import (
 )
 from trials.services.receptor_hierarchy import expand_values as expand_receptor_values
 from trials.services.therapy_match_profile import THERAPY_MATCH_PROFILE
+from trials.services.omop.patient_therapy_codes import to_match_codes
 from trials.services.patient_info.genetic_mutations import GeneticMutations
 from trials.services.patient_info.patient_info_flipi_score import PatientInfoFlipyScore
 from trials.services.trial_details.configs import PHASE_CODE_MAPPING
@@ -1065,22 +1066,25 @@ class TrialQuerySet(models.QuerySet):
         return scope
 
     def eligible_for_therapy_from_lines(self, therapy_codes: list[str]) -> models.QuerySet:
+        from trials.models import Therapy
         return self.eligible_for_required_and_excluded_lists(
-            values=therapy_codes,
+            values=to_match_codes(Therapy, therapy_codes),
             required_attr_name=THERAPY_MATCH_PROFILE.therapies_required,
             excluded_attr_name=THERAPY_MATCH_PROFILE.therapies_excluded
         )
 
     def eligible_for_therapy_components(self, therapy_component_codes: list[str]) -> models.QuerySet:
+        from trials.models import TherapyComponent
         return self.eligible_for_required_and_excluded_lists(
-            values=therapy_component_codes,
+            values=to_match_codes(TherapyComponent, therapy_component_codes),
             required_attr_name=THERAPY_MATCH_PROFILE.therapy_components_required,
             excluded_attr_name=THERAPY_MATCH_PROFILE.therapy_components_excluded
         )
 
     def eligible_for_therapy_types(self, therapy_type_codes: list[str]) -> models.QuerySet:
+        from trials.models import TherapyComponentCategory
         return self.eligible_for_required_and_excluded_lists(
-            values=therapy_type_codes,
+            values=to_match_codes(TherapyComponentCategory, therapy_type_codes),
             required_attr_name=THERAPY_MATCH_PROFILE.therapy_types_required,
             excluded_attr_name=THERAPY_MATCH_PROFILE.therapy_types_excluded
         )

--- a/trials/services/omop/patient_therapy_codes.py
+++ b/trials/services/omop/patient_therapy_codes.py
@@ -25,6 +25,12 @@ def to_match_codes(model, codes):
     codes dropped). Off: returns ``codes`` unchanged. ``None``/empty pass through
     untouched so the matcher's "unknown" (None) vs "no match" ([]) logic is
     preserved.
+
+    KNOWN DIVERGENCE (#194): if a non-empty input maps to ``[]`` (all codes
+    unmapped), the queryset's required/excluded filter short-circuits on ``[]``
+    and loosens, while the matcher treats it as a non-match. The correct product
+    behavior is a cutover-gate decision (mapping coverage / SME review); the flag
+    ships OFF, and omop_shadow_compare quantifies the unmapped rate before any flip.
     """
     if not omop_therapy_enabled() or not codes:
         return codes
@@ -42,11 +48,16 @@ def to_match_value_map(model, code_to_title):
     """
     if not omop_therapy_enabled() or not code_to_title:
         return code_to_title
-    code_to_cid = dict(
-        model.objects.filter(code__in=list(code_to_title)).values_list('code', 'omop_concept_id')
+    # order_by('code') so that when two codes collapse to the same concept_id the
+    # surviving title is deterministic (display-only; the matching path in
+    # to_match_codes is already deterministic via set+sort).
+    code_to_cid = (
+        model.objects.filter(code__in=list(code_to_title))
+        .order_by('code')
+        .values_list('code', 'omop_concept_id')
     )
     return {
         str(cid): code_to_title[code]
-        for code, cid in code_to_cid.items()
+        for code, cid in code_to_cid
         if cid is not None
     }

--- a/trials/services/omop/patient_therapy_codes.py
+++ b/trials/services/omop/patient_therapy_codes.py
@@ -1,0 +1,52 @@
+"""Translate a patient's internal therapy codes to OMOP concept_ids for matching.
+
+The OMOP cutover flips the TRIAL therapy columns from internal codes to OMOP
+concept_id strings (see therapy_match_profile). For matching to still work the
+PATIENT side must speak the same language: when ``EXACT_OMOP_THERAPY`` is on, the
+patient's vocab codes (regimen / drug component / drug class) are mapped to the
+same concept_id strings via the vocab models' ``omop_concept_id`` before any
+overlap test (queryset ``has_any_keys`` filters + the per-trial matcher).
+
+This is the EXACT-specific counterpart to the trial-side profile — CB has no
+patient side (its PatientInfo is stateless and lives in EXACT). Both the trial
+column names and these patient codes flip on the same flag.
+
+When the flag is off these are pass-throughs (zero behavior change). Unmapped /
+unknown codes are dropped — the same cutover-divergence the shadow-compare report
+surfaces on the trial side.
+"""
+from trials.services.therapy_match_profile import omop_therapy_enabled
+
+
+def to_match_codes(model, codes):
+    """Translate a list of patient vocab codes to the values used for matching.
+
+    Under OMOP: returns sorted, de-duplicated OMOP concept_id strings (unmapped
+    codes dropped). Off: returns ``codes`` unchanged. ``None``/empty pass through
+    untouched so the matcher's "unknown" (None) vs "no match" ([]) logic is
+    preserved.
+    """
+    if not omop_therapy_enabled() or not codes:
+        return codes
+    from trials.services.omop.therapy_concept_mapper import map_codes_to_concept_ids
+    concept_ids, _unmapped = map_codes_to_concept_ids(model, list(codes))
+    return concept_ids
+
+
+def to_match_value_map(model, code_to_title):
+    """Translate a ``{code: title}`` display map to ``{match_value: title}``.
+
+    Under OMOP the keys become concept_id strings (unmapped codes dropped) so the
+    match-details builder compares against the same concept_ids the trial columns
+    hold. Off: returns the map unchanged.
+    """
+    if not omop_therapy_enabled() or not code_to_title:
+        return code_to_title
+    code_to_cid = dict(
+        model.objects.filter(code__in=list(code_to_title)).values_list('code', 'omop_concept_id')
+    )
+    return {
+        str(cid): code_to_title[code]
+        for code, cid in code_to_cid.items()
+        if cid is not None
+    }

--- a/trials/services/therapy_match_profile.py
+++ b/trials/services/therapy_match_profile.py
@@ -3,20 +3,29 @@
 The single seam for the OMOP therapy migration. The search queryset
 (`trials/querysets/trial.py`) and the per-trial matcher
 (`trials/services/user_to_trial_attr_matcher.py`) read the trial's therapy
-columns by the names defined here instead of hardcoding string literals. To flip
-matching onto the OMOP `concept_id` columns, override this profile in one place
-(behind a feature flag at cutover) — no dispatch or matching logic changes.
+columns by the names defined here instead of hardcoding string literals. The
+active profile flips from the legacy internal-code columns to the OMOP
+`concept_id` columns based on the ``EXACT_OMOP_THERAPY`` setting — no dispatch or
+matching logic changes.
 
 Ported from CancerBot (CB epic #4447) to keep CB→EXACT ports cheap; CB owns the
 upstream seam. EXACT is the downstream that flips to the OMOP profile at cutover.
 
-Scope: this profile owns ONLY the trial-side column *names* read by matching. It
-deliberately does NOT change dispatch order / matching semantics (kept
-behavior-identical), the patient-side therapy code derivation, or config-driven
-surfaces (`USER_TO_TRIAL_ATTRS_MAPPING` `attr` lists, the eligibility-count
-mapper SQL) — those are a separate seam.
+Scope: this profile owns ONLY the trial-side column *names* read by matching. The
+PATIENT-side codes are translated to concept_ids separately (see
+``trials/services/omop/patient_therapy_codes.py``); both flip on the same flag.
+This profile deliberately does NOT change dispatch order / matching semantics
+(kept behavior-identical).
+
+Only the three mapped levels (regimen / drug component / drug class) flip to
+OMOP. ``planned_*`` / ``supportive_*`` stay on the legacy columns: their vocabs
+have no ``omop_concept_id`` yet, so the backfill leaves the omop_* planned/
+supportive columns empty — flipping them would silently drop the constraint.
+Flip those two levels here once their vocabs gain concept_ids.
 """
 from dataclasses import dataclass
+
+from django.conf import settings
 
 
 @dataclass(frozen=True)
@@ -29,13 +38,62 @@ class TherapyMatchProfile:
     therapy_types_excluded: str = 'therapy_types_excluded'
     # planned/supportive: the QUERYSET filter reads these via the profile, but the
     # per-trial matcher reads them through USER_TO_TRIAL_ATTRS_MAPPING (the
-    # config-driven seam). At OMOP cutover BOTH seams must flip together.
+    # config-driven seam). These stay legacy under the OMOP profile (see module
+    # docstring); flip BOTH seams together once their vocabs gain concept_ids.
     planned_therapies_required: str = 'planned_therapies_required'
     planned_therapies_excluded: str = 'planned_therapies_excluded'
     supportive_therapies_required: str = 'supportive_therapies_required'
     supportive_therapies_excluded: str = 'supportive_therapies_excluded'
 
 
-# The active profile. Swap this (or its field values) to retarget matching at the
-# OMOP columns. Keep it the ONLY place that names trial therapy columns for match.
-THERAPY_MATCH_PROFILE = TherapyMatchProfile()
+# Legacy (internal-code) columns — the default.
+LEGACY_THERAPY_MATCH_PROFILE = TherapyMatchProfile()
+
+# OMOP cutover profile: the three mapped levels read the omop_* concept_id
+# columns; planned_*/supportive_* intentionally stay legacy (see module docstring).
+OMOP_THERAPY_MATCH_PROFILE = TherapyMatchProfile(
+    therapies_required='omop_therapies_required',
+    therapies_excluded='omop_therapies_excluded',
+    therapy_components_required='omop_therapy_components_required',
+    therapy_components_excluded='omop_therapy_components_excluded',
+    therapy_types_required='omop_therapy_types_required',
+    therapy_types_excluded='omop_therapy_types_excluded',
+)
+
+
+def omop_therapy_enabled() -> bool:
+    """Whether trial therapy matching reads the OMOP concept_id columns.
+
+    Off by default; capability-gated by the ``EXACT_OMOP_THERAPY`` setting. The
+    patient-side code translation keys off the same flag.
+    """
+    return bool(getattr(settings, 'EXACT_OMOP_THERAPY', False))
+
+
+def get_therapy_match_profile() -> TherapyMatchProfile:
+    """Return the active profile for the current ``EXACT_OMOP_THERAPY`` setting."""
+    return OMOP_THERAPY_MATCH_PROFILE if omop_therapy_enabled() else LEGACY_THERAPY_MATCH_PROFILE
+
+
+class _ActiveTherapyMatchProfile:
+    """Settings-aware view of the active profile.
+
+    Resolves the ``EXACT_OMOP_THERAPY`` setting on every attribute access so the
+    queryset and matcher pick up the flag without re-import (and tests can toggle
+    it with ``override_settings``). Attribute writes are refused — swapping the
+    profile is a settings change, never a mutation.
+    """
+    __slots__ = ()
+
+    def __getattr__(self, name):
+        return getattr(get_therapy_match_profile(), name)
+
+    def __setattr__(self, name, value):
+        raise AttributeError(
+            "THERAPY_MATCH_PROFILE is read-only; set EXACT_OMOP_THERAPY to switch profiles."
+        )
+
+
+# The active profile. Reads trial therapy column names for matching; the ONLY
+# place that names them. Swap profiles via the EXACT_OMOP_THERAPY setting.
+THERAPY_MATCH_PROFILE = _ActiveTherapyMatchProfile()

--- a/trials/services/user_to_trial_attr_matcher.py
+++ b/trials/services/user_to_trial_attr_matcher.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal, Optional
 
 from trials.services.therapy_match_profile import THERAPY_MATCH_PROFILE
+from trials.services.omop.patient_therapy_codes import to_match_codes, to_match_value_map
 
 if TYPE_CHECKING:
     from trials.models import Trial
@@ -264,6 +265,15 @@ class UserToTrialAttrMatcher:
                 "values": sorted(list(set(values)))
             }
 
+        # Under the OMOP profile the trial columns hold concept_ids, so the patient
+        # display maps ({code: title}) are re-keyed to {concept_id: title} for the
+        # overlap test. Pass-through when the flag is off. Models imported lazily
+        # above (Therapy) / here to avoid an import cycle at module load.
+        from trials.models import Therapy, TherapyComponent, TherapyComponentCategory
+        therapies = to_match_value_map(Therapy, therapies)
+        therapy_types_to_therapy = to_match_value_map(TherapyComponentCategory, therapy_types_to_therapy)
+        therapy_components_to_therapy = to_match_value_map(TherapyComponent, therapy_components_to_therapy)
+
         out = {
             "therapiesRequired": match_required(getattr(self.trial, THERAPY_MATCH_PROFILE.therapies_required), therapies, mismatch_status),
             "therapiesExcluded": match_excluded(getattr(self.trial, THERAPY_MATCH_PROFILE.therapies_excluded), therapies),
@@ -339,21 +349,24 @@ class UserToTrialAttrMatcher:
         return 'matched'
 
     def _match_therapy_related_things(self, values, has_no_prior_therapy):
+        from trials.models import Therapy, TherapyComponent, TherapyComponentCategory
+
+        # Patient codes (`values` and the derived component/type codes) are
+        # internal vocab codes; the trial columns hold internal codes (legacy) or
+        # OMOP concept_ids (cutover). to_match_codes() translates the patient codes
+        # to whatever the active profile compares against — a pass-through when the
+        # OMOP flag is off. Derivation below stays on the original internal codes.
         results = []
-        res = self._match_therapy_things(values, getattr(self.trial, THERAPY_MATCH_PROFILE.therapies_required), getattr(self.trial, THERAPY_MATCH_PROFILE.therapies_excluded), has_no_prior_therapy)
+        res = self._match_therapy_things(to_match_codes(Therapy, values), getattr(self.trial, THERAPY_MATCH_PROFILE.therapies_required), getattr(self.trial, THERAPY_MATCH_PROFILE.therapies_excluded), has_no_prior_therapy)
         if res == 'not_matched':
             return res
         results.append(res)
 
         therapies = None
         if values:
-            from trials.models import Therapy
             therapies = Therapy.objects.filter(code__in=values).all()
 
         if therapies and therapies.count() > 0:
-            from trials.models import TherapyComponent
-            from trials.models import TherapyComponentCategory
-
             components = TherapyComponent.objects.filter(therapycomponentconnection__therapy__in=therapies).order_by('id').all()
             component_codes = [x.code for x in components]
 
@@ -363,12 +376,12 @@ class UserToTrialAttrMatcher:
             component_codes = None
             therapy_types = None
 
-        res = self._match_therapy_things(component_codes, getattr(self.trial, THERAPY_MATCH_PROFILE.therapy_components_required), getattr(self.trial, THERAPY_MATCH_PROFILE.therapy_components_excluded), has_no_prior_therapy)
+        res = self._match_therapy_things(to_match_codes(TherapyComponent, component_codes), getattr(self.trial, THERAPY_MATCH_PROFILE.therapy_components_required), getattr(self.trial, THERAPY_MATCH_PROFILE.therapy_components_excluded), has_no_prior_therapy)
         if res == 'not_matched':
             return res
         results.append(res)
 
-        res = self._match_therapy_things(therapy_types, getattr(self.trial, THERAPY_MATCH_PROFILE.therapy_types_required), getattr(self.trial, THERAPY_MATCH_PROFILE.therapy_types_excluded), has_no_prior_therapy)
+        res = self._match_therapy_things(to_match_codes(TherapyComponentCategory, therapy_types), getattr(self.trial, THERAPY_MATCH_PROFILE.therapy_types_required), getattr(self.trial, THERAPY_MATCH_PROFILE.therapy_types_excluded), has_no_prior_therapy)
         if res == 'not_matched':
             return res
         results.append(res)


### PR DESCRIPTION
## Phase 3b of the EXACT-side OMOP therapy cutover

Port of CB epic #4447. Makes matching actually run on OMOP concept_ids, behind **`EXACT_OMOP_THERAPY` (OFF by default)**. Pass-through / zero behavior change when off (the full suite stays green with the flag off). Schema-unchanged.

### What changes
- `exact/settings.py`: `EXACT_OMOP_THERAPY` flag (env-driven, default off).
- `therapy_match_profile.py`: `LEGACY` + `OMOP` profiles and a settings-aware active view (`THERAPY_MATCH_PROFILE`) that resolves the flag on each access — so the queryset/matcher pick it up without re-import and tests can `override_settings`. **Only the 3 mapped levels (regimen/component/class) flip;** planned/supportive stay legacy (their vocabs have no `omop_concept_id` yet — flipping would silently drop the constraint).
- **`trials/services/omop/patient_therapy_codes.py` (NEW)** — the EXACT-specific counterpart with no CB equivalent (CB has no patient side). `to_match_codes` translates the patient's internal therapy codes to the same concept_ids before every overlap test; `to_match_value_map` re-keys the match-details display. Pass-through when off; `None`/`[]` preserved; unmapped dropped.
- queryset `eligible_for_therapy_{from_lines,components,types}` + matcher `_match_therapy_related_things` / `therapy_related_things_match_status` route patient codes through the helper. **Derivation stays on internal codes**; only comparison inputs are translated.

### Self-review (per rule)
- ✅ Claude fresh-context review (separate subagent): no blockers. Verified flag-off neutrality (identity-preserving), proxy correctness (no recursion/pickle/deepcopy issues), derive-then-translate ordering, None/[] semantics, no import cycle.
- ✅ `codex review --base 2omop`.
- **Both flagged** the all-unmapped queryset-vs-matcher asymmetry → tracked as **#194** (cutover-gate product decision; inert while flag OFF) + documented in code. Per-trial translation memoization → **#195**. Fixed now: matcher flag-on parity tests + deterministic display re-key.

### Test
Full suite: 811 passed, 5 skipped. `makemigrations --check`: No changes detected. 16 OMOP-matching/profile tests (helper, profile flag switch, queryset + matcher parity legacy-vs-OMOP).

🤖 Generated with [Claude Code](https://claude.com/claude-code)