### PR TITLE
feat(omop): return OMOP code + title (omopConcepts) in trial detail therapy criteria

### DIFF
--- a/tests/services/test_omop_component_type_matching.py
+++ b/tests/services/test_omop_component_type_matching.py
@@ -14,7 +14,7 @@ from django.test import override_settings
 
 from trials.models import (
     Therapy, TherapyComponent, TherapyComponentCategory,
-    TherapyComponentConnection, TherapyComponentCategoryConnection,
+    TherapyComponentConnection, TherapyComponentCategoryConnection, OmopConcept,
 )
 from trials.services.omop.therapy_graph import derive_component_and_type_values
 from trials.services.user_to_trial_attr_matcher import UserToTrialAttrMatcher
@@ -140,6 +140,41 @@ def test_display_type_excluded_status_via_cb_graph():
     trial = TrialFactory(disease='multiple myeloma', therapy_types_excluded=['zz_proteasome_inh'])
     out = UserToTrialAttrMatcher(trial, pi).therapy_related_things_match_status()
     assert out['therapyTypesExcluded']['status'] == 'not_matched'
+
+
+# ── detail response: OMOP code + title (omopConcepts) ────────────────
+
+@override_settings(EXACT_OMOP_THERAPY=True)
+def test_display_includes_omop_concepts_code_and_title():
+    _graph()
+    OmopConcept.objects.create(concept_id=BORT_CID, concept_name='bortezomib', vocabulary_id='RxNorm')
+    pi = PatientInfo(disease='multiple myeloma', first_line_therapy=str(VRD_CID), prior_therapy='One line')
+    trial = TrialFactory(disease='multiple myeloma', omop_therapy_components_required=[str(BORT_CID)])
+    out = UserToTrialAttrMatcher(trial, pi).therapy_related_things_match_status()
+    assert out['therapyComponentsRequired']['omopConcepts'] == [
+        {'code': BORT_CID, 'title': 'bortezomib', 'vocab': 'RxNorm'}
+    ]
+    # types are CB-coded (not OMOP) → no omopConcepts on the type criterion
+    assert 'omopConcepts' not in out['therapyTypesRequired']
+
+
+@override_settings(EXACT_OMOP_THERAPY=True)
+def test_omop_concepts_unresolved_keeps_code():
+    _graph()  # no OmopConcept row for BORT_CID
+    pi = PatientInfo(disease='multiple myeloma', first_line_therapy=str(VRD_CID), prior_therapy='One line')
+    trial = TrialFactory(disease='multiple myeloma', omop_therapy_components_required=[str(BORT_CID)])
+    out = UserToTrialAttrMatcher(trial, pi).therapy_related_things_match_status()
+    assert out['therapyComponentsRequired']['omopConcepts'] == [
+        {'code': BORT_CID, 'title': None, 'vocab': None}
+    ]
+
+
+def test_no_omop_concepts_field_when_flag_off():
+    _graph()
+    pi = PatientInfo(disease='multiple myeloma', first_line_therapy='zz_vrd', prior_therapy='One line')
+    trial = TrialFactory(disease='multiple myeloma', therapy_components_required=['zz_bort'])
+    out = UserToTrialAttrMatcher(trial, pi).therapy_related_things_match_status()
+    assert 'omopConcepts' not in out['therapyComponentsRequired']
 
 
 def test_legacy_component_and_type_still_match_by_code():

--- a/trials/services/trial_details/trial_templates.py
+++ b/trials/services/trial_details/trial_templates.py
@@ -74,9 +74,17 @@ class TrialTemplates:
                     pass
                 elif field_name in THERAPIES_ATTRS:
                     if field['value'] == []:
+                        # field['value'] is the LEGACY column; under OMOP the backfill
+                        # fills omop_* FROM legacy, so omop non-empty ⟹ legacy non-empty
+                        # (this skip never drops an omop criterion today). Full omop-only
+                        # rendering tracked in #207.
                         continue  # skip
                     field['matchingType'] = therapy_match_statuses[field_name]["status"]
                     field['uvalue'] = therapy_match_statuses[field_name]["values"]
+                    # OMOP code + title for the OMOP-mapped levels (regimen/component);
+                    # absent for legacy/type criteria. See therapy_related_things_match_status.
+                    if 'omopConcepts' in therapy_match_statuses[field_name]:
+                        field['omopConcepts'] = therapy_match_statuses[field_name]['omopConcepts']
                     out['trialEligibilityAttributes'].append(field)
                 elif not self._trial_attributes.is_blank(field_name, field['value'], field.get('search_type')):
                     if field['ufield']:

--- a/trials/services/user_to_trial_attr_matcher.py
+++ b/trials/services/user_to_trial_attr_matcher.py
@@ -112,6 +112,26 @@ def min_max_match(
         return 'matched'
 
 
+def _resolve_omop_concepts(concept_id_values):
+    """Resolve a list of OMOP concept_id strings to [{code, title, vocab}] via
+    OmopConcept. Unresolved concept_ids still return their code (title/vocab None)."""
+    if not concept_id_values:
+        return []
+    from trials.models import OmopConcept
+    cids = [int(v) for v in concept_id_values if str(v).isdigit()]
+    by_id = {c.concept_id: c for c in OmopConcept.objects.filter(concept_id__in=cids)}
+    out = []
+    for v in concept_id_values:
+        code = int(v) if str(v).isdigit() else v
+        c = by_id.get(code) if isinstance(code, int) else None
+        out.append({
+            'code': code,
+            'title': c.concept_name if c else None,
+            'vocab': c.vocabulary_id if c else None,
+        })
+    return out
+
+
 class UserToTrialAttrMatcher:
     def __init__(self, trial: 'Trial', patient_info: 'PatientInfo') -> None:
         self.trial = trial
@@ -311,6 +331,18 @@ class UserToTrialAttrMatcher:
             "therapyComponentsRequired": match_required(getattr(self.trial, THERAPY_MATCH_PROFILE.therapy_components_required), therapy_components_to_therapy, mismatch_status),
             "therapyComponentsExcluded": match_excluded(getattr(self.trial, THERAPY_MATCH_PROFILE.therapy_components_excluded), therapy_components_to_therapy),
         }
+
+        # OMOP code + title per criterion (additive). Only the OMOP-mapped levels
+        # (regimen + component) hold concept_ids; resolve the TRIAL's required/excluded
+        # concept_ids to OMOP names via OmopConcept. Types stay CB-coded (no OMOP).
+        if omop_therapy_enabled():
+            for key, col in (
+                ('therapiesRequired', THERAPY_MATCH_PROFILE.therapies_required),
+                ('therapiesExcluded', THERAPY_MATCH_PROFILE.therapies_excluded),
+                ('therapyComponentsRequired', THERAPY_MATCH_PROFILE.therapy_components_required),
+                ('therapyComponentsExcluded', THERAPY_MATCH_PROFILE.therapy_components_excluded),
+            ):
+                out[key]['omopConcepts'] = _resolve_omop_concepts(getattr(self.trial, col))
 
         return out
 


### PR DESCRIPTION
## What
`GET /trials/<id>/` now returns OMOP **code + title** for the OMOP-mapped therapy criteria, resolving the trial's required/excluded concept_ids via the `OmopConcept` table (#206).

Response shape (frontend-approved, **additive** — existing `value`/`uvalue`/`status` unchanged):
```
therapyComponentsRequired: {
  status: 'matched',
  values: ['**Bortezomib**', ...],          # unchanged
  omopConcepts: [{code: 1336825, title: 'bortezomib', vocab: 'RxNorm'}]   # NEW
}
```

## How
- `therapy_related_things_match_status`: under `EXACT_OMOP_THERAPY`, add `omopConcepts: [{code, title, vocab}]` to the 4 OMOP-mapped criteria (regimen + component × required/excluded), resolved from the trial's `omop_*` column concept_ids via `_resolve_omop_concepts` → `OmopConcept` (unresolved → code with title/vocab null). **Types stay CB-coded → no omopConcepts.**
- `TrialTemplates`: surface `field['omopConcepts']` on the detail `trialEligibilityAttributes` entries.

## Verified live on CTOMOP 9001 (flag ON)
- `therapyComponentsRequired` → `omopConcepts=[{code:1336825, title:'bortezomib', vocab:'RxNorm'}]`
- `therapyTypesRequired` → no `omopConcepts` (CB-coded type, correct)

## Self-review (per rule)
- ✅ Claude fresh-context: clean, no blockers (additive, flag-gated, correct source = trial omop columns).
- ✅ `codex review --base 2omop`: one P2 — detail therapy fields are legacy-column-driven, so a hypothetical omop-only trial would hide the criterion. Deferred to **#207**: unreachable today (backfill fills omop *from* legacy ⟹ legacy non-empty whenever omop is), flag OFF by default; code note added.

API-only; no schema change. 3 new tests; full suite 838 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)