### PR TITLE
feat(omop): phase 3d — CTOMOP adapter sources patient therapies from concept_ids under flag

### DIFF
--- a/tests/services/patient_info/test_ctomop_adapter_omop.py
+++ b/tests/services/patient_info/test_ctomop_adapter_omop.py
@@ -1,0 +1,81 @@
+"""OMOP cutover: CTOMOP adapter therapy mapping respects EXACT_OMOP_THERAPY.
+
+The adapter is the ingest boundary (Phase 3c: EXACT does no patient-side crosswalk).
+- Flag OFF (legacy): therapy display text -> EXACT internal code via resolve_therapy_code.
+- Flag ON (OMOP): therapy fields come straight from CTOMOP's *_therapy_id concept_ids
+  (the consumer supplies concepts); resolve_therapy_code is NOT used; a line with no
+  concept_id becomes None (unknown).
+"""
+from unittest.mock import patch
+
+import pytest
+from django.test import override_settings
+
+from trials.services.patient_info.ctomop_adapter import normalize_ctomop_row
+
+pytestmark = pytest.mark.django_db
+
+
+def _row(**kw):
+    base = {'disease': 'multiple myeloma'}
+    base.update(kw)
+    return base
+
+
+@override_settings(EXACT_OMOP_THERAPY=False)
+def test_flag_off_resolves_display_text_to_internal_code():
+    with patch(
+        'trials.services.patient_info.ctomop_adapter.resolve_therapy_code',
+        return_value='resolved_code',
+    ) as m:
+        r = normalize_ctomop_row(_row(
+            first_line_therapy='RVd (Lenalidomide/Bortezomib/Dexamethasone)',
+            first_line_therapy_id=35806260,  # ignored when flag off
+        ))
+    assert r['first_line_therapy'] == 'resolved_code'
+    m.assert_called_with('RVd (Lenalidomide/Bortezomib/Dexamethasone)')
+
+
+@override_settings(EXACT_OMOP_THERAPY=True)
+def test_flag_on_uses_concept_ids_not_resolver():
+    with patch(
+        'trials.services.patient_info.ctomop_adapter.resolve_therapy_code',
+    ) as m:
+        r = normalize_ctomop_row(_row(
+            first_line_therapy='RVd (Lenalidomide/Bortezomib/Dexamethasone)',
+            first_line_therapy_id=35806260,
+            second_line_therapy='Daratumumab',
+            second_line_therapy_id=35806063,
+            later_therapy='Pomalidomide',  # no concept_id -> unknown
+        ))
+    m.assert_not_called()
+    assert r['first_line_therapy'] == '35806260'   # concept_id, as string
+    assert r['second_line_therapy'] == '35806063'
+    assert r['later_therapy'] is None              # no *_therapy_id present
+
+
+@override_settings(EXACT_OMOP_THERAPY=True)
+def test_flag_on_missing_concept_id_is_none():
+    r = normalize_ctomop_row(_row(
+        first_line_therapy='Some Free Text',  # text present, but no concept_id
+        first_line_therapy_id='0',            # sentinel-empty -> None
+    ))
+    assert r['first_line_therapy'] is None
+
+
+@override_settings(EXACT_OMOP_THERAPY=True)
+def test_flag_on_remaps_later_therapies_from_concept_ids():
+    # later_therapies feeds the same overlap as the scalar lines, so under OMOP it
+    # must carry concept_ids (from later_therapy_ids), not raw codes.
+    r = normalize_ctomop_row(_row(
+        later_therapy_ids=[35806261, 35806262, 0],  # 0 dropped
+        later_therapies=[{'therapy': 'pomalidomide'}],  # raw codes ignored under OMOP
+    ))
+    assert r['later_therapies'] == [{'therapy': '35806261'}, {'therapy': '35806262'}]
+
+
+@override_settings(EXACT_OMOP_THERAPY=False)
+def test_flag_off_leaves_later_therapies_list_untouched():
+    lst = [{'therapy': 'pomalidomide'}]
+    r = normalize_ctomop_row(_row(later_therapies=list(lst)))
+    assert r['later_therapies'] == lst  # legacy: not concept-remapped

--- a/trials/services/patient_info/ctomop_adapter.py
+++ b/trials/services/patient_info/ctomop_adapter.py
@@ -25,6 +25,8 @@ from datetime import date
 from decimal import Decimal
 from functools import lru_cache
 
+from trials.services.therapy_match_profile import omop_therapy_enabled
+
 
 logger = logging.getLogger(__name__)
 
@@ -387,21 +389,36 @@ def normalize_ctomop_row(row: dict) -> dict:
     if not row.get('lactate_dehydrogenase_level') and row.get('ldh_u_l') is not None:
         row['lactate_dehydrogenase_level'] = row['ldh_u_l']
 
-    # ── Therapy fields — resolve CTOMOP display names to EXACT therapy codes ────
-    # CTOMOP stores therapy names as human-readable strings (e.g. "Anastrozole
-    # (Arimidex) (Anastrozole)"). EXACT's eligibility filters use normalized codes
-    # (e.g. "anastrozole"). resolve_therapy_code() does a title→code lookup via
-    # the LRU-cached Therapy/TherapyComponent map, stripping trailing parentheticals
-    # to match the EXACT title. Unresolvable values are set to None so they are
-    # treated as unknown (potential) by the matcher rather than silently skipping
-    # therapy-type exclusion checks.
-    for _tf in ('first_line_therapy', 'second_line_therapy', 'later_therapy'):
-        val = row.get(_tf)
-        if isinstance(val, str) and val.strip():
-            row[_tf] = resolve_therapy_code(val)
+    # ── Therapy fields ─────────────────────────────────────────────────────────
+    _EMPTY_CID = (None, '', 0, '0')
+    if omop_therapy_enabled():
+        # OMOP mode: the patient speaks OMOP concept_ids (EXACT does no crosswalk).
+        # The therapy-LINE fields map to the trial omop_* columns, so source them
+        # from CTOMOP's resolved concept_ids: the scalar lines from *_therapy_id,
+        # and the later_therapies list from later_therapy_ids (get_user_therapies
+        # folds that list into the same code set the omop_* overlap reads, so raw
+        # internal codes there would silently never match). A line with no concept
+        # becomes None / [] (unknown) rather than an unmatchable internal code.
+        for _tf in ('first_line_therapy', 'second_line_therapy', 'later_therapy'):
+            cid = row.get(f'{_tf}_id')
+            row[_tf] = str(cid) if cid not in _EMPTY_CID else None
+        later_ids = row.get('later_therapy_ids') or []
+        row['later_therapies'] = [
+            {'therapy': str(c)} for c in later_ids if c not in _EMPTY_CID
+        ]
+    else:
+        # Legacy mode: resolve CTOMOP display strings (e.g. "Anastrozole (Arimidex)")
+        # to EXACT normalized codes (e.g. "anastrozole") via the LRU-cached
+        # Therapy/TherapyComponent title→code map. Unresolvable values → None so the
+        # matcher treats them as unknown (potential), not a skipped exclusion check.
+        for _tf in ('first_line_therapy', 'second_line_therapy', 'later_therapy'):
+            val = row.get(_tf)
+            if isinstance(val, str) and val.strip():
+                row[_tf] = resolve_therapy_code(val)
 
-    # JSON list fields (supportive_therapies, later_therapies) expect
-    # [{therapy: code, ...}] objects — clear if CTOMOP sent raw text.
+    # JSON list fields expect [{therapy: code, ...}] objects — clear if CTOMOP sent
+    # raw text. supportive_therapies stays on the legacy column (the OMOP profile
+    # keeps supportive/planned legacy), so it is not concept-remapped above.
     for _tf in ('supportive_therapies', 'later_therapies'):
         val = row.get(_tf)
         if isinstance(val, str) and not val.strip().startswith('['):


### PR DESCRIPTION
## Phase 3d of the EXACT-side OMOP therapy cutover

The ingest-boundary half of the OMOP patient contract — complements the matcher/queryset pass-through from phase 3c (#198). Behind **`EXACT_OMOP_THERAPY` (default OFF)**; flag-OFF is unchanged.

### Problem
The CTOMOP `?person_id=` path (`build_patient_info_from_ctomop_row → normalize_ctomop_row`) resolved therapy display text → EXACT **internal codes** via `resolve_therapy_code`. Correct for legacy matching, but wrong under OMOP: the trial `omop_*` columns hold **concept_ids**, and EXACT does no patient-side crosswalk (the consumer/CTOMOP supplies concepts).

### Change
Under `omop_therapy_enabled()`, the adapter sources the therapy-**line** fields from CTOMOP's resolved concept_ids:
- scalar lines (`first/second/later_line_therapy`) ← `*_therapy_id`
- `later_therapies` list ← `later_therapy_ids` (it folds into the same `get_user_therapies()` set the `omop_*` overlap reads, so raw codes there would silently never match — caught in self-review)
- a line with no concept → `None`/`[]` (unknown), not an unmatchable internal code

`supportive_therapies`/`planned_therapies` intentionally stay legacy (the OMOP profile keeps them on legacy columns). Flag OFF keeps the `resolve_therapy_code` path verbatim.

### Self-review (per rule)
- ✅ Claude fresh-context review (separate subagent): no blockers; verified flag-OFF unchanged + no import cycle. **Fixed its SHOULD-FIX** (`later_therapies` not remapped → leak) + NITs (`'0'` sentinel, stale comment).
- ✅ `codex review --base 2omop`: no regressions.

### Verified end-to-end (local, over HTTP)
`GET /trials/?person_id=9001` (EXACT flag ON) → pulls patient from a local CTOMOP (`/api/patient-info/9001/`, service token) → therapies `['35806063','35806260']` → concept overlap → **OMOP-DEMO-MM eligible**.

### Test
Schema-unchanged (`makemigrations --check` clean). 5 adapter tests (both flag states, missing/`'0'` concept, `later_therapies` remap). Full suite: 812 passed, 5 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)