### PR TITLE
perf(api): single-pass match in the trial detail (retrieve) endpoint (#201)

### DIFF
--- a/tests/views/test_trial_detail_hardening.py
+++ b/tests/views/test_trial_detail_hardening.py
@@ -1,0 +1,46 @@
+"""
+#201 — trial detail (retrieve) computes score+status in a single matcher pass
+(match_score_and_status), with no memoization (re-reflects current patient state),
+and the explainer reuses the serializer's matcher instance.
+"""
+import pytest
+
+from trials.services.patient_info.patient_info import PatientInfo
+from trials.services.user_to_trial_attr_matcher import UserToTrialAttrMatcher
+from trials.services.trial_match_explainer import TrialMatchExplainer
+from tests.factories import TrialFactory
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.mark.parametrize('trial_kwargs', [
+    {},                                             # bare -> partial/potential
+    {'disease_progression_active_required': True},  # patient blank -> unknown
+    {'age_low_limit': 18},                          # conflict (patient age 10)
+])
+def test_match_score_and_status_matches_separate_methods(trial_kwargs):
+    pi = PatientInfo(disease='multiple myeloma', patient_age=10)
+    trial = TrialFactory(disease='multiple myeloma', **trial_kwargs)
+    m = UserToTrialAttrMatcher(trial, pi)
+    # single-pass result must equal calling the two methods separately
+    assert m.match_score_and_status() == (m.trial_match_score(), m.trial_match_status())
+
+
+def test_match_score_and_status_does_not_cache_patient_state():
+    # No memoization: re-evaluates against the current patient on each call.
+    trial = TrialFactory(disease='multiple myeloma', disease_progression_active_required=True)
+    pi = PatientInfo(disease='multiple myeloma')
+    m = UserToTrialAttrMatcher(trial, pi)
+    pi.progression = ''
+    _, status_blank = m.match_score_and_status()
+    pi.progression = 'smoldering'
+    _, status_smoldering = m.match_score_and_status()
+    assert status_blank != status_smoldering  # reflects the mutation
+
+
+def test_explainer_reuses_supplied_matcher():
+    pi = PatientInfo(disease='multiple myeloma')
+    trial = TrialFactory(disease='multiple myeloma')
+    m = UserToTrialAttrMatcher(trial, pi)
+    ex = TrialMatchExplainer(trial, pi, matcher=m)
+    assert ex._matcher is m

--- a/trials/api/trials_serializers.py
+++ b/trials/api/trials_serializers.py
@@ -191,11 +191,12 @@ class TrialDetailsSerializer(serializers.ModelSerializer):
         if patient_info is not None:
             from trials.services.user_to_trial_attr_matcher import UserToTrialAttrMatcher
             matcher = UserToTrialAttrMatcher(trial=instance, patient_info=patient_info)
-            response['matchScore'] = matcher.trial_match_score()
-            response['matchingType'] = matcher.trial_match_status()
+            # one pass for both (instead of trial_match_score() + trial_match_status()) — #201
+            response['matchScore'], response['matchingType'] = matcher.match_score_and_status()
             if self.context.get('explain'):
                 from trials.services.trial_match_explainer import TrialMatchExplainer
-                response['matchReasons'] = TrialMatchExplainer(instance, patient_info).explain()
+                # reuse the matcher instance rather than building a second one — #201
+                response['matchReasons'] = TrialMatchExplainer(instance, patient_info, matcher=matcher).explain()
             else:
                 response['matchReasons'] = None
         else:

--- a/trials/services/trial_match_explainer.py
+++ b/trials/services/trial_match_explainer.py
@@ -54,10 +54,12 @@ class TrialMatchExplainer:
     actionable information (disqualifiers, then data gaps) appears first.
     """
 
-    def __init__(self, trial, patient_info):
+    def __init__(self, trial, patient_info, matcher=None):
         self.trial = trial
         self.patient_info = patient_info
-        self._matcher = UserToTrialAttrMatcher(trial, patient_info)
+        # Reuse a caller-supplied matcher when given (avoids rebuilding it) — e.g.
+        # the detail serializer already constructed one for this (trial, patient).
+        self._matcher = matcher if matcher is not None else UserToTrialAttrMatcher(trial, patient_info)
         self._pi_attrs = PatientInfoAttributes(patient_info)
 
     def explain(self):

--- a/trials/services/user_to_trial_attr_matcher.py
+++ b/trials/services/user_to_trial_attr_matcher.py
@@ -172,6 +172,40 @@ class UserToTrialAttrMatcher:
             return 0
         return int(float(eligible_count) * 100 / float(all_count))
 
+    def match_score_and_status(self) -> tuple[int, 'TrialMatchStatus']:
+        """Single-pass equivalent of (trial_match_score(), trial_match_status()).
+
+        Walks the attr mapping once instead of twice — callers that need both
+        (the detail serializer) avoid the duplicate pass. Results are identical to
+        calling the two methods separately; no caching, so it still reflects the
+        current patient state on every call.
+        """
+        eligible_count = 0
+        all_count = 0
+        has_not_matched = False
+        has_unknown = False
+        for attr, trial_attr_meta in self.mapping.items():
+            if "disease" in trial_attr_meta and (
+                self.disease_code is None
+                or not disease_attr_applies(trial_attr_meta["disease"], self.disease_code)
+            ):
+                continue
+            status = self.attr_match_status(attr)
+            all_count += 1
+            if status == 'not_matched':
+                has_not_matched = True
+            elif status == 'matched':
+                eligible_count += 1
+            elif status == 'unknown':
+                has_unknown = True
+
+        if has_not_matched:
+            return 0, 'not_eligible'
+        if all_count == 0:
+            return 0, 'eligible'
+        score = int(float(eligible_count) * 100 / float(all_count))
+        return score, ('potential' if has_unknown else 'eligible')
+
     def is_patient_info_attr_blank(self, patient_info_attr: str) -> bool:
         return self.patient_info_attr.is_attr_blank(patient_info_attr)
 


### PR DESCRIPTION
## #201 — fewer matcher passes on the detail endpoint

`GET /trials/<id>/` computed the per-patient match by calling `trial_match_score()` **and** `trial_match_status()` (two full walks of the ~160-attr mapping), and `TrialMatchExplainer` built its own matcher.

- **`UserToTrialAttrMatcher.match_score_and_status()`** — one pass returning both; results **identical** to calling the two methods (verified by a parametrized test across eligible/potential/not_eligible). **No caching** — still re-reflects the current patient state on every call.
- **`TrialMatchExplainer(..., matcher=None)`** — reuses a supplied matcher instance instead of building a second one.
- The detail serializer uses `match_score_and_status()` and passes its matcher to the explainer.

Deliberately **not** per-instance memoization of `attr_match_status`: that breaks the contract that it re-evaluates the current patient (relied on by tests that mutate a reused matcher) — a first memoized attempt was reverted after self-review caught this.

## Self-review (per rule)
Two-part (Claude fresh subagent + `codex`), run on the combined #201+#202 change:
- Both **approved #201** (Claude verified `match_score_and_status` equivalence case-by-case + the explainer reuse + confirmed no leftover memoization).
- Both flagged the **#202** attempt (rendering anonymous detail with a default `PatientInfo()` fabricates per-criterion matches against MM defaults — codex P2). **#202 dropped from this PR** and kept open: the correct fix is a render-layer (`TrialAttributes`/`TrialTemplates`) no-patient refactor, not a fake patient.

## Scope
API-only; no schema change; list/search untouched; behavior-neutral (with-patient detail unchanged). Full suite 821 passed.

Closes #201. (#202 stays open — see issue.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)