### PR TITLE
fix(omop): per-criterion therapy display in trial detail under OMOP

### DIFF
--- a/tests/services/test_omop_component_type_matching.py
+++ b/tests/services/test_omop_component_type_matching.py
@@ -104,6 +104,44 @@ def test_type_excluded_blocks_via_cb_category_graph():
 
 # ── legacy unchanged ─────────────────────────────────────────────────
 
+# ── detail display (therapy_related_things_match_status) under OMOP ───
+
+@override_settings(EXACT_OMOP_THERAPY=True)
+def test_display_component_required_status_via_concept_id():
+    _graph()
+    pi = PatientInfo(disease='multiple myeloma', first_line_therapy=str(VRD_CID), prior_therapy='One line')
+    trial = TrialFactory(disease='multiple myeloma', omop_therapy_components_required=[str(BORT_CID)])
+    out = UserToTrialAttrMatcher(trial, pi).therapy_related_things_match_status()
+    assert out['therapyComponentsRequired']['status'] == 'matched'
+
+
+@override_settings(EXACT_OMOP_THERAPY=True)
+def test_display_component_excluded_status_via_concept_id():
+    _graph()
+    pi = PatientInfo(disease='multiple myeloma', first_line_therapy=str(VRD_CID), prior_therapy='One line')
+    trial = TrialFactory(disease='multiple myeloma', omop_therapy_components_excluded=[str(BORT_CID)])
+    out = UserToTrialAttrMatcher(trial, pi).therapy_related_things_match_status()
+    assert out['therapyComponentsExcluded']['status'] == 'not_matched'
+
+
+@override_settings(EXACT_OMOP_THERAPY=True)
+def test_display_type_required_status_via_cb_graph():
+    _graph()
+    pi = PatientInfo(disease='multiple myeloma', first_line_therapy=str(VRD_CID), prior_therapy='One line')
+    trial = TrialFactory(disease='multiple myeloma', therapy_types_required=['zz_proteasome_inh'])
+    out = UserToTrialAttrMatcher(trial, pi).therapy_related_things_match_status()
+    assert out['therapyTypesRequired']['status'] == 'matched'
+
+
+@override_settings(EXACT_OMOP_THERAPY=True)
+def test_display_type_excluded_status_via_cb_graph():
+    _graph()
+    pi = PatientInfo(disease='multiple myeloma', first_line_therapy=str(VRD_CID), prior_therapy='One line')
+    trial = TrialFactory(disease='multiple myeloma', therapy_types_excluded=['zz_proteasome_inh'])
+    out = UserToTrialAttrMatcher(trial, pi).therapy_related_things_match_status()
+    assert out['therapyTypesExcluded']['status'] == 'not_matched'
+
+
 def test_legacy_component_and_type_still_match_by_code():
     _graph()
     pi = PatientInfo(disease='multiple myeloma')

--- a/trials/services/omop/therapy_graph.py
+++ b/trials/services/omop/therapy_graph.py
@@ -21,7 +21,7 @@ has no resolvable regimens (preserves the matcher's "unknown" semantics).
 from trials.services.therapy_match_profile import omop_therapy_enabled
 
 
-def _resolve_regimens(therapy_identifiers):
+def resolve_regimens(therapy_identifiers):
     """Patient regimen identifiers → internal Therapy queryset.
 
     Under OMOP the identifiers are concept_ids → match Therapy.omop_concept_id;
@@ -40,7 +40,7 @@ def derive_component_and_type_values(therapy_identifiers):
         return None, None
     from trials.models import TherapyComponent, TherapyComponentCategory
 
-    therapies = _resolve_regimens(therapy_identifiers)
+    therapies = resolve_regimens(therapy_identifiers)
     if not therapies.exists():
         return None, None
 

--- a/trials/services/user_to_trial_attr_matcher.py
+++ b/trials/services/user_to_trial_attr_matcher.py
@@ -234,31 +234,36 @@ class UserToTrialAttrMatcher:
         return 'not_matched'
 
     def therapy_related_things_match_status(self):
-        therapies = []
-        therapy_components = []
-        therapy_components_to_therapy = {}
-        therapy_types = []
-        therapy_types_to_therapy = {}
+        from trials.services.therapy_match_profile import omop_therapy_enabled
+        from trials.services.omop.therapy_graph import resolve_regimens
+
+        therapies = {}                       # regimen match-value -> title
+        therapy_components_to_therapy = {}   # component match-value -> title
+        therapy_types_to_therapy = {}        # CB category code -> title (types not OMOP-mapped)
         therapy_codes = self.patient_info_attr.get_user_therapies()
 
         mismatch_status = self.therapy_related_things_mismatch_status()
 
-        if len(therapy_codes) > 0:
-            from trials.models import Therapy
-
-            therapies = Therapy.objects.filter(code__in=therapy_codes)
-            for therapy in therapies:
+        # Build the patient-side display maps keyed by whatever the trial columns
+        # hold per the active profile, so match_required/excluded overlap correctly:
+        # under OMOP regimen/component keys are concept_ids (reverse-mapped via the
+        # CB graph), type keys are CB category codes (legacy column); legacy → codes.
+        if therapy_codes:
+            omop = omop_therapy_enabled()
+            for therapy in resolve_regimens(therapy_codes):
+                if omop:
+                    if therapy.omop_concept_id is not None:
+                        therapies[str(therapy.omop_concept_id)] = therapy.title
+                else:
+                    therapies[therapy.code] = therapy.title
                 for component in therapy.components.order_by('id').all():
-                    if component not in therapy_components:
-                        therapy_components.append(component)
-                        therapy_components_to_therapy[component.code] = component.title
-
-                        for category in component.categories.all():
-                            if category not in therapy_types:
-                                therapy_types.append(category)
-                                therapy_types_to_therapy[category.code] = category.title
-
-        therapies = {x.code: x.title for x in therapies}
+                    if omop:
+                        if component.omop_concept_id is not None:
+                            therapy_components_to_therapy.setdefault(str(component.omop_concept_id), component.title)
+                    else:
+                        therapy_components_to_therapy.setdefault(component.code, component.title)
+                    for category in component.categories.all():
+                        therapy_types_to_therapy.setdefault(category.code, category.title)
 
         def match_required(trial_values, matching_values, mismatch_status):
             overlap = get_overlap(trial_values, matching_values.keys())


### PR DESCRIPTION
## Follow-up to #204 — fix the per-criterion DISPLAY

#204 made component/type **matching** work under OMOP, but the per-criterion **display** (`therapy_related_things_match_status` → `details.trialEligibilityAttributes` on `GET /trials/<id>/`) still derived the patient's components/types by internal `code`. Under OMOP (codes are concept_ids) it found nothing → showed `therapyComponentsRequired` / `therapyTypesRequired` as **`unknown`** even when the top-level `matchingType` was `eligible`.

### Fix
Build the patient-side `{match_value: title}` display maps keyed by what the active profile compares against: under OMOP regimen+component keys = concept_id strings (reverse-mapped via the shared `resolve_regimens`/CB graph), type keys = CB category codes (legacy column); legacy mode unchanged (by code). Now the per-criterion display agrees with `matchScore`/`matchingType`.
- `therapy_graph`: expose `resolve_regimens` (was `_resolve_regimens`).
- `matcher.therapy_related_things_match_status`: OMOP-aware key building.

### Verified live on CTOMOP 9001 (flag ON), detail `details.trialEligibilityAttributes`:
| trial | matchingType | per-criterion display |
|---|---|---|
| component-required | eligible | **matched** (bortezomib) |
| component-excluded | not_eligible | **not_matched** |
| type-required | eligible | **matched** (proteasome_inhibitor) |
| type-excluded | not_eligible | **not_matched** |

### Self-review (per rule)
- ✅ Claude fresh-context: clean, no blockers; verified legacy maps byte-identical + OMOP column alignment + rename fully propagated.
- ✅ `codex review --base 2omop`: no regression.

API-only; no schema change. Full suite 833 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)