### PR TITLE
docs(adr): rewrite ADR 0001 to the as-built OMOP therapy design (+ decision A on types)

### DIFF
--- a/docs/adr/0001-cross-vocabulary-mapping.md
+++ b/docs/adr/0001-cross-vocabulary-mapping.md
@@ -1,160 +1,182 @@
-# ADR 0001: Cross-vocabulary mapping between EXACT, CTOMOP, and CancerBot
+# ADR 0001: Cross-vocabulary therapy matching (CB ↔ OMOP ↔ EXACT)
 
-- **Status:** Proposed
-- **Date:** 2026-06-18
-- **Deciders:** EXACT team (pending review by CancerBot + CTOMOP terminology owners)
-- **Reviews:** Codex (consult) on architecture options + the ETL re-keying idea; gstack `/plan-eng-review` (eng-manager pass) — substrate decision (OMOP `concept_relationship` upstream + compiled EXACT table), governance-as-Phase-0, per-domain kill switch, resolver test matrix, and outbound-annotation caching folded in.
-- **Related:** #172 (HemOnc therapy concept_ids — first domain instance), CTOMOP PR #168 / issue #165
+- **Status:** Accepted. **Authoring (CB crosswalk) + materialized trial `omop_*` columns + the flag seam are implemented** behind `EXACT_OMOP_THERAPY` (default OFF) on branch `feat/omop-crosswalk-exact` (EXACT PRs #192–#208, #4476; CB epic #4447), **not yet merged to `main`**. The **matching design (§3–§4) is the decided target** — the feat branch currently uses an interim graph-based derivation; see "Delta from the current feat-branch implementation" + "Migration". Non-therapy domains: proposed (future, last section).
+- **Date:** 2026-06-18 (rewritten 2026-06-19)
+- **Deciders:** EXACT + CancerBot teams
+- **Reviews:** Codex (consult) + gstack `/plan-eng-review` on the options; this revision reconciled against the as-built code after auditing CB epic #4447 and the EXACT port.
+- **Related — implementation (already built):** CB epic **#4447** (and #4442/#4444/#4445/#4451/#4453/#4455/#4457/#4446); EXACT port **#4476**. Source-of-truth docs in CB: `docs/exact-downstream-and-omop.md`, `docs/omop/therapy-paths-audit.md`; in EXACT: `docs/porting-from-cancerbot.md`. Patient side: CTOMOP PR #168 (HemOnc concept_ids on PatientInfo). Trackers: #172, #173, #174.
+
+> **Revision note.** The first version of this ADR was written greenfield and proposed a generic patient→EXACT boundary resolver. That framing was **wrong for therapy**: a coordinated CB→EXACT epic had already built a different, better-fitting design (CB authors the crosswalk and materializes OMOP `concept_id` columns on trials; EXACT matches on `concept_id` overlap behind a feature flag). This rewrite documents the **as-built** therapy design and the requirement that drives it, and scopes the generic-resolver vision to the not-yet-built non-therapy domains.
 
 ## Context
 
 Three systems share clinical-trial matching but speak different vocabularies:
 
-- **CancerBot (CB)** owns the clinical-trial data and its own vocabularies (therapy codes, markers, diseases, staging, etc.).
-- **EXACT** (this repo) is the trial-matching engine. It imports CB trials and uses CB-derived vocabularies. Its taxonomies (`Therapy`, `Marker`, `Disease`, `TherapyComponent`/`TherapyComponentCategory`, `PlannedTherapy`, ...) are keyed by internal string `code`/`title`. It has essentially **no standard-vocabulary anchor on the matching path**: the only standard-coded fields are two free-text columns on the `Trial` model itself, `condition_code_icd_10` and `condition_code_snomed_ct` (`trials/models.py:342-343`), which describe a trial's target condition and are not consumed by the matcher or by any patient representation.
-- **CTOMOP** is a separate OMOP-CDM patient-data service with its own and standard vocabularies (OMOP standard `concept_id`s: HemOnc, SNOMED, LOINC, RxNorm, plus source values).
+- **CancerBot (CB)** owns the clinical-trial data and its own vocabularies (therapy codes, markers, diseases, staging, …). **CB is upstream**; EXACT is a downstream port (~95% identical matcher).
+- **EXACT** (this repo) is a **stateless, read-only** trial-matching engine. Its taxonomies (`Therapy`, `TherapyComponent`, `TherapyComponentCategory`, …) are keyed by internal `code`/`title`.
+- **CTOMOP** is an OMOP-CDM patient-data service providing standard `concept_id`s (HemOnc regimens, RxNorm drugs, SNOMED, LOINC).
 
-**The task:** EXACT must search and match trials against patient values that arrive encoded in CTOMOP vocabularies, across **many domains** (not just therapy).
+**The task:** match trials against patient data that arrives in CTOMOP/OMOP vocabularies, on a shared vocabulary rather than CB-private string codes — so a stateless downstream (EXACT) and external patient sources (CTOMOP) interoperate.
 
-### Current state
+Two bridges exist, and they are different things:
+- **Legacy generic bridge (name-string):** `ctomop_adapter.py::normalize_ctomop_row` resolves CTOMOP display strings to EXACT codes by lowercased name lookup across ~15 domains. Brittle, no provenance, silent failure (the bugs in #174). Still the path for every non-therapy domain.
+- **OMOP therapy bridge (concept_id, this ADR):** the built design below, for regimen + drug-component therapy matching.
 
-The bridge lives in one file: `trials/services/patient_info/ctomop_adapter.py::normalize_ctomop_row`. It is a large hand-maintained crosswalk that resolves CTOMOP display strings and concept names to EXACT codes by **lowercased name-string lookup** against EXACT taxonomies, plus ~15 domain-specific special-cases: receptor status, TNM staging, histologic type, ethnicity, tumor/biopsy grade, therapy-line outcomes, refractory status, genetic mutations, lab column renames, therapies, behaviour flags, metastatic status, prior therapy, gender.
+## Key requirement: the trials DB is a read-only-replica distribution surface
 
-Problems with the current approach:
-- **Brittle:** name-spelling drift between CTOMOP and EXACT silently drops values.
-- **No provenance / no versioning:** mappings are executable code, not reviewable data.
-- **Silent failure:** an unmapped value is indistinguishable from an absent value; both flow to the matcher as "unknown".
-- **Clinical policy hidden in code:** transforms like `Equivocal -> HER2 low`, `Hispanic -> other`, grade-3 collapse, and regimen/component substitution are clinical decisions, not terminology synonyms, yet they are buried in aliases and inline transforms with no review trail.
-
-CTOMOP has now started providing stable standard `concept_id`s (HemOnc Regimen ids for therapy lines, CTOMOP PR #168), which is the first stable cross-vocabulary anchor and the trigger for this ADR.
+EXACT's trials DB is intended to be consumed as a **read-only replica by other projects in the future**, not only by EXACT's own matcher. A pure SQL replica consumer can only `SELECT`; it **cannot** run a Python resolver, load a mapping artifact, or execute an ETL. Therefore the OMOP concept_ids must be **materialized, self-describing columns on the trial rows** — the data has to carry its own vocabulary. This requirement is decisive: it rules *in* "concept_id columns on trials" and rules *out* any design that needs the consumer to resolve at read time.
 
 ## Options considered (the four ways)
 
-Where should the therapy (and every other domain's) crosswalk live? Four shapes, with good/bad for each.
+The original framing pitted "columns on trials" against "resolve at a boundary" as rivals. That was a **false dichotomy** — there are two independent axes: **where the mapping is authored** vs **how it is distributed to consumers**. The read-only-replica requirement fixes the distribution axis to materialized columns.
 
-### Option 1 — Expand the trials database
-Denormalize CTOMOP-vocab columns (e.g. HemOnc `concept_id`s) onto EXACT's persisted trials and match on them.
-- **Good:** single-vocab, fast SQL filtering; no runtime mapping; self-contained inside EXACT.
-- **Bad:** two representations of the same requirement → drift; stale concept_ids persisted on every trial row; a destructive overwrite loses the CB criterion and is not re-derivable after a vocab update; the overlap logic gets duplicated across the SQL prefilter, the Python matcher, and the per-attr metadata builder; ambiguous source identity (`vrd` vs `vrd_lite` share a drug set); helps no other consumer (e.g. SoC). **Rejected** as the worst option (see Rejected options).
+### Option 1 — Concept_id columns on the trials DB *(distribution layer — adopted)*
+Materialize OMOP `concept_id` columns on the persisted trials; consumers match/query on them.
+- **Good:** self-describing for **any** read-only-replica consumer (the key requirement above); single-vocab, GIN-indexed SQL filtering; no runtime mapping for the consumer.
+- **Bad (only in a *naive* form):** if there were two independent sources of truth they would drift. The as-built design removes this: **one** authority (CB) fills the columns from **one** vocab map, a single locked writer, and `shadow_compare` detects drift. So the columns are an additive projection of a single source, not a second source.
+- **Verdict:** **adopted as the distribution layer.** (The original "rejected as worst" verdict assumed EXACT's matcher was the only consumer and conflated this with the destructive Option 4 — both wrong given the replica requirement.)
 
-### Option 2 — EXACT does all the mapping of therapies → HemOnc concept IDs (in EXACT)
-EXACT owns the crosswalk internally: today's `normalize_ctomop_row`, or a new EXACT-only mapping table.
-- **Good:** no upstream dependency; ships today; EXACT fully controls its vocabulary; incremental.
-- **Bad:** every consumer re-implements the same clinical mapping and they **diverge** — EXACT targets internal codes, SoC targets RxNorm, both hand-bridging the same CTOMOP fields; clinical policy (`Equivocal → HER2 low`, regimen→component) is duplicated and can silently disagree app-to-app; no shared provenance / versioning / review; maintenance × N consumers. `#174` is this option's bug surface. **Rejected as the primary mechanism** — it is the brittle status quo.
+### Option 2 — Each consumer maps internally
+Each app hand-bridges CTOMOP fields to its own vocabulary (today's `normalize_ctomop_row`; SoC's `_*_codes.py`).
+- **Good:** no upstream dependency; ships today.
+- **Bad:** N consumers re-implement the same clinical mapping and diverge; clinical policy duplicated; no shared provenance. `#174`/`#198` are its bug surface.
+- **Verdict:** **rejected** as the therapy mechanism (it is the brittle status quo that the OMOP path replaces).
 
-### Option 3 — CTOMOP exposes a crosswalk (chosen, with one refinement)
-The source side, where the patient vocabulary and OMOP `concept_relationship` already live, owns and publishes the mapping; consumers read a version-pinned artifact.
-- **Good:** one source of truth; OMOP `concept_relationship` is native to CTOMOP; one mapping serves EXACT and SoC; provenance / versioning / clinical review in one place.
-- **Bad:** cross-team governance dependency (Conway — the Phase-0 risk); CTOMOP must **not** encode consumer-specific policy (EXACT's category buckets, SoC's RxNorm targets); a **live network service** would add availability / reproducibility coupling.
-- **Refinements that make it the decision:** ship a **versioned compiled artifact, not a live service**; CTOMOP exposes only **source → standard anchor**, and **per-consumer target resolution stays consumer-side**.
+### Option 3 — Source (CB/OMOP) owns the crosswalk *(authoring layer — adopted)*
+The side that owns the trial vocabulary authors and curates the CB↔OMOP mapping; consumers receive the result.
+- **Good:** one source of truth; provenance / versioning / clinical review in one place; OMOP-native.
+- **Verdict:** **adopted as the authoring layer.** Realized as CB-owned curation (CSV + `TherapyOmopMapping`), not a live network service.
 
-### Option 4 — Dedicated ETL service that rewrites the whole trial corpus into CTOMOP vocabulary
-A standalone ETL reads every CB trial and rewrites **all** its fields into CTOMOP vocab, so EXACT's persisted trials end up fully CTOMOP-vocab. Claim: then EXACT needs no crosswalk at all — both patient and trial sides speak CTOMOP-vocab, and all mapping lives at the ETL-service level. (Distinct from Option 1: Option 1 *adds* concept_id columns beside the CB fields; Option 4 *replaces* the trial corpus.)
-- **Good:** centralizes the mapping in one service — but that half is already Option 3; EXACT runtime does no live mapping.
-- **Bad:** the ETL **is** the crosswalk, relocated and run destructively — "no crosswalk needed" is false (the full CB-code → CTOMOP-concept mapping with relationship/lossy/no-map semantics is still required). **Blast radius** jumps from one stateless patient record per request to the **entire persistent trial corpus** — a bad mapping release silently shifts eligibility across all trials. Destructive overwrite **loses the CB source criterion** and is not re-derivable after a mapping fix or vocab update without re-running from CB. Coverage asymmetry (concept_ids only for MM therapy today) forces a **mixed-vocab corpus for years** → the matcher must run in two vocab spaces (the dual-vocab anti-pattern). Re-keying **breaks the therapy → component → category expansion** (`user_to_trial_attr_matcher.py`) and cannot express no-map / "A or B" composites (`cyclophosphamide_or_melphalan`) unless the entire EXACT taxonomy is ported into OMOP-space — which is the rejected native-OMOP option, done destructively. It maps the **expensive** persistent side to save runtime on the **cheap** stateless side. **Rejected** (Codex + eng review). It only wins as a **platform migration** (CB stops being the trial-authoring vocabulary AND CTOMOP has lossless reviewed coverage of every domain AND trials are curated natively in OMOP) — none true today. A *safe* ETL that preserves raw CB beside the projection is no longer "fully CTOMOP, no crosswalk"; it collapses back into Option 3.
+**Options 1 and 3 are not competitors — they are different layers.** Authoring at the source (3) + distribution via materialized columns (1) is the as-built design.
 
-## Decision
+### Option 4 — Dedicated ETL service that rewrites the whole trial corpus into CTOMOP vocab
+A standalone ETL *replaces* every trial's fields with CTOMOP vocab so EXACT needs "no crosswalk."
+- **Bad:** the ETL **is** the crosswalk, relocated and made **destructive**; it loses the CB source criterion (not re-derivable after a fix); blast radius = the entire corpus; partial concept coverage forces a mixed-vocab corpus for years; re-keying breaks the legacy therapy→component→category expansion and cannot express no-map / "A or B" composites without porting the whole taxonomy to OMOP.
+- **Verdict:** **rejected** (Codex + eng review). Distinct from Option 1: Option 1 *adds* concept_id columns beside the CB fields (non-destructive, source preserved in CB); Option 4 *replaces* the corpus. A safe ETL that preserves raw CB collapses back into Option 1+3.
 
-Adopt option 3 (refined) as the **hybrid** architecture:
+## Decision — the design
 
-1. **Mechanism — a single generic, versioned, reviewed crosswalk (was "option B").** One first-class mapping store keyed by `(source_system, source_vocabulary, source_concept_id | normalized_source_value)` to `(target_vocabulary = CB, target_code)`, covering all domains through one resolver, rather than 15 per-domain tables or 15 inline special-cases.
+**Authoring (CB) + materialized distribution columns (CB-filled) + a flag-gated matching seam (EXACT), with all `CB↔HemOnc` mapping kept out of EXACT.** §1–§2 are as-built; §3–§4 are the decided target (the current `feat` branch differs — see "Delta from the current feat-branch implementation"). Concretely:
 
-   **Substrate (eng review):** author and govern the mappings using **OMOP `concept_relationship` semantics on the CTOMOP/OMOP side** (`Maps to` / `Maps to value` / `Is a` — the standard vocabulary-relationship model; CTOMOP already added the vocabulary-relationship tables in `0065_add_vocabulary_relationship_tables`), then **compile a denormalized lookup table into EXACT** for runtime. This reuses a domain standard instead of re-inventing relationship semantics, and keeps governance where the OMOP vocabulary already lives. EXACT does not query OMOP vocab tables at match time — it consumes the compiled, version-pinned artifact (see Governance).
+### 1. The crosswalk lives in CB and is curated there
+- Built offline **in CB** by `cancerbot/docs/omop/mapping/build_mapping.py`: name-match CB vocab titles against pinned Athena/CTOMOP dumps (RxNorm drugs, **HemOnc** regimens, drug-class categories) + hand-curated overrides + explicit `NO_OMOP` (procedures). `build_mapping.py` itself does **no** LLM step; the `llm`-tagged rows are LLM-proposed and merged into the CSV by a separate curation step. **EXACT vendors only the resulting CSV** (`docs/omop/mapping/therapy_omop_mapping.csv`) and loads it via `load_therapy_omop_concept_ids` (which accepts `auto`/`curated`/`llm` rows).
+- Serialized to `docs/omop/mapping/therapy_omop_mapping.csv` (~328 rows), materialized into two models (ported to EXACT, #4476): **`TherapyOmopMapping`** (`level`, `cb_code`, `omop_concept_id` nullable, `omop_name`, `omop_vocab`, `match`) and **`OmopConcept`** (`concept_id → concept_name/vocabulary_id`).
 
-2. **Governance / source of truth — an externally owned, git-versioned artifact (was "option F").** The mapping is owned jointly by CB and CTOMOP terminology governance, not by any single application's internal loader. Ship a versioned artifact (e.g. JSON) compiled into an EXACT table; **do not** stand up a live network terminology service until multiple consumers actually require live resolution (it adds availability and reproducibility failure modes). **This is the critical path, not a side question (eng review / Conway):** the crosswalk spans three teams (CB owns trial vocab, CTOMOP owns patient vocab, a clinical reviewer owns equivalence). Naming the artifact owner and release process is **Phase 0** — every other phase depends on it, and an unowned crosswalk is the most likely way this stalls.
+### 2. Concept_ids are materialized onto the trial rows (CB fills them)
+- `omop_concept_id` (nullable, indexed) on the vocab models `Therapy` / `TherapyComponent` / `TherapyComponentCategory` is the source of truth.
+- 10 `omop_*` JSONB array columns on `Trial` (5 required/excluded pairs) hold concept_id **strings** (so the existing `has_any_keys`/GIN overlap filters carry over), backfilled from the vocab `omop_concept_id` via `omop/therapy_concept_mapper.py` + a locked writer (`therapy_sync`). GIN pair indexes per required/excluded pair.
 
-3. **Upstream emission — optional optimization only (was "option E").** CTOMOP may consume the same released artifact to emit pre-mapped values for stable production interfaces, but CTOMOP is **not** the source of truth (it must not silently encode CB semantics and EXACT-specific policy).
+### 3. EXACT matches on concept_id overlap behind a one-place seam
+- `TherapyMatchProfile` (`trials/services/therapy_match_profile.py`) holds **only the trial-side column names**; the queryset and matcher read columns via the profile. Two instances; `EXACT_OMOP_THERAPY` (env, **default OFF**) selects legacy vs OMOP. Flipping the flag swaps which columns are read — no matching-logic change.
+- When ON, matching per level:
+  - **regimen + drug-component:** **direct `concept_id` overlap** — patient concept_ids ∩ the trial `omop_therapies_*` / `omop_therapy_components_*` columns. **No EXACT-side resolution** — both sides are already concept_ids.
+  - **type (drug class):** EXACT holds **exactly one** CB-generated lookup, `component_concept_id → CB category code`; the patient's component concepts resolve to CB category codes, overlapped against the trial's legacy `therapy_types_*` (CB codes). This is the **only** crosswalk knowledge in the EXACT codebase.
+  - `planned_*`/`supportive_*` stay legacy until their vocabs gain concept_ids.
 
-4. **Direction — map patient -> CB/EXACT vocabulary.** Trial criteria are authored and validated in CB semantics; one patient record is translated once, versus re-authoring every trial criterion. EXACT's therapy hierarchy and bespoke categories are not faithfully represented by single standard concepts. Preserve the OMOP identifiers and raw source values **beside** the resolved CB code; never destroy the source representation.
+### 4. EXACT does NOT own the CB↔HemOnc mapping; the patient arrives pre-expanded
+EXACT is stateless and owns no CB↔HemOnc crosswalk. The full `CB code ↔ HemOnc/RxNorm concept` mapping (therapy + component) lives **only in CB**, where it fills the trial `omop_*` columns. **CTOMOP supplies the patient pre-expanded to regimen + component `concept_id`s** — regimen ids are already on `PatientInfo` (PR #168); component (drug) concepts already exist in CTOMOP's OMOP `DrugExposure` (`drug_concept`, RxNorm) and are surfaced on the `PatientInfo` contract EXACT reads. So EXACT does **pure concept overlap** for regimen + component and holds **no reverse-resolution logic** — the only mapping it consults is `component_concept_id → category` (for types). The trial-detail response additively attaches `omopConcepts` (`[{code,title,vocab}]`, via `OmopConcept`).
 
-### Rejected options
+### Direction (corrected)
+Under OMOP, both sides speak **OMOP concept_ids** for regimen + component (not "patient → CB vocab"). Types are the one CB-hierarchy construct: patient component concepts → CB category codes (one lookup) → overlap the CB-code `therapy_types_*` column. Legacy mode keeps internal-code matching with full expansion; the two coexist behind the flag, and legacy-mode EXACT stays byte-identical to CB.
 
-- **Native standard vocabularies in EXACT (re-key taxonomies + trial criteria onto OMOP).** Rejected: many trial criteria have no lossless single OMOP concept; re-curation would cause semantic collapse, not eliminate mapping.
-- **Denormalize CTOMOP values onto trials + dual-vocabulary matching.** Rejected as worst option: duplicated state, synchronization failures, ambiguous precedence, and stale concept_ids persisted on every trial. (See #172 for why drug-set identity is also unsafe: `vrd` and `vrd_lite` share an identical drug set but are distinct.)
-- **Pure per-domain mapping tables (the literal "option A").** Rejected as primary: 15 schemas and workflows with inconsistent semantics. The generic crosswalk should carry domain as metadata instead.
-- **ETL batch-rekeying of EXACT's persisted trials into CTOMOP vocabulary.** Rejected: it does not remove the crosswalk, it relocates it to ingest-time and makes it a **destructive** overwrite (loses the CB source criterion; not re-derivable after a vocab update without re-running from CB). It is also the harder direction (trial -> patient vocab) and loses EXACT's richer trial semantics — the therapy -> component -> category hierarchy the matcher depends on (`user_to_trial_attr_matcher.py:339`), "A or B" composites (e.g. `cyclophosphamide_or_melphalan`, `therapies_mapper.py:293`), and no-map criteria with no single CTOMOP concept. With concept_ids only for MM therapy today, it would force a mixed-vocab trials DB for years (the dual-vocab anti-pattern). Batch resolution is fine, but only as the compiled cache / upstream emission above, not as destructive re-keying. (Reviewed with Codex + eng review.)
+## The crosswalk shape, as built
 
-## Required shape of the crosswalk
-
-Do not key it by Django class name (`exact_model`) — that is an implementation detail. Minimum mapping identity:
-
+The CSV seed header (`cb_title` is CSV-only; the `TherapyOmopMapping` model omits it):
 ```
-source_system
-source_vocabulary
-source_vocabulary_version
-source_domain
-source_concept_id | normalized_source_value
-target_vocabulary           # CB
-target_vocabulary_version
-target_domain
-target_code
-relationship                # align to OMOP relationship vocabulary: Maps to (exact) | Maps to value | Is a (narrower) | Subsumes (broader) | derived | lossy | no-map
-mapping_status              # candidate | reviewed | unmapped
-valid_from / valid_to
-provenance
-clinical_context
-reviewer
-reviewed_at
+level            # regimen | component | category   (category level slated for removal — decision A)
+cb_code          # CB internal code  ── model: unique together (level, cb_code) → 1:1 per code
+cb_title         # CSV only (human label; not stored on the model)
+omop_concept_id  # nullable: null = no clean standard concept (expanded into components/classes at backfill)
+omop_name
+omop_vocab       # RxNorm | HemOnc | drug-class
+match            # auto | curated | llm | needs_review | no_omop   (provenance / coverage status)
 ```
 
-**`relationship` is mandatory and is the core insight:** a crosswalk is not a synonym table. Many mappings are contextual, directional, one-to-many, or impossible. Equivalence, narrowing, broadening, and lossy collapses must be distinguishable so that downstream code can refuse to let a lossy or unmapped fact strengthen eligibility.
+It is a **flat 1:1 per-code map with provenance**, not a relationship-typed graph. Key consequences:
+- **No relationship typing.** Instead of `exact/narrower/broader/lossy`, the design uses `match` (provenance/confidence) + `null` concept (no clean mapping) + **fan-out at backfill** (a regimen with no single concept is expanded into its component/class concepts). Unmapped rows are retained and queryable (coverage is visible, not silently dropped).
+- **1-to-many collapses are accepted, not typed.** `vrd` and `vrd_lite` share the same drug set and map to the same HemOnc concept → under OMOP they **collapse to one concept** (the dose distinction is lost). The design accepts this; `shadow_compare` ranks such divergence-risk codes by trial frequency to drive SME review. (Relationship typing — to *represent* such lossy collapses instead of accepting them — is part of the future generic vision, not the therapy as-built.)
 
-Do **not** put a global unique constraint on `(vocabulary, concept_id)` unless one-to-one semantics are proven.
+## Hierarchy: keep ours; the only EXACT crosswalk is component → category
 
-## Three integration points (bidirectional)
+HemOnc's class structure fits our category hierarchy poorly, so **we keep our own hierarchy** and push all `CB↔HemOnc` mapping out of the EXACT codebase:
 
-The crosswalk is **bidirectional** and serves three call sites, not one. The first version of the analysis covered only inbound matching; this ADR corrects that.
+- **`therapy` (regimen) and `component` (drug) map 1:1 to concept_ids — in CB.** CB fills the trial `omop_therapies_*` / `omop_therapy_components_*` columns; **CTOMOP** supplies the patient's regimen + component concept_ids. EXACT never resolves either — pure overlap on both sides.
+- **`type` (category) is the one thing EXACT knows.** Types have no usable OMOP concept (below), so they stay a **CB-hierarchy construct**. EXACT holds **one CB-generated lookup, `component_concept_id → CB category code`**: the patient's component concepts resolve to CB categories, overlapped against the trial's legacy `therapy_types_*` (CB codes). The category linkage is CB-authored (`TherapyComponentCategoryConnection`); EXACT just reads the compiled `component→category` table.
 
-1. **Inbound resolution (matching).** `ctomop_adapter` resolves CTOMOP `concept_id` / source value to EXACT `code`(s); the existing matcher then runs unchanged in EXACT code-space (`user_to_trial_attr_matcher.py`), preserving therapy -> component -> category expansion. Resolution order:
-   1. reviewed concept-id mapping,
-   2. reviewed source-value mapping,
-   3. explicitly recorded `unmapped` result.
-   Never automatic title/name matching in production.
+Net effect: **EXACT holds no `CB↔HemOnc` therapy/component mapping and no reverse-resolution** (the current `omop/therapy_graph.py` regimen→internal→graph walk is removed). The only crosswalk in EXACT is `component→category`.
 
-2. **Outbound option annotation (presentation).** The trial detail response (`trials/services/trial_details/trial_attributes.py`, via the trials retrieve endpoint) and `form-settings` (`FormSettingsViewSet`) return the full option set for select / multi-select attributes (therapies, markers, receptors, mutations, staging, ...). Today these come purely from EXACT vocabularies via `ValueOptions.all_options()` (`{value: code, label: title}`) with no mapping out. For CTOMOP consumers, each option must be **annotated** from the crosswalk:
-   ```json
-   { "value": "vrd", "label": "VRd (...)", "conceptId": 35803361,
-     "mappingStatus": "reviewed", "relationship": "exact" }
-   ```
-   Options whose relationship to CTOMOP is `no-map` / `broader` / `lossy` must be flagged so a consumer does not present a selectable option that can never (or wrongly) light up from CTOMOP patient data. Conversely, CTOMOP patient values with **no** EXACT option need an explicit `unmapped` / `other` representation so the patient's real value is not silently invisible in the detail view.
+### Why types are NOT OMOP-mapped (decided A)
 
-   **Performance (eng review):** `ValueOptions.all_options()` is already cached (`cache_key` v2). Fold the crosswalk annotation **into that cached blob**, not a per-request join — otherwise every trial-detail / form-settings response does an N-options crosswalk lookup. Bust the cache on crosswalk-artifact version change.
+Two reasons, both decisive:
+1. **No usable type concept.** Reaching a class concept means a CB-category → HemOnc/ATC-class mapping — the "HemOnc categories fit our hierarchy poorly" problem (those category rows are mostly hand-`curated`, and ~9 of ~30 have no clean class concept at all).
+2. **The patient never carries a type concept.** CTOMOP supplies regimen + component concepts; types are always derived as **CB category codes**. So an `omop_therapy_types_*` column holding HemOnc class concepts (e.g. `proteasome_inhibitor → 35807295`) is **unmatchable**, not merely unused — patient types are CB codes and can never overlap a class concept.
 
-3. **Per-attribute match metadata.** `therapy_related_things_match_status()` already returns `{ status: matched | not_matched | unknown, values: [...] }` per attribute, computed live in the detail path (`trial_details/trial_templates.py`). This stays in EXACT code-space; the only addition is an optional `matchSource` (`concept_id` | `source_value` | `name`) provenance field, which doubles as the observability signal for the shadow-mode rollout below.
+**Decision (A):** types are not OMOP-mapped. **Drop** the dead `omop_therapy_types_*` columns + the `category` level from `THERAPY_LEVELS` and the CB pipeline. Types match in CB-category-code space, via the `component→category` lookup, in both modes. (Rejected alt "B-components" — stuff class-member component concepts into `omop_therapy_types_*` — adds backfill+matcher rework and a fail-closed guard; revisit only if a third-party replica must match types in pure OMOP.)
 
-## Rollout safety
+### How search/matching works under the decision
 
-- **Shadow mode first.** When both a concept_id and a name are present for a patient fact, resolve both, record disagreements as metrics, and **do not** change eligibility until the disagreement rate is validated near zero. On disagreement, treat as unknown / quarantine; never silently prefer one source.
-- **Distinguish "absent" from "terminology layer failed."** These must be different states end to end.
-- **Migration metrics to expose:** concept-id coverage, source-value coverage, name-only coverage, disagreement count, ambiguous-mapping count, eligibility-result diffs.
-- **Per-domain kill switch (eng review):** the concept-id path must be enableable/disableable **per domain**, so a bad mapping release for one domain rolls back to the name path for that domain alone, not the whole crosswalk. Blast radius of a bad release = one domain.
+Under `EXACT_OMOP_THERAPY=ON`, patient on RVd supplies regimen `[35806260]` + components `[1336825, 19026972, …]` (from CTOMOP):
 
-### Resolver test matrix (eng review)
+| Level | Patient values (from CTOMOP) | EXACT step | Trial column (profile) | Overlap space |
+|---|---|---|---|---|
+| regimen | regimen `concept_id`s | none (direct) | `omop_therapies_*` | OMOP concept_id |
+| component | component `concept_id`s | none (direct) | `omop_therapy_components_*` | OMOP concept_id |
+| type | component `concept_id`s | `component→category` lookup → CB codes | legacy `therapy_types_*` | CB code |
 
-The resolver is the highest-risk new code (the current bridge's silent-failure bugs are tracked in #174). The invariant is only a guarantee if it is tested. Required matrix, as its own module (not inline in `normalize_ctomop_row`), with the crosswalk as data:
-- each relationship type (`Maps to` / `Maps to value` / narrower / broader / lossy / no-map) resolves to the correct status, and lossy/no-map never clears an exclusion;
-- ambiguous mapping (e.g. `vrd` vs `vrd_lite`) fails closed, not by dict/import order;
-- `unmapped` (terminology-layer failure) is distinct from `absent` (no patient value) end to end;
-- id-vs-name disagreement in shadow mode is recorded, never silently resolved.
+- **Search (queryset):** `eligible_for_*` read the column names via `THERAPY_MATCH_PROFILE` and filter with `has_any_keys` overlap (+ the `has_no_prior_therapy` empty-list early return). Regimen/component filter the `omop_*` columns directly; types filter the legacy column after the one `component→category` lookup.
+- **Match (matcher):** `get_overlap` per level → `matched / not_matched / unknown`. E.g. patient components `{1336825, …}` → categories `{proteasome_inhibitor, …}`; trial `therapy_types_required = ['proteasome_inhibitor']` → matched; excluded overlap → hard reject.
+
+Net: regimen + component match in **OMOP concept_id space with zero EXACT logic**; types match in **CB-category-code space** via the single `component→category` lookup.
+
+### Delta from the current feat-branch implementation
+
+The `feat/omop-crosswalk-exact` code today does this differently and must change to reach the decision:
+- **Today:** patient arrives regimen-only; `omop/therapy_graph.py` reverse-maps regimen `concept_id` → internal `Therapy` (via `Therapy.omop_concept_id`) → components → categories (all CB M2M). `omop_therapy_types_*` is built (dead).
+- **Target (decided):** CTOMOP surfaces component concepts on `PatientInfo`; EXACT drops `therapy_graph` reverse-resolution and does pure overlap for regimen+component; adds a compiled `component→category` lookup for types; drops `omop_therapy_types_*` + the `category` pipeline level.
+
+## Distribution: read-only replica
+
+The `omop_*` trial columns ARE the integration contract. Other projects read the trials DB replica and get concept_ids in SQL, GIN-indexed, with no resolver. This is why materialized columns (Option 1) are required, and why a boundary-resolver or ETL would be harder/unworkable for a pure SQL consumer.
+
+## Rollout safety (as built + plan)
+
+- **Default OFF.** `EXACT_OMOP_THERAPY` is off everywhere; legacy parity is byte-identical to CB and CI-guarded (drift detector + hardcoded-field scanner + parity test, per the porting doc).
+- **Cutover gate:** `omop/shadow_compare.py` re-derives expected `omop_*` from legacy and reports (a) **drift** (stored vs recomputed → stale backfill) and (b) **divergence risk** (legacy codes with no OMOP concept → would match differently after the flip), ranking top unmapped codes by trial frequency.
+- **Order:** CB ships + backfills columns; **EXACT flips first** behind the flag; dual-field period; CB drops legacy columns only after all EXACT envs are cut over.
+- **Production write path:** in split-DB prod, CB ships populated columns; EXACT has no live `post_save` sync (only a local backfill command).
+
+## What's left (finish, not build)
+
+- **Data:** SME-curate the ~50 `needs_review` codes; pin a real CTOMOP release. Until then backfill writes empty arrays for those.
+- **Cutover:** drive `shadow_compare` to clean, then flip the flag per environment.
+- **Demographics:** OMOP gender/ethnicity (gender + ethnicity→RACE concepts) is built in CB but **not yet ported to EXACT** (`shadow_compare` notes therapy-only).
+- **Levels:** `planned_*`/`supportive_*` await concept_ids in their vocabs; `therapy_types_*` intentionally stays legacy (CB category codes).
+
+### Migration to the decided minimal-EXACT design (delta from `feat/omop-crosswalk-exact`)
+1. **CTOMOP (under our control):** surface patient **component (drug) concept_ids** on the `PatientInfo` contract (data already exists in OMOP `DrugExposure.drug_concept`, RxNorm), alongside the regimen ids (PR #168).
+2. **CB:** generate + ship a compiled **`component_concept_id → CB category code`** lookup (from `TherapyComponentCategoryConnection`), regenerated on component↔category changes, `shadow_compare`-guarded like the columns.
+3. **EXACT:** remove `omop/therapy_graph.py` reverse-resolution; regimen+component = direct overlap on the patient-supplied concepts; add the `component→category` lookup for types.
+4. **EXACT:** drop `omop_therapy_types_*` columns + the `category` level from `THERAPY_LEVELS` and the CB pipeline; `makemigrations --check` after dropping the columns + their GIN indexes.
+
+## Generic cross-vocabulary mapping — non-therapy domains (future, NOT yet built)
+
+The other ~14 domains (markers, conditions, staging, grades, labs, receptor status, …) still go through the brittle name-string `normalize_ctomop_row` path. Extending the OMOP approach there is **future work** and is where the original generic-crosswalk ideas apply:
+- a generic, versioned, reviewed mapping store with **`relationship` typing** (`Maps to / narrower / broader / lossy / no-map`) so lossy collapses are *represented*, not just accepted;
+- `unmapped` ≠ `absent` end-to-end; fail-closed on ambiguity;
+- a second consumer (**SoC**, the therapy recommendation engine, currently on its own RxNorm `_*_codes.py` bridges — see SoC ADR 0001 / #198) reading the same artifact.
+These are not decided for therapy (which is intentionally simpler: 1:1 + `match` + accepted collapse) and should be revisited per domain.
 
 ## Invariant
 
 > No unresolved or lossy fact may silently strengthen eligibility.
 
-This is the acceptance test for every change made under this ADR.
+Acceptance test for every change here. The OMOP therapy path honors it via default-OFF + `shadow_compare` divergence-risk gating before cutover; the legacy path violates it today (the bugs below).
 
-## Consequences
+## Known correctness bugs in the legacy (name-string) bridge
 
-**Positive:** one reviewable, versioned, auditable mapping mechanism replacing brittle inline string lookups; clinical policy becomes data with provenance and review; graceful degradation during the long partial-concept-coverage period; the same artifact serves matching, option annotation, and (optionally) CTOMOP's own emission.
-
-**Negative / cost:** requires a governance process and owners across two (three) teams; requires building the crosswalk store, loader, CI validation, and shadow-mode instrumentation; back-filling reviewed mappings for ~15 domains is real curation work, done incrementally (therapy / MM first, per #172).
-
-## Known correctness bugs in the current bridge
-
-These were surfaced during analysis and verified against the code. They are clinical-safety issues (false eligibility from information loss), tracked separately from this ADR:
-
-- `ctomop_adapter.py` `resolve_code_csv` silently drops unresolved items from multi-value fields (markers, medications). An unmapped **excluded** fact can disappear and produce a false `eligible`. (verified)
-- `trials/querysets/trial.py` `eligible_for_required_and_excluded_lists` returns `self` (no filtering) when the patient value list is empty / fully unmapped, so all candidates pass the prefilter. (verified)
-- Unmapped scalar values become `None`, which the aggregate `trial_match_status` reports as `potential` rather than a mapping failure. (consistent with code)
-- `_match_type_bool_restriction` (`user_to_trial_attr_matcher.py:731`) converts a missing value to `False`; when the trial value is `True` and the attribute is not `under_user_control`, it returns `not_matched` (an actual exclusion) rather than `unknown` (uncertainty). (verified)
-- Process-lifetime cached title mappings (`_build_code_lookup`) can go stale after a taxonomy update. (flagged)
+On the `ctomop_adapter` path (not the OMOP concept path), verified, tracked in #174 — clinical-safety (false eligibility from information loss):
+- `resolve_code_csv` silently drops unresolved items from multi-value fields → an unmapped **excluded** fact disappears → false `eligible`. (verified)
+- `eligible_for_required_and_excluded_lists` returns `self` (no filter) on an empty/unmapped value list → all candidates pass the prefilter. (verified)
+- Unmapped scalar → `None` → aggregate reports `potential`, not a mapping failure. (consistent with code)
+- `_match_type_bool_restriction` (`user_to_trial_attr_matcher.py:731`) turns a missing value into `False` → `not_matched` (exclusion) rather than `unknown`. (verified)
+- Process-lifetime cached title mappings (`_build_code_lookup`) go stale after a taxonomy update. (flagged)


### PR DESCRIPTION
Rewrites ADR 0001 from its original greenfield framing (a generic patient→EXACT boundary resolver) to the **as-built** OMOP therapy design, after auditing the implementation.

### Why
The therapy cross-vocab work is already built — CB epic #4447, ported to EXACT on `feat/omop-crosswalk-exact` (PRs #192–#208, #4476), flag-gated `EXACT_OMOP_THERAPY` (default OFF), **not yet on `main`**. The old ADR mis-described it on direction, "Option 1 rejected", and relationship-typing.

### What the ADR now records
- **Read-only-replica distribution** as the key requirement → materialized `concept_id` columns on trials are *required* (a SQL replica can't run a resolver/ETL). "Columns" (Option 1) and "source-owned authoring" (Option 3) are two layers, not rivals.
- **As-built:** CB curates the CB↔OMOP crosswalk (CSV → `TherapyOmopMapping`/`OmopConcept`, 1:1 + `match` provenance) and fills `omop_*` concept columns on trials; EXACT matches on concept_id overlap behind `TherapyMatchProfile`. Patient supplied as regimen concepts by CTOMOP; component/type **derived via the CB graph**; types are CB category codes in both modes.
- **Decision A on types (this session):** types are **not** OMOP-mapped. `omop_therapy_types_*` holds HemOnc class concepts the patient never produces → **unmatchable**; remove those columns + the `category` level. Types stay on legacy CB-category-code columns. (B-components recorded as the rejected alternative.)
- End-to-end **search/matching walkthrough** under A.
- Generic relationship-typed crosswalk scoped to **future non-therapy domains**; legacy-bridge bugs (#174) kept, scoped to the name-string path.

### Note
Docs-only. The ADR documents code on `feat/omop-crosswalk-exact` (not merged to main) — implementation-status is stated in the header. Reviewed two-part (fresh-context subagent + Codex) against the implementation branch + CB; all claims verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)