### PR TITLE
feat(search): add ?therapy_id= filter by intervention-arm OMOP concept_id

### DIFF
--- a/tests/querysets/test_by_therapy_id.py
+++ b/tests/querysets/test_by_therapy_id.py
@@ -1,0 +1,64 @@
+"""Tests for TrialQuerySet.by_therapy_id and ?therapy_id= StudyPreferences parsing."""
+
+import pytest
+
+from trials.models import Trial
+from trials.querysets.trial import TrialQuerySet
+from trials.services.study_preferences import study_preferences_from_query_params
+from tests.factories import TrialFactory
+
+
+@pytest.mark.django_db
+class TestByTherapyId:
+    def test_returns_trial_with_matching_concept_id(self):
+        t = TrialFactory(omop_intervention_concept_ids=[19140573])
+        TrialFactory(omop_intervention_concept_ids=[])
+
+        qs = Trial.objects.by_therapy_id([19140573])
+        assert t in qs
+        assert qs.count() == 1
+
+    def test_no_op_when_list_empty(self):
+        TrialFactory(omop_intervention_concept_ids=[19140573])
+        total = Trial.objects.count()
+
+        qs = Trial.objects.by_therapy_id([])
+        assert qs.count() == total
+
+    def test_or_semantics_across_multiple_ids(self):
+        t1 = TrialFactory(omop_intervention_concept_ids=[19140573])
+        t2 = TrialFactory(omop_intervention_concept_ids=[19136050])
+        TrialFactory(omop_intervention_concept_ids=[99999999])
+
+        qs = Trial.objects.by_therapy_id([19140573, 19136050])
+        assert set(qs) == {t1, t2}
+
+    def test_does_not_match_trial_with_empty_field(self):
+        TrialFactory(omop_intervention_concept_ids=[])
+        qs = Trial.objects.by_therapy_id([19140573])
+        assert qs.count() == 0
+
+    def test_ignores_non_integer_therapy_id_in_query_params(self):
+        prefs = study_preferences_from_query_params({'therapy_id': 'notanumber'})
+        assert prefs.therapy_id == []
+
+    def test_parses_single_therapy_id_from_query_params(self):
+        class FakeParams(dict):
+            def getlist(self, key):
+                v = self.get(key)
+                return [v] if v is not None else []
+
+        prefs = study_preferences_from_query_params(FakeParams({'therapy_id': '19140573'}))
+        assert prefs.therapy_id == [19140573]
+
+    def test_parses_multiple_therapy_ids_from_query_params(self):
+        class MultiParams:
+            def getlist(self, key):
+                if key == 'therapy_id':
+                    return ['19140573', '19136050']
+                return []
+            def get(self, key, default=None):
+                return default
+
+        prefs = study_preferences_from_query_params(MultiParams())
+        assert prefs.therapy_id == [19140573, 19136050]

--- a/trials/migrations/0008_trial_omop_intervention_concept_ids.py
+++ b/trials/migrations/0008_trial_omop_intervention_concept_ids.py
@@ -1,0 +1,25 @@
+from django.contrib.postgres.indexes import GinIndex
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("trials", "0007_alter_trial_benefit_score_and_more"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="trial",
+            name="omop_intervention_concept_ids",
+            field=models.JSONField(blank=True, default=list),
+        ),
+        migrations.AddIndex(
+            model_name="trial",
+            index=GinIndex(
+                fields=["omop_intervention_concept_ids"],
+                name="idx_omop_intervention_cids_gin",
+                opclasses=["jsonb_ops"],
+            ),
+        ),
+    ]

--- a/trials/models.py
+++ b/trials/models.py
@@ -366,6 +366,9 @@ class Trial(TimeStampMixin):
     supportive_therapies_excluded = models.JSONField(blank=True, null=False, default=list)
     planned_therapies_required = models.JSONField(blank=True, null=False, default=list)
     planned_therapies_excluded = models.JSONField(blank=True, null=False, default=list)
+    # Populated by CB during trial sync: OMOP concept_ids of the intervention arm
+    # (what therapy the trial is giving/testing). Used by ?therapy_id= search.
+    omop_intervention_concept_ids = models.JSONField(blank=True, null=False, default=list)
     relapse_count_min = models.IntegerField(blank=True, null=True)
     relapse_count_max = models.IntegerField(blank=True, null=True)
     remission_duration_min = models.IntegerField(blank=True, null=True)
@@ -623,6 +626,7 @@ class Trial(TimeStampMixin):
             GinIndex(fields=['therapy_components_required', 'therapy_components_excluded'], name='idx_therapy_comps_pair_gin', opclasses=['jsonb_ops', 'jsonb_ops']),
             GinIndex(fields=['supportive_therapies_required', 'supportive_therapies_excluded'], name='idx_sup_therapies_pair_gin', opclasses=['jsonb_ops', 'jsonb_ops']),
             GinIndex(fields=['planned_therapies_required', 'planned_therapies_excluded'], name='idx_planned_therapies_pair_gin', opclasses=['jsonb_ops', 'jsonb_ops']),
+            GinIndex(fields=['omop_intervention_concept_ids'], name='idx_omop_intervention_cids_gin', opclasses=['jsonb_ops']),
             GinIndex(fields=['cytogenic_markers_required', 'cytogenic_markers_excluded'], name='idx_cytogenic_markers_pair_gin', opclasses=['jsonb_ops', 'jsonb_ops']),
             GinIndex(fields=['molecular_markers_required', 'molecular_markers_excluded'], name='idx_molecular_markers_pair_gin', opclasses=['jsonb_ops', 'jsonb_ops']),
             GinIndex(fields=['tumor_stages_required', 'tumor_stages_excluded'], name='idx_tumor_stages_pair_gin', opclasses=['jsonb_ops', 'jsonb_ops']),

--- a/trials/querysets/trial.py
+++ b/trials/querysets/trial.py
@@ -342,6 +342,17 @@ class TrialQuerySet(models.QuerySet):
             })
             count = new_count
 
+        query = query.by_therapy_id(study_info.therapy_id)
+        if add_traces:
+            new_count = query.count()
+            traces.append({
+                'attr': 'study_info.therapy_id',
+                'val': study_info.therapy_id,
+                'records': new_count,
+                'dropped': count - new_count,
+            })
+            count = new_count
+
         query = query.by_intervention_treatment(study_info.search_treatment)
         if add_traces:
             new_count = query.count()
@@ -514,6 +525,20 @@ class TrialQuerySet(models.QuerySet):
             Q(brief_title__icontains=search_title) |
             Q(official_title__icontains=search_title)
         )
+
+    def by_therapy_id(self, therapy_ids: list[int]) -> models.QuerySet:
+        """Filter trials by intervention-arm concept_id(s).
+
+        Matches trials where ``omop_intervention_concept_ids`` contains ANY of
+        the given concept_ids. Populated by CB during trial sync; empty until
+        CB backfill runs (filter is a no-op on such trials).
+        """
+        if not therapy_ids:
+            return self
+        q = Q()
+        for tid in therapy_ids:
+            q |= Q(omop_intervention_concept_ids__contains=[tid])
+        return self.filter(q)
 
     def by_intervention_treatment(self, search_treatment):
         if not search_treatment or search_treatment == '':

--- a/trials/querysets/trial.py
+++ b/trials/querysets/trial.py
@@ -279,6 +279,10 @@ class TrialQuerySet(models.QuerySet):
 
         query = self
 
+        # therapy_id applies to all search paths (standard and admin).
+        if study_info:
+            query = query.by_therapy_id(study_info.therapy_id)
+
         if search_type in ['all', 'favorites', 'my_trials']:
             query, _ = query.filter_for_admin(study_info, patient_info)
             max_distance = D(mi=1000)
@@ -339,17 +343,6 @@ class TrialQuerySet(models.QuerySet):
                 'val': study_info.search_title,
                 'records': new_count,
                 'dropped': count-new_count
-            })
-            count = new_count
-
-        query = query.by_therapy_id(study_info.therapy_id)
-        if add_traces:
-            new_count = query.count()
-            traces.append({
-                'attr': 'study_info.therapy_id',
-                'val': study_info.therapy_id,
-                'records': new_count,
-                'dropped': count - new_count,
             })
             count = new_count
 

--- a/trials/services/study_preferences.py
+++ b/trials/services/study_preferences.py
@@ -73,9 +73,13 @@ def study_preferences_from_query_params(params) -> StudyPreferences:
         return val if val else None
 
     def _int_list(key):
-        raw = params.getlist(key) if hasattr(params, 'getlist') else (
-            [params[key]] if key in params else []
-        )
+        if hasattr(params, 'getlist'):
+            raw = params.getlist(key)
+        elif key in params:
+            v = params[key]
+            raw = v if isinstance(v, list) else [v]
+        else:
+            raw = []
         result = []
         for v in raw:
             try:

--- a/trials/services/study_preferences.py
+++ b/trials/services/study_preferences.py
@@ -15,6 +15,9 @@ class StudyPreferences:
     search_title: Optional[str] = None
     search_disease: Optional[str] = None
     search_treatment: Optional[str] = None
+    # Intervention-arm filter: OMOP concept_ids of the therapy being studied.
+    # Populated by CB; accepts ?therapy_id= one or more times.
+    therapy_id: list[int] = field(default_factory=list)
 
     # Sponsor / registry filters
     sponsor: Optional[str] = None
@@ -69,10 +72,23 @@ def study_preferences_from_query_params(params) -> StudyPreferences:
         val = params.get(key)
         return val if val else None
 
+    def _int_list(key):
+        raw = params.getlist(key) if hasattr(params, 'getlist') else (
+            [params[key]] if key in params else []
+        )
+        result = []
+        for v in raw:
+            try:
+                result.append(int(v))
+            except (TypeError, ValueError):
+                pass
+        return result
+
     return StudyPreferences(
         search_title=_str('searchTitle'),
         search_disease=_str('searchDisease'),
         search_treatment=_str('searchTreatment'),
+        therapy_id=_int_list('therapy_id'),
         sponsor=_str('sponsor'),
         register=_str('register'),
         study_id=_str('studyId'),


### PR DESCRIPTION
## Summary

- Adds `omop_intervention_concept_ids` JSONField (GIN-indexed) to `Trial` — populated by CB at sync time
- Adds `TrialQuerySet.by_therapy_id()` — OR-semantics filter using `@>` operator (GIN-compatible)
- Adds `therapy_id` to `StudyPreferences`; supports `?therapy_id=123&therapy_id=456`
- Wires `by_therapy_id` at `filtered_trials()` level — applies to all `search_type` paths

## Why

"Show Trials" feature: UI calls EXACT with `?therapy_id=<omop_concept_id>` to get trials where a therapy is the intervention arm. CB populates `omop_intervention_concept_ids` during trial sync. Field defaults to `[]` so existing trials degrade gracefully until CB backfills.

## Cherry-pick note

Original branch `feat/therapy-id-search` was based on `2omop`. Cherry-picked onto `main` with conflict resolution:
- Kept only `omop_intervention_concept_ids` (dropped `omop_*` therapy fields that belong to `2omop`)
- Migration renumbered `0013→0008`, dependency updated to `0007_alter_trial_benefit_score_and_more`

## Pre-push review

- Claude (fresh context): P1=none, P2=none. P3: TrialFactory auto-discovery via `DjangoModelFactory` — confirmed fine
- Codex: "No discrete correctness issues"

## Test plan

- [x] 7/7 `tests/querysets/test_by_therapy_id.py` pass (on `2omop` DB)
- [ ] Migration applies cleanly on staging
- [ ] `?therapy_id=<id>` returns only trials with matching concept_id in `omop_intervention_concept_ids`

🤖 Generated with [Claude Code](https://claude.com/claude-code)