### PR TITLE
feat(omop): component matching on concept_ids + type matching via CB category graph (#197)

### DIFF
--- a/tests/services/test_omop_component_type_matching.py
+++ b/tests/services/test_omop_component_type_matching.py
@@ -1,0 +1,116 @@
+"""OMOP component + type matching via the CB graph (#197 design).
+
+Under EXACT_OMOP_THERAPY:
+- regimen + component match on OMOP concept_ids (omop_* columns);
+- type/category is NOT OMOP-mapped — matched through the CB graph
+  (categories ↔ components ↔ therapies) against the LEGACY therapy_types_* columns.
+
+The matcher reverse-maps the patient's regimen concept_ids to internal Therapies
+(Therapy.omop_concept_id), walks to components (→ their OMOP concept_ids) and to
+categories (→ CB codes).
+"""
+import pytest
+from django.test import override_settings
+
+from trials.models import (
+    Therapy, TherapyComponent, TherapyComponentCategory,
+    TherapyComponentConnection, TherapyComponentCategoryConnection,
+)
+from trials.services.omop.therapy_graph import derive_component_and_type_values
+from trials.services.user_to_trial_attr_matcher import UserToTrialAttrMatcher
+from trials.services.patient_info.patient_info import PatientInfo
+from tests.factories import TrialFactory
+
+pytestmark = pytest.mark.django_db
+
+# concept_ids for the test graph (zz_ codes avoid seeded-data collisions)
+VRD_CID, BORT_CID, LEN_CID = 900260, 900825, 900972
+
+
+def _graph():
+    vrd = Therapy.objects.create(code='zz_vrd', title='zz VRd', omop_concept_id=VRD_CID)
+    bort = TherapyComponent.objects.create(code='zz_bort', title='zz Bortezomib', omop_concept_id=BORT_CID)
+    lena = TherapyComponent.objects.create(code='zz_lena', title='zz Lenalidomide', omop_concept_id=LEN_CID)
+    pi_cat = TherapyComponentCategory.objects.create(code='zz_proteasome_inh', title='zz Proteasome Inhibitor')
+    TherapyComponentConnection.objects.create(therapy=vrd, component=bort)
+    TherapyComponentConnection.objects.create(therapy=vrd, component=lena)
+    TherapyComponentCategoryConnection.objects.create(category=pi_cat, component=bort)
+    return vrd, bort, lena, pi_cat
+
+
+# ── shared derivation helper ─────────────────────────────────────────
+
+def test_derive_legacy_codes_when_flag_off():
+    _graph()
+    comps, types = derive_component_and_type_values(['zz_vrd'])
+    assert sorted(comps) == ['zz_bort', 'zz_lena']           # internal codes
+    assert types == ['zz_proteasome_inh']                    # CB category code
+
+
+@override_settings(EXACT_OMOP_THERAPY=True)
+def test_derive_concept_ids_for_components_cb_codes_for_types_when_flag_on():
+    _graph()
+    comps, types = derive_component_and_type_values([str(VRD_CID)])  # patient sends regimen concept_id
+    assert sorted(comps) == [str(BORT_CID), str(LEN_CID)]    # component OMOP concept_ids
+    assert types == ['zz_proteasome_inh']                    # types stay CB codes (not OMOP-mapped)
+
+
+@override_settings(EXACT_OMOP_THERAPY=True)
+def test_derive_none_when_regimen_concept_unknown():
+    _graph()
+    assert derive_component_and_type_values(['99999999']) == (None, None)
+
+
+# ── matcher: component level on OMOP concepts ────────────────────────
+
+@override_settings(EXACT_OMOP_THERAPY=True)
+def test_component_required_matches_via_concept_id():
+    _graph()
+    pi = PatientInfo(disease='multiple myeloma')
+    trial = TrialFactory(disease='multiple myeloma', omop_therapy_components_required=[str(BORT_CID)])
+    res = UserToTrialAttrMatcher(trial, pi)._match_therapy_related_things([str(VRD_CID)], False)
+    assert res == 'matched'
+
+
+@override_settings(EXACT_OMOP_THERAPY=True)
+def test_component_excluded_blocks_via_concept_id():
+    _graph()
+    pi = PatientInfo(disease='multiple myeloma')
+    trial = TrialFactory(disease='multiple myeloma', omop_therapy_components_excluded=[str(BORT_CID)])
+    res = UserToTrialAttrMatcher(trial, pi)._match_therapy_related_things([str(VRD_CID)], False)
+    assert res == 'not_matched'
+
+
+# ── matcher: type level via CB category graph (legacy column) ─────────
+
+@override_settings(EXACT_OMOP_THERAPY=True)
+def test_type_required_matches_via_cb_category_graph():
+    _graph()
+    pi = PatientInfo(disease='multiple myeloma')
+    # type column stays LEGACY (CB code) even under OMOP
+    trial = TrialFactory(disease='multiple myeloma', therapy_types_required=['zz_proteasome_inh'])
+    res = UserToTrialAttrMatcher(trial, pi)._match_therapy_related_things([str(VRD_CID)], False)
+    assert res == 'matched'
+
+
+@override_settings(EXACT_OMOP_THERAPY=True)
+def test_type_excluded_blocks_via_cb_category_graph():
+    _graph()
+    pi = PatientInfo(disease='multiple myeloma')
+    trial = TrialFactory(disease='multiple myeloma', therapy_types_excluded=['zz_proteasome_inh'])
+    res = UserToTrialAttrMatcher(trial, pi)._match_therapy_related_things([str(VRD_CID)], False)
+    assert res == 'not_matched'
+
+
+# ── legacy unchanged ─────────────────────────────────────────────────
+
+def test_legacy_component_and_type_still_match_by_code():
+    _graph()
+    pi = PatientInfo(disease='multiple myeloma')
+    trial = TrialFactory(
+        disease='multiple myeloma',
+        therapy_components_required=['zz_bort'],
+        therapy_types_required=['zz_proteasome_inh'],
+    )
+    res = UserToTrialAttrMatcher(trial, pi)._match_therapy_related_things(['zz_vrd'], False)
+    assert res == 'matched'

--- a/tests/services/test_therapy_match_profile.py
+++ b/tests/services/test_therapy_match_profile.py
@@ -42,18 +42,17 @@ def test_active_profile_defaults_to_legacy_columns():
 @override_settings(EXACT_OMOP_THERAPY=True)
 def test_active_profile_flips_mapped_levels_when_flag_on():
     assert omop_therapy_enabled() is True
-    # the three mapped levels flip to the omop_* columns...
+    # regimen + component flip to the omop_* concept_id columns...
     assert THERAPY_MATCH_PROFILE.therapies_required == 'omop_therapies_required'
     assert THERAPY_MATCH_PROFILE.therapies_excluded == 'omop_therapies_excluded'
     assert THERAPY_MATCH_PROFILE.therapy_components_required == 'omop_therapy_components_required'
     assert THERAPY_MATCH_PROFILE.therapy_components_excluded == 'omop_therapy_components_excluded'
-    assert THERAPY_MATCH_PROFILE.therapy_types_required == 'omop_therapy_types_required'
-    assert THERAPY_MATCH_PROFILE.therapy_types_excluded == 'omop_therapy_types_excluded'
-    # ...but planned/supportive stay legacy (their vocabs have no concept_ids yet).
+    # ...but types stay LEGACY (not OMOP-mapped — matched via the CB category graph),
+    # as do planned/supportive (their vocabs have no concept_ids yet).
+    assert THERAPY_MATCH_PROFILE.therapy_types_required == 'therapy_types_required'
+    assert THERAPY_MATCH_PROFILE.therapy_types_excluded == 'therapy_types_excluded'
     assert THERAPY_MATCH_PROFILE.planned_therapies_required == 'planned_therapies_required'
-    assert THERAPY_MATCH_PROFILE.planned_therapies_excluded == 'planned_therapies_excluded'
     assert THERAPY_MATCH_PROFILE.supportive_therapies_required == 'supportive_therapies_required'
-    assert THERAPY_MATCH_PROFILE.supportive_therapies_excluded == 'supportive_therapies_excluded'
 
 
 def test_get_therapy_match_profile_switches_on_flag():

--- a/trials/querysets/trial.py
+++ b/trials/querysets/trial.py
@@ -1046,26 +1046,18 @@ class TrialQuerySet(models.QuerySet):
         if therapy_codes is None or therapy_codes == []:
             return self
 
-        from trials.models import TherapyComponent, TherapyComponentCategory
-
         scope = self.eligible_for_therapy_from_lines(therapy_codes)
 
-        # Component/class codes are derived from the regimen via the INTERNAL vocab
-        # graph (by `code`). Under EXACT_OMOP_THERAPY the patient sends concept_ids,
-        # so this finds nothing → component/class filters are skipped and matching
-        # is regimen-level only. EXACT can't expand concept_ids (stateless, no
-        # vocab); the consumer must supply pre-expanded concepts at cutover (#197).
-        components = TherapyComponent.objects.filter(therapycomponentconnection__therapy__code__in=therapy_codes).all()
-        component_codes = [x.code for x in components]
+        # Component + type values from the regimen via the CB graph (shared with the
+        # matcher). Under OMOP: components → their OMOP concept_ids (vs the omop
+        # component column), types → CB category codes (vs the LEGACY therapy_types
+        # column the OMOP profile keeps). See trials/services/omop/therapy_graph.
+        from trials.services.omop.therapy_graph import derive_component_and_type_values
+        component_codes, therapy_types = derive_component_and_type_values(therapy_codes)
 
-        if len(component_codes) > 0:
+        if component_codes:
             scope = scope.eligible_for_therapy_components(component_codes)
-
-        categories = TherapyComponentCategory.objects.filter(
-            therapycomponentcategoryconnection__component__in=components).all()
-        therapy_types = [x.code for x in categories]
-
-        if len(therapy_types) > 0:
+        if therapy_types:
             scope = scope.eligible_for_therapy_types(therapy_types)
         return scope
 

--- a/trials/services/omop/therapy_graph.py
+++ b/trials/services/omop/therapy_graph.py
@@ -1,0 +1,60 @@
+"""Derive a patient's component + type match-values from their regimen therapies
+via the internal CB graph (Therapy → TherapyComponent → TherapyComponentCategory).
+
+The matcher and the search queryset both need, from the patient's regimen-line
+therapies, the drug-component and drug-class (type) values to overlap against the
+trial columns. This is the single shared derivation so the two stay consistent.
+
+Vocabulary by level (see therapy_match_profile):
+- regimen: handled by the caller directly (concept_ids under OMOP / codes legacy).
+- component: OMOP-mapped — under EXACT_OMOP_THERAPY the patient's regimen
+  concept_ids are reverse-mapped to internal Therapies (via Therapy.omop_concept_id),
+  walked to their components, and the components' OMOP concept_ids are returned
+  (to overlap the omop_therapy_components_* columns). Legacy → internal codes.
+- type / component-category: NOT OMOP-mapped — always returned as CB category
+  CODES (to overlap the legacy therapy_types_* columns), because EXACT keeps CB's
+  own category vocabulary and matches types through this graph (#197).
+
+Returns ``(component_values, type_values)``; ``(None, None)`` when the patient
+has no resolvable regimens (preserves the matcher's "unknown" semantics).
+"""
+from trials.services.therapy_match_profile import omop_therapy_enabled
+
+
+def _resolve_regimens(therapy_identifiers):
+    """Patient regimen identifiers → internal Therapy queryset.
+
+    Under OMOP the identifiers are concept_ids → match Therapy.omop_concept_id;
+    legacy → match Therapy.code.
+    """
+    from trials.models import Therapy
+    if omop_therapy_enabled():
+        # concept_ids are non-negative ints; isdigit() also keeps int() safe
+        cids = [int(v) for v in therapy_identifiers if str(v).isdigit()]
+        return Therapy.objects.filter(omop_concept_id__in=cids) if cids else Therapy.objects.none()
+    return Therapy.objects.filter(code__in=therapy_identifiers)
+
+
+def derive_component_and_type_values(therapy_identifiers):
+    if not therapy_identifiers:
+        return None, None
+    from trials.models import TherapyComponent, TherapyComponentCategory
+
+    therapies = _resolve_regimens(therapy_identifiers)
+    if not therapies.exists():
+        return None, None
+
+    components = TherapyComponent.objects.filter(
+        therapycomponentconnection__therapy__in=therapies
+    ).order_by('id')
+    categories = TherapyComponentCategory.objects.filter(
+        therapycomponentcategoryconnection__component__in=components
+    ).order_by('id')
+
+    if omop_therapy_enabled():
+        component_values = [str(c.omop_concept_id) for c in components if c.omop_concept_id is not None]
+    else:
+        component_values = [c.code for c in components]
+    # types are not OMOP-mapped — CB category codes, both modes
+    type_values = [cat.code for cat in categories]
+    return component_values, type_values

--- a/trials/services/therapy_match_profile.py
+++ b/trials/services/therapy_match_profile.py
@@ -20,11 +20,17 @@ trial columns are read; both sides must speak the same vocabulary, which is the
 consumer's responsibility. This profile deliberately does NOT change dispatch
 order / matching semantics (kept behavior-identical).
 
-Only the three mapped levels (regimen / drug component / drug class) flip to
-OMOP. ``planned_*`` / ``supportive_*`` stay on the legacy columns: their vocabs
-have no ``omop_concept_id`` yet, so the backfill leaves the omop_* planned/
-supportive columns empty — flipping them would silently drop the constraint.
-Flip those two levels here once their vocabs gain concept_ids.
+Only regimen + drug-component flip to OMOP concept_ids. The columns that stay on
+the legacy (internal-code) columns under OMOP:
+- ``therapy_types_*`` (drug class / component-category): types are deliberately
+  NOT OMOP-mapped (HemOnc's class structure is poor) — EXACT keeps CB's own
+  category vocabulary and matches types through the CB graph
+  ``categories ↔ components ↔ therapies`` (the matcher reverse-maps the patient's
+  component concept_ids back to internal components, then to CB categories, and
+  overlaps those against the legacy ``therapy_types_*`` columns). See #197.
+- ``planned_*`` / ``supportive_*``: their vocabs have no ``omop_concept_id`` yet,
+  so the backfill leaves the omop_* columns empty — flipping them would silently
+  drop the constraint.
 """
 from dataclasses import dataclass
 
@@ -52,15 +58,14 @@ class TherapyMatchProfile:
 # Legacy (internal-code) columns — the default.
 LEGACY_THERAPY_MATCH_PROFILE = TherapyMatchProfile()
 
-# OMOP cutover profile: the three mapped levels read the omop_* concept_id
-# columns; planned_*/supportive_* intentionally stay legacy (see module docstring).
+# OMOP cutover profile: regimen + component read the omop_* concept_id columns.
+# therapy_types_* / planned_* / supportive_* intentionally stay legacy (see module
+# docstring): types are matched via the CB category graph, not OMOP concept_ids.
 OMOP_THERAPY_MATCH_PROFILE = TherapyMatchProfile(
     therapies_required='omop_therapies_required',
     therapies_excluded='omop_therapies_excluded',
     therapy_components_required='omop_therapy_components_required',
     therapy_components_excluded='omop_therapy_components_excluded',
-    therapy_types_required='omop_therapy_types_required',
-    therapy_types_excluded='omop_therapy_types_excluded',
 )
 
 

--- a/trials/services/user_to_trial_attr_matcher.py
+++ b/trials/services/user_to_trial_attr_matcher.py
@@ -379,28 +379,13 @@ class UserToTrialAttrMatcher:
             return res
         results.append(res)
 
-        # Component/class codes are derived from the regimen via the INTERNAL vocab
-        # graph (by `code`). Under EXACT_OMOP_THERAPY the patient sends concept_ids,
-        # so this finds nothing → component/class levels report 'unknown' (never a
-        # false match). EXACT can't expand concept_ids (stateless); the consumer
-        # must supply pre-expanded concepts at cutover (#197).
-        therapies = None
-        if values:
-            from trials.models import Therapy
-            therapies = Therapy.objects.filter(code__in=values).all()
-
-        if therapies and therapies.count() > 0:
-            from trials.models import TherapyComponent
-            from trials.models import TherapyComponentCategory
-
-            components = TherapyComponent.objects.filter(therapycomponentconnection__therapy__in=therapies).order_by('id').all()
-            component_codes = [x.code for x in components]
-
-            categories = TherapyComponentCategory.objects.filter(therapycomponentcategoryconnection__component__in=components).order_by('id').all()
-            therapy_types = [x.code for x in categories]
-        else:
-            component_codes = None
-            therapy_types = None
+        # Component + type (class) values are derived from the regimen via the CB
+        # graph. Under OMOP the regimen concept_ids are reverse-mapped to internal
+        # Therapies, components → their OMOP concept_ids (vs omop_therapy_components_*),
+        # types → CB category codes (vs the LEGACY therapy_types_* columns, which the
+        # OMOP profile keeps — types are not OMOP-mapped). See #197 / therapy_graph.
+        from trials.services.omop.therapy_graph import derive_component_and_type_values
+        component_codes, therapy_types = derive_component_and_type_values(values)
 
         res = self._match_therapy_things(component_codes, getattr(self.trial, THERAPY_MATCH_PROFILE.therapy_components_required), getattr(self.trial, THERAPY_MATCH_PROFILE.therapy_components_excluded), has_no_prior_therapy)
         if res == 'not_matched':


### PR DESCRIPTION
## Makes component + type matching work under OMOP (#197)

Previously OMOP matching was **regimen-only**: the matcher/queryset derived components & types from the patient's regimen by internal **code**, which finds nothing when the patient sends concept_ids → component/type levels went `unknown`.

### Design (per product decision)
- **regimen + component → OMOP concept_ids** (omop_* columns), direct overlap.
- **type / component-category → NOT OMOP-mapped** (HemOnc's class structure is poor): keep CB's own category vocabulary. The OMOP profile keeps `therapy_types_*` on the **legacy** columns; types are matched through the CB graph `categories ↔ components ↔ therapies`.

### Implementation
- `therapy_match_profile`: OMOP profile flips only `therapies` + `therapy_components`; `therapy_types_*` stays legacy (like planned/supportive).
- **NEW `trials/services/omop/therapy_graph.derive_component_and_type_values()`** — shared by matcher + queryset. Under OMOP it reverse-maps the patient's regimen concept_ids → internal Therapies (`Therapy.omop_concept_id`) → components (→ their OMOP concept_ids, for the omop component column) and → categories (→ CB codes, for the legacy type column). Legacy mode unchanged (by code). `(None, None)` when no regimen resolves (preserves `unknown`).
- matcher `_match_therapy_related_things` + queryset `eligible_for_therapy_related_things_from_lines` both call the helper.

### Verified live on CTOMOP patient 9001 (flag ON)
regimen concepts `[35806260, 35806063]` → component concept_ids `[1336825, 19026972, 1518254, 35605744]` + CB type `[proteasome_inhibitor]`:
| trial | result |
|---|---|
| component-required (1336825) | **eligible** |
| component-excluded (1336825) | **not_eligible** |
| type-required (CB `proteasome_inhibitor`) | **eligible** |
| type-excluded | **not_eligible** |

### Self-review (per rule)
- ✅ Claude fresh-context review: clean, no blockers; verified legacy equivalence + OMOP correctness; fixed one digit-guard NIT.
- ✅ `codex review --base 2omop`: no issues.

### Scope/notes
API-only; **no schema change**. `omop_therapy_types_*` columns + GIN + backfill remain but are now unread by matching (harmless; re-usable if types ever get OMOP-mapped). Full suite 829 passed.

Closes #197.

🤖 Generated with [Claude Code](https://claude.com/claude-code)