### PR TITLE
feat(api): report per-patient match in the trial detail (retrieve) endpoint

### DIFF
--- a/tests/views/test_retrieve_match.py
+++ b/tests/views/test_retrieve_match.py
@@ -1,0 +1,89 @@
+"""
+get_trial_by_id (retrieve / TrialDetailsSerializer) reports the per-patient match.
+
+Previously the detail endpoint returned trial info + goodnessScore but no match
+(matchScore/matchingType/matchReasons were null). This surfaces the match via the
+**conflict-aware Python matcher** (trial_match_score / trial_match_status), NOT the
+list/search `match_score` annotation — retrieve skips filtered_trials, so a
+conflicting trial must be reported not_eligible, not mislabeled eligible by a
+filled-vs-null completeness score.
+"""
+from unittest.mock import patch
+
+import pytest
+from django.test import override_settings
+from rest_framework.test import APIClient
+
+from trials.api.trials_serializers import TrialDetailsSerializer
+from trials.services.patient_info.patient_info import PatientInfo
+from tests.factories import TrialFactory
+
+pytestmark = pytest.mark.django_db
+
+SERVICE_TOKEN = "test-service-token-value"
+
+
+def _detail_context(patient_info, explain=True):
+    return {
+        'patient_info': patient_info,
+        'explain': explain,
+        'counts': {},
+        'template': None,
+        'distance_units': 'km',
+        'recruitment_status': None,
+        'search_type': None,
+    }
+
+
+def test_detail_reports_match_for_patient():
+    pi = PatientInfo(disease='multiple myeloma')
+    trial = TrialFactory(disease='multiple myeloma')
+    data = TrialDetailsSerializer(trial, context=_detail_context(pi)).data
+
+    assert data['matchScore'] is not None
+    assert data['matchingType'] in ('eligible', 'potential', 'not_eligible')
+    assert isinstance(data['matchReasons'], list) and data['matchReasons']
+
+
+def test_detail_conflicting_patient_is_not_eligible():
+    # The key correctness fix: retrieve has no filtered_trials, so a trial the
+    # patient conflicts with must come back not_eligible / score 0 — NOT eligible.
+    pi = PatientInfo(disease='multiple myeloma', patient_age=10)
+    trial = TrialFactory(disease='multiple myeloma', age_low_limit=18)
+    data = TrialDetailsSerializer(trial, context=_detail_context(pi)).data
+
+    assert data['matchingType'] == 'not_eligible'
+    assert data['matchScore'] == 0
+
+
+def test_detail_no_explain_leaves_matchreasons_none():
+    pi = PatientInfo(disease='multiple myeloma')
+    trial = TrialFactory(disease='multiple myeloma')
+    data = TrialDetailsSerializer(trial, context=_detail_context(pi, explain=False)).data
+
+    assert data['matchReasons'] is None
+    assert data['matchingType'] in ('eligible', 'potential', 'not_eligible')
+
+
+@override_settings(SERVICE_AUTH_TOKEN=SERVICE_TOKEN)
+def test_retrieve_endpoint_reports_match_via_view():
+    """End-to-end through the DRF view: ?person_id resolves the patient (mocked
+    CTOMOP fetch), and the detail response carries the match fields."""
+    trial = TrialFactory(disease='multiple myeloma')
+    client = APIClient()
+    client.credentials(HTTP_AUTHORIZATION=f"Bearer {SERVICE_TOKEN}")
+    with patch('trials.services.patient_info.ctomop_client.CtomopClient') as MockClient:
+        MockClient.return_value.fetch_patient.return_value = {
+            'person_id': 9001, 'disease': 'multiple myeloma',
+        }
+        resp = client.get(f'/trials/{trial.id}/?person_id=9001&explain=true')
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body['matchScore'] is not None
+    assert body['matchingType'] in ('eligible', 'potential', 'not_eligible')
+    assert isinstance(body['matchReasons'], list)
+
+
+# NOTE: GET /trials/<id>/ with NO patient is a pre-existing 500 (TrialTemplates
+# renders patient-relative attribute values) — unrelated to this change.

--- a/trials/api/trials_serializers.py
+++ b/trials/api/trials_serializers.py
@@ -178,7 +178,29 @@ class TrialDetailsSerializer(serializers.ModelSerializer):
 
         response['details'] = details_and_groups['details']
         response['groupNames'] = details_and_groups['group_names']
-        response['matchScore'] = getattr(instance, 'match_score', None)
         response['goodnessScore'] = getattr(instance, 'goodness_score', None)
+
+        # Per-patient match — reported on the detail view (get_trial_by_id), not
+        # just trial info + goodness. Uses the conflict-aware Python matcher rather
+        # than the list/search `match_score` ANNOTATION: that annotation only counts
+        # filled-vs-null attrs and assumes filtered_trials already dropped the
+        # not-eligible rows. retrieve returns the trial by id WITHOUT that filter,
+        # so a conflicting trial (e.g. wrong disease/age/gender) must be scored by
+        # the matcher (which returns 0 / not_eligible on a conflict), not mislabeled
+        # eligible by the completeness annotation.
+        if patient_info is not None:
+            from trials.services.user_to_trial_attr_matcher import UserToTrialAttrMatcher
+            matcher = UserToTrialAttrMatcher(trial=instance, patient_info=patient_info)
+            response['matchScore'] = matcher.trial_match_score()
+            response['matchingType'] = matcher.trial_match_status()
+            if self.context.get('explain'):
+                from trials.services.trial_match_explainer import TrialMatchExplainer
+                response['matchReasons'] = TrialMatchExplainer(instance, patient_info).explain()
+            else:
+                response['matchReasons'] = None
+        else:
+            response['matchScore'] = None
+            response['matchingType'] = None
+            response['matchReasons'] = None
 
         return response


### PR DESCRIPTION
## What

`GET /trials/<id>/` (`TrialDetailsSerializer`) returned trial info + `goodnessScore` but **no per-patient match** — `matchScore`/`matchingType`/`matchReasons` were null, because the match pipeline ran only for list/search. This adds them so the detail view (`get_trial_by_id`) reports the match.

## How — uses the conflict-aware matcher, not the annotation
Retrieve deliberately skips `filtered_trials` (it must return the trial by id even when not eligible). The list/search `match_score` **SQL annotation** only counts filled-vs-null attributes and assumes `filtered_trials` already removed the not-eligible rows — so scoring retrieve with it would **mislabel a conflicting trial (wrong disease/age/gender) as eligible/100**. Instead the serializer uses the **conflict-aware Python matcher** `UserToTrialAttrMatcher.trial_match_score()` (0 on any conflict) / `.trial_match_status()` (`eligible`/`potential`/`not_eligible`); `matchReasons` via `TrialMatchExplainer` under `?explain=true`. No view/queryset change; list/search untouched; `details`/`groupNames` unchanged.

## Self-review (per rule)
Two-part review run **twice** (first attempt used the SQL annotation):
- Both Claude (fresh subagent) and `codex` flagged the annotation mislabeling conflicts as eligible (codex P1) → reworked to the conflict-aware matcher.
- Re-reviewed the final version: both clean, no blockers. Addressed the remaining SHOULD-FIX (tests bypassed the view) by adding an end-to-end APIClient test. Deferred: matcher runs a few passes per single-object retrieve (acceptable, no N+1).

## Verified live
`/trials/10/?person_id=9001` → `matchScore=100 eligible` (MM↔MM); `/trials/5/?person_id=9001` → `matchScore=0 not_eligible` (MM patient ↔ BC trial — correctly rejected).

## Test
4 tests (eligible, conflict→not_eligible/score 0, explain gating, end-to-end via DRF view). Full suite 816 passed; `makemigrations --check` clean. API-only, no schema change.

Pre-existing/out of scope: `GET /trials/<id>/` with **no** patient 500s via `TrialTemplates` (renders patient-relative values) — unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)