### PR TITLE
feat(omop): promop concept-graph client + release-pinned cache (#234)

### DIFF
--- a/exact/settings.py
+++ b/exact/settings.py
@@ -378,6 +378,14 @@ ADD_SEARCH_TRIALS_TRACES = os.environ.get('ADD_SEARCH_TRIALS_TRACES', 'false') =
 CTOMOP_BASE = os.environ.get('CTOMOP_BASE', '')
 CTOMOP_SERVICE_TOKEN = os.environ.get('CTOMOP_SERVICE_TOKEN', '')
 
+# promop concept-graph API (#234; promop ADR 0001 / promop#279) — API + cache
+# source of truth for vocabulary/concept-graph data. Falls back to the CTOMOP_*
+# settings (same promop host) until the dedicated OAuth2 path (#237) lands.
+# Empty default keeps ConceptGraphClient unconfigured (callers get
+# ConceptGraphUnavailable) so nothing silently no-ops.
+PROMOP_API_BASE = os.environ.get('PROMOP_API_BASE', '')
+PROMOP_SERVICE_TOKEN = os.environ.get('PROMOP_SERVICE_TOKEN', '')
+
 
 # ---------------------------------------------------------------------------
 # OMOP therapy matching (epic #4447 cutover).

--- a/tests/services/omop/test_concept_graph_cache.py
+++ b/tests/services/omop/test_concept_graph_cache.py
@@ -1,0 +1,209 @@
+"""Tests for CachedConceptGraphClient — the release-pinned, per-source cache (#234 slice 2).
+
+Uses a mocked ConceptGraphClient (to count/inspect fetches) over the real Django cache
+(LocMemCache under test_settings). Contract: per-source reuse, release-keyed, and
+fail-closed — failures and truncated sources are never cached.
+"""
+from unittest.mock import MagicMock
+
+import pytest
+from django.core.cache import caches
+
+from trials.services.omop.concept_graph_client import (
+    ConceptGraphClient,
+    ConceptGraphResult,
+    ConceptGraphUnavailable,
+)
+from trials.services.omop.concept_graph_cache import CachedConceptGraphClient
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    caches['default'].clear()
+    yield
+    caches['default'].clear()
+
+
+def _res(groups, truncated=None, versions=('v1',)):
+    return ConceptGraphResult(groups=groups, truncated=truncated or [],
+                              versions=frozenset(versions))
+
+
+def _mock_client():
+    return MagicMock(spec=ConceptGraphClient)
+
+
+class TestCachedExpand:
+    def test_miss_then_hit(self):
+        client = _mock_client()
+        client.expand.return_value = _res({1: [10, 11]})
+        cached = CachedConceptGraphClient(client=client)
+
+        r1 = cached.descendants([1], release='rel-2024-12')
+        r2 = cached.descendants([1], release='rel-2024-12')
+
+        assert r1.groups == {1: [10, 11]} == r2.groups
+        assert r1.versions == frozenset({'v1'})
+        client.expand.assert_called_once()  # second call served from cache
+
+    def test_per_source_reuse_across_requests(self):
+        client = _mock_client()
+        client.expand.side_effect = [
+            _res({1: [10], 2: [20]}),   # first request fetches 1 and 2
+            _res({3: [30]}),            # second request fetches only the miss (3)
+        ]
+        cached = CachedConceptGraphClient(client=client)
+
+        cached.descendants([1, 2], release='r')
+        r2 = cached.descendants([2, 3], release='r')
+
+        assert r2.groups == {2: [20], 3: [30]}   # 2 from cache, 3 fresh
+        assert client.expand.call_count == 2
+        second_missing = client.expand.call_args_list[1].args[0]
+        assert second_missing == [3]             # only the uncached id was fetched
+
+    def test_truncated_source_not_cached(self):
+        client = _mock_client()
+        client.expand.return_value = _res({1: [10]}, truncated=[1])
+        cached = CachedConceptGraphClient(client=client)
+
+        r1 = cached.descendants([1], release='r')
+        r2 = cached.descendants([1], release='r')
+
+        assert r1.truncated == [1]
+        assert client.expand.call_count == 2     # not cached → re-fetched
+
+    def test_mixed_batch_caches_only_clean_sources(self):
+        # Partial-projection safety: in a batch where one source truncates and
+        # another is clean, only the clean one is cached; a later request serves
+        # the clean one from cache and re-fetches the truncated one.
+        client = _mock_client()
+        client.expand.side_effect = [
+            _res({1: [10], 2: [20]}, truncated=[1]),  # 1 truncated, 2 clean
+            _res({1: [10]}, truncated=[1]),           # re-fetch of the uncached 1
+        ]
+        cached = CachedConceptGraphClient(client=client)
+
+        r1 = cached.descendants([1, 2], release='r')
+        assert r1.groups == {1: [10], 2: [20]}
+        assert r1.truncated == [1]
+
+        r2 = cached.descendants([1, 2], release='r')
+        assert r2.groups == {1: [10], 2: [20]}
+        assert client.expand.call_count == 2
+        # Only the truncated id was re-fetched; the clean one came from cache.
+        assert client.expand.call_args_list[1].args[0] == [1]
+
+    def test_failure_not_cached_and_propagates(self):
+        client = _mock_client()
+        client.expand.side_effect = ConceptGraphUnavailable('promop down')
+        cached = CachedConceptGraphClient(client=client)
+
+        with pytest.raises(ConceptGraphUnavailable):
+            cached.descendants([1], release='r')
+
+        # A later successful call must re-invoke the client (nothing was cached).
+        client.expand.side_effect = None
+        client.expand.return_value = _res({1: [10]})
+        assert cached.descendants([1], release='r').groups == {1: [10]}
+        assert client.expand.call_count == 2
+
+    def test_release_required(self):
+        cached = CachedConceptGraphClient(client=_mock_client())
+        with pytest.raises(ValueError):
+            cached.descendants([1], release='')
+
+    def test_bad_direction_raises(self):
+        cached = CachedConceptGraphClient(client=_mock_client())
+        with pytest.raises(ValueError):
+            cached.expand([1], 'sideways', release='r')
+
+    def test_empty_ids_no_client_call(self):
+        client = _mock_client()
+        cached = CachedConceptGraphClient(client=client)
+        res = cached.descendants([], release='r')
+        assert res.groups == {}
+        client.expand.assert_not_called()
+
+    def test_release_scopes_the_key(self):
+        client = _mock_client()
+        client.expand.side_effect = [_res({1: [10]}), _res({1: [99]})]
+        cached = CachedConceptGraphClient(client=client)
+
+        a = cached.descendants([1], release='rel-A')
+        b = cached.descendants([1], release='rel-B')   # different release → separate key
+
+        assert a.groups == {1: [10]}
+        assert b.groups == {1: [99]}
+        assert client.expand.call_count == 2
+
+    def test_relationship_ids_scope_the_key(self):
+        client = _mock_client()
+        client.expand.side_effect = [_res({1: [10]}), _res({1: [20]})]
+        cached = CachedConceptGraphClient(client=client)
+
+        a = cached.descendants([1], release='r', relationship_ids=['Has targeted therapy'])
+        b = cached.descendants([1], release='r', relationship_ids=['Has cytotoxic chemo'])
+
+        assert a.groups == {1: [10]}
+        assert b.groups == {1: [20]}
+        assert client.expand.call_count == 2
+
+    def test_assembles_cached_and_fresh(self):
+        client = _mock_client()
+        client.expand.side_effect = [_res({1: [10]}), _res({2: [20]}, versions=('v2',))]
+        cached = CachedConceptGraphClient(client=client)
+
+        cached.descendants([1], release='r')             # seed cache for 1
+        r = cached.descendants([1, 2], release='r')      # 1 cached, 2 fresh
+
+        assert r.groups == {1: [10], 2: [20]}
+        assert r.versions == frozenset({'v1', 'v2'})
+        second_missing = client.expand.call_args_list[1].args[0]
+        assert second_missing == [2]
+
+    def test_direction_scopes_the_key(self):
+        # A descendants/ancestors collision would be catastrophic — pin it.
+        client = _mock_client()
+        client.expand.side_effect = [_res({1: [10]}), _res({1: [20]})]
+        cached = CachedConceptGraphClient(client=client)
+        d = cached.descendants([1], release='r')
+        a = cached.ancestors([1], release='r')
+        assert d.groups == {1: [10]}
+        assert a.groups == {1: [20]}
+        assert client.expand.call_count == 2
+
+    def test_vocabulary_ids_scope_the_key(self):
+        client = _mock_client()
+        client.expand.side_effect = [_res({1: [10]}), _res({1: [20]})]
+        cached = CachedConceptGraphClient(client=client)
+        cached.descendants([1], release='r', vocabulary_ids=['HemOnc'])
+        cached.descendants([1], release='r', vocabulary_ids=['RxNorm'])
+        assert client.expand.call_count == 2
+
+    def test_concept_class_ids_scope_the_key(self):
+        client = _mock_client()
+        client.expand.side_effect = [_res({1: [10]}), _res({1: [20]})]
+        cached = CachedConceptGraphClient(client=client)
+        cached.descendants([1], release='r', concept_class_ids=['Ingredient'])
+        cached.descendants([1], release='r', concept_class_ids=['Drug Class'])
+        assert client.expand.call_count == 2
+
+    def test_max_levels_scope_the_key(self):
+        client = _mock_client()
+        client.expand.side_effect = [_res({1: [10]}), _res({1: [20]})]
+        cached = CachedConceptGraphClient(client=client)
+        cached.ancestors([1], release='r', max_levels=1)
+        cached.ancestors([1], release='r', max_levels=2)
+        assert client.expand.call_count == 2
+
+    def test_empty_group_is_cached(self):
+        # A legitimately-empty expansion (leaf, not truncated, not raised) is a
+        # KNOWN-empty result and IS cacheable — only Unavailable/truncated must not cache.
+        client = _mock_client()
+        client.expand.return_value = _res({1: []})
+        cached = CachedConceptGraphClient(client=client)
+        r1 = cached.descendants([1], release='r')
+        r2 = cached.descendants([1], release='r')
+        assert r1.groups == {1: []} == r2.groups
+        client.expand.assert_called_once()  # empty result served from cache

--- a/tests/services/omop/test_concept_graph_client.py
+++ b/tests/services/omop/test_concept_graph_client.py
@@ -1,0 +1,231 @@
+"""Tests for ConceptGraphClient — the thin API layer over promop's concept graph (#234).
+
+Contract under test: `expand`/`descendants`/`ancestors` return a `ConceptGraphResult`
+(groups de-duped + sorted, truncation surfaced, versions collected) on success, and
+**raise** `ConceptGraphUnavailable` on any hard failure — unlike CtomopClient, which
+returns None. Raising is deliberate: the graph feeds a persisted eligibility projection,
+so a silent empty expansion would fail open.
+"""
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+from trials.services.omop.concept_graph_client import (
+    ConceptGraphClient,
+    ConceptGraphResult,
+    ConceptGraphUnavailable,
+    GRAPH_MAX_SOURCE_IDS,
+)
+
+PATCH = 'trials.services.omop.concept_graph_client.requests.get'
+
+
+def _resp(json_data, status=200):
+    r = MagicMock()
+    r.ok = 200 <= status < 300
+    r.status_code = status
+    r.reason = 'OK' if r.ok else 'Bad'
+    r.json.return_value = json_data
+    return r
+
+
+def _bad_json(status=200):
+    r = MagicMock()
+    r.ok = True
+    r.status_code = status
+    r.reason = 'OK'
+    r.json.side_effect = ValueError('not json')
+    return r
+
+
+def _client():
+    return ConceptGraphClient(base_url='https://promop.example.com/', token='tk')
+
+
+class TestExpand:
+    def test_descendants_happy(self):
+        body = {
+            'direction': 'descendants',
+            'results': {'9901001': [
+                {'concept_id': 9901002, 'vocabulary_version': 'HemOnc 2024-12-19'},
+                {'concept_id': 9901003, 'vocabulary_version': 'HemOnc 2024-12-19'},
+            ]},
+            'truncated': [],
+        }
+        with patch(PATCH, return_value=_resp(body)) as m:
+            res = _client().descendants([9901001], relationship_ids=['Has targeted therapy'])
+
+        assert isinstance(res, ConceptGraphResult)
+        assert res.groups == {9901001: [9901002, 9901003]}
+        assert res.truncated == []
+        assert res.versions == frozenset({'HemOnc 2024-12-19'})
+
+        # URL + repeatable query params + Bearer auth.
+        assert m.call_args.args[0] == 'https://promop.example.com/api/v1/concepts/graph/'
+        params = m.call_args.kwargs['params']
+        assert ('direction', 'descendants') in params
+        assert ('concept_id', 9901001) in params
+        assert ('relationship_id', 'Has targeted therapy') in params
+        assert m.call_args.kwargs['headers']['Authorization'] == 'Bearer tk'
+        assert m.call_args.kwargs['headers']['Accept'] == 'application/json'
+
+    def test_groups_deduped_and_sorted(self):
+        body = {'results': {'1': [
+            {'concept_id': 30}, {'concept_id': 10}, {'concept_id': 30}, {'concept_id': 20},
+        ]}, 'truncated': []}
+        with patch(PATCH, return_value=_resp(body)):
+            res = _client().descendants([1])
+        assert res.groups == {1: [10, 20, 30]}
+
+    def test_truncation_surfaced(self):
+        body = {'results': {'1': [{'concept_id': 2}]}, 'truncated': [1]}
+        with patch(PATCH, return_value=_resp(body)):
+            res = _client().descendants([1])
+        assert res.truncated == [1]
+
+    def test_batches_over_the_cap(self):
+        ids = list(range(1, 2 * GRAPH_MAX_SOURCE_IDS + 5))  # forces 3 chunks
+        with patch(PATCH, return_value=_resp({'results': {}, 'truncated': []})) as m:
+            _client().descendants(ids)
+        assert m.call_count == 3
+        first = m.call_args_list[0].kwargs['params']
+        assert sum(1 for k, _ in first if k == 'concept_id') == GRAPH_MAX_SOURCE_IDS
+
+    def test_empty_ids_makes_no_call(self):
+        with patch(PATCH) as m:
+            res = _client().descendants([])
+        m.assert_not_called()
+        assert res.groups == {}
+        assert res.truncated == []
+
+    def test_invalid_ids_dropped_before_request(self):
+        with patch(PATCH, return_value=_resp({'results': {'5': []}, 'truncated': []})) as m:
+            _client().descendants(['abc', '5', -1, 0, 5])  # dupes/junk/non-positive
+        cids = [v for k, v in m.call_args.kwargs['params'] if k == 'concept_id']
+        assert cids == [5]
+
+    def test_ancestors_direction(self):
+        with patch(PATCH, return_value=_resp({'results': {}, 'truncated': []})) as m:
+            _client().ancestors([1], max_levels=1, vocabulary_ids=['HemOnc'])
+        params = m.call_args.kwargs['params']
+        assert ('direction', 'ancestors') in params
+        assert ('max_levels', 1) in params
+        assert ('vocabulary_id', 'HemOnc') in params
+
+    def test_bad_direction_raises_value_error(self):
+        with pytest.raises(ValueError):
+            _client().expand([1], 'sideways')
+
+    def test_base_unset_raises(self):
+        client = ConceptGraphClient(base_url='', token='tk')
+        with patch(PATCH) as m:
+            with pytest.raises(ConceptGraphUnavailable):
+                client.descendants([1])
+        m.assert_not_called()
+
+    @pytest.mark.parametrize('status', [400, 401, 403, 404, 500, 503])
+    def test_non_ok_status_raises(self, status):
+        with patch(PATCH, return_value=_resp({}, status=status)):
+            with pytest.raises(ConceptGraphUnavailable):
+                _client().descendants([1])
+
+    def test_network_error_raises(self):
+        with patch(PATCH, side_effect=requests.ConnectionError('boom')):
+            with pytest.raises(ConceptGraphUnavailable):
+                _client().descendants([1])
+
+    def test_timeout_raises(self):
+        with patch(PATCH, side_effect=requests.Timeout('slow')):
+            with pytest.raises(ConceptGraphUnavailable):
+                _client().descendants([1])
+
+    def test_malformed_json_raises(self):
+        with patch(PATCH, return_value=_bad_json()):
+            with pytest.raises(ConceptGraphUnavailable):
+                _client().descendants([1])
+
+    def test_non_dict_body_raises(self):
+        with patch(PATCH, return_value=_resp([{'concept_id': 1}])):
+            with pytest.raises(ConceptGraphUnavailable):
+                _client().descendants([1])
+
+    def test_no_auth_header_when_token_unset(self):
+        client = ConceptGraphClient(base_url='https://promop.example.com', token='')
+        with patch(PATCH, return_value=_resp({'results': {}, 'truncated': []})) as m:
+            client.descendants([1])
+        assert 'Authorization' not in m.call_args.kwargs['headers']
+
+    def test_settings_fallback_to_ctomop(self, settings):
+        settings.PROMOP_API_BASE = ''
+        settings.CTOMOP_BASE = 'https://fallback.example.com'
+        settings.PROMOP_SERVICE_TOKEN = ''
+        settings.CTOMOP_SERVICE_TOKEN = 'ctok'
+        client = ConceptGraphClient()
+        with patch(PATCH, return_value=_resp({'results': {}, 'truncated': []})) as m:
+            client.descendants([1])
+        assert m.call_args.args[0].startswith('https://fallback.example.com/')
+        assert m.call_args.kwargs['headers']['Authorization'] == 'Bearer ctok'
+
+
+class TestExpandHardening:
+    """A 2xx body with the wrong shape is UNUSABLE — it must raise
+    ConceptGraphUnavailable (fail-closed), not escape as a raw
+    AttributeError/TypeError or read as an empty (fail-open) expansion.
+    """
+
+    def test_missing_results_key_raises(self):
+        with patch(PATCH, return_value=_resp({'truncated': []})):
+            with pytest.raises(ConceptGraphUnavailable):
+                _client().descendants([1])
+
+    def test_results_not_dict_raises(self):
+        with patch(PATCH, return_value=_resp({'results': [], 'truncated': []})):
+            with pytest.raises(ConceptGraphUnavailable):
+                _client().descendants([1])
+
+    def test_nodes_not_list_raises(self):
+        with patch(PATCH, return_value=_resp({'results': {'1': 7}, 'truncated': []})):
+            with pytest.raises(ConceptGraphUnavailable):
+                _client().descendants([1])
+
+    def test_node_not_dict_raises(self):
+        with patch(PATCH, return_value=_resp({'results': {'1': [7]}, 'truncated': []})):
+            with pytest.raises(ConceptGraphUnavailable):
+                _client().descendants([1])
+
+    def test_truncated_not_list_raises(self):
+        with patch(PATCH, return_value=_resp({'results': {}, 'truncated': 1})):
+            with pytest.raises(ConceptGraphUnavailable):
+                _client().descendants([1])
+
+    def test_unrequested_source_id_ignored(self):
+        body = {'results': {'1': [{'concept_id': 2}], '999': [{'concept_id': 3}]},
+                'truncated': [999]}
+        with patch(PATCH, return_value=_resp(body)):
+            res = _client().descendants([1])
+        assert res.groups == {1: [2]}          # only the requested id
+        assert 999 not in res.groups
+        assert res.truncated == []             # echoed unrequested id dropped
+
+    def test_merges_across_chunks(self):
+        ids = list(range(1, GRAPH_MAX_SOURCE_IDS + 3))  # 2 chunks: 200 + 2
+        b1 = {'results': {'1': [{'concept_id': 10, 'vocabulary_version': 'v1'}]}, 'truncated': [1]}
+        b2 = {'results': {str(GRAPH_MAX_SOURCE_IDS + 1): [{'concept_id': 99,
+                                                           'vocabulary_version': 'v2'}]},
+              'truncated': []}
+        with patch(PATCH, side_effect=[_resp(b1), _resp(b2)]) as m:
+            res = _client().descendants(ids)
+        assert m.call_count == 2
+        assert res.groups[1] == [10]
+        assert res.groups[GRAPH_MAX_SOURCE_IDS + 1] == [99]
+        assert res.groups[2] == []             # requested, no results → empty
+        assert res.versions == frozenset({'v1', 'v2'})
+        assert res.truncated == [1]
+
+    def test_mid_batch_chunk_error_raises(self):
+        ids = list(range(1, GRAPH_MAX_SOURCE_IDS + 2))  # 2 chunks
+        ok = _resp({'results': {}, 'truncated': []})
+        with patch(PATCH, side_effect=[ok, _resp({}, status=500)]):
+            with pytest.raises(ConceptGraphUnavailable):
+                _client().descendants(ids)

--- a/trials/services/omop/concept_graph_cache.py
+++ b/trials/services/omop/concept_graph_cache.py
@@ -1,0 +1,154 @@
+"""Release-pinned cache over ConceptGraphClient (#234 slice 2; promop ADR 0001 / promop#279).
+
+Access is API + cache: promop is the source of truth; this is the consumer-side cache.
+Per the ADR's consumer-conformance rules:
+
+- **Per-source caching.** Each source concept_id's expansion is cached independently, so a
+  regimen that recurs across many trials is fetched once and reused. A request expands the
+  cache-miss ids in a single batched client call, then assembles the full result.
+- **Release-pinned key.** The cache key includes an explicit ``release`` pin (the promop
+  release id, once promop emits one — until then a caller-supplied stand-in such as a pinned
+  vocabulary version). ``release`` is REQUIRED: caching vocabulary data without a version is
+  a correctness bug (a release bump silently serves stale expansions), so an empty ``release``
+  raises. Two sides matched against each other (patient vs trial) must pin the SAME release.
+  LIMITATION: the pin is a cache NAMESPACE + the TTL bounds intra-release staleness; it is
+  not sent to promop or verified against the response, because promop does not yet accept a
+  release param nor stamp a release id (promop#279). Until it does, a release bump is
+  invalidated by the new key + old entries expiring via TTL — not by end-to-end enforcement.
+
+KNOWN LIMITATION (fix before matcher wiring): ``versions`` is cached per source but is the
+batch-level union the client returns, not the source's own versions — a single-source hit
+can report versions from other concepts fetched in the same batch. Harmless while
+``versions`` is observability-only; authoritative provenance moves to the promop release id
+(promop#279), which supersedes this field.
+- **Fail-closed.** Client failures (``ConceptGraphUnavailable``) are never cached and always
+  propagate — the caller applies its fail-closed policy. A **truncated** source (its result
+  hit promop's node cap → incomplete) is never cached, so a partial projection is not
+  persisted; it stays in the result's ``truncated`` list for the caller to fail-closed on.
+
+Backend: Django's cache framework (``caches[alias]``). Production points the alias at a
+**DB-backed cache** (shared across Redis-less Cloud Run instances); tests use LocMemCache.
+"""
+import hashlib
+import json
+
+from django.conf import settings
+from django.core.cache import InvalidCacheBackendError, caches
+
+from trials.services.omop.concept_graph_client import (
+    ConceptGraphClient,
+    ConceptGraphResult,
+    _positive_ints,
+)
+
+DEFAULT_TTL_SECONDS = 3600  # 1h; a release bump invalidates via the release-pinned key
+_KEY_PREFIX = 'cgc'
+# Bump when the cache key or stored-value shape changes, to invalidate old entries.
+_CACHE_SCHEMA = 'v1'
+
+
+def _key_prefix(release, direction, relationship_ids, vocabulary_ids,
+                concept_class_ids, max_levels) -> str:
+    """Stable hash of everything that scopes an expansion except the source id.
+
+    Full SHA-256 (no truncation) so distinct scopes cannot collide; the schema tag
+    lets a shape change invalidate every entry.
+    """
+    payload = json.dumps([
+        _CACHE_SCHEMA, str(release), direction,
+        sorted(relationship_ids or []),
+        sorted(vocabulary_ids or []),
+        sorted(concept_class_ids or []),
+        max_levels,
+    ], sort_keys=True)
+    return hashlib.sha256(payload.encode('utf-8')).hexdigest()
+
+
+class CachedConceptGraphClient:
+    def __init__(self, client: ConceptGraphClient | None = None,
+                 cache_alias: str | None = None, ttl: int = DEFAULT_TTL_SECONDS):
+        self.client = client or ConceptGraphClient()
+        # Prod must point CONCEPT_GRAPH_CACHE_ALIAS at a SHARED (DB-backed) cache:
+        # the 'default' alias is Redis-when-configured else per-process LocMemCache
+        # (see exact/cache_config.py), so on Redis-less Cloud Run the default is
+        # per-worker and defeats cross-instance reuse. Configuring the DB-backed
+        # alias + its cache table is a follow-up (slice 2b). Falls back to 'default'
+        # so an unconfigured alias never raises.
+        alias = cache_alias or getattr(settings, 'CONCEPT_GRAPH_CACHE_ALIAS', 'default')
+        try:
+            self.cache = caches[alias]
+        except InvalidCacheBackendError:
+            self.cache = caches['default']
+        self.ttl = ttl
+
+    def descendants(self, concept_ids, *, release, relationship_ids=None, **kwargs):
+        return self.expand(concept_ids, 'descendants', release=release,
+                           relationship_ids=relationship_ids, **kwargs)
+
+    def ancestors(self, concept_ids, *, release, relationship_ids=None, **kwargs):
+        return self.expand(concept_ids, 'ancestors', release=release,
+                           relationship_ids=relationship_ids, **kwargs)
+
+    def expand(self, concept_ids, direction, *, release,
+               relationship_ids=None, vocabulary_ids=None, concept_class_ids=None,
+               max_levels=None) -> ConceptGraphResult:
+        """Cached counterpart to ``ConceptGraphClient.expand``.
+
+        ``release`` (required, non-empty) pins the promop release the cache is keyed on.
+        Raises ``ValueError`` for an empty ``release`` or a bad ``direction``, and lets
+        ``ConceptGraphUnavailable`` from the underlying client propagate (never cached).
+        """
+        if not release:
+            raise ValueError('release pin is required (cache must be release-keyed)')
+        if direction not in ('ancestors', 'descendants'):
+            raise ValueError(f'bad direction: {direction!r}')
+
+        source_ids = _positive_ints(concept_ids)
+        if not source_ids:
+            return ConceptGraphResult(groups={}, truncated=[], versions=frozenset())
+
+        prefix = _key_prefix(release, direction, relationship_ids,
+                             vocabulary_ids, concept_class_ids, max_levels)
+
+        groups: dict[int, list[int]] = {}
+        versions: set[str] = set()
+        truncated: set[int] = set()
+        missing: list[int] = []
+
+        for cid in source_ids:
+            entry = self.cache.get(f'{_KEY_PREFIX}:{prefix}:{cid}')
+            if entry is None:
+                missing.append(cid)
+            else:
+                groups[cid] = entry['groups']
+                versions.update(entry['versions'])
+
+        if missing:
+            # One batched fetch for the misses; raises → nothing cached, propagates.
+            res = self.client.expand(
+                missing, direction,
+                relationship_ids=relationship_ids,
+                vocabulary_ids=vocabulary_ids,
+                concept_class_ids=concept_class_ids,
+                max_levels=max_levels,
+            )
+            versions.update(res.versions)
+            res_versions = sorted(res.versions)
+            for cid in missing:
+                g = res.groups.get(cid, [])
+                groups[cid] = g
+                if cid in res.truncated:
+                    # Incomplete — surface but do NOT cache a partial projection.
+                    truncated.add(cid)
+                else:
+                    self.cache.set(
+                        f'{_KEY_PREFIX}:{prefix}:{cid}',
+                        {'groups': g, 'versions': res_versions},
+                        self.ttl,
+                    )
+
+        return ConceptGraphResult(
+            groups={cid: groups[cid] for cid in source_ids},
+            truncated=sorted(truncated),
+            versions=frozenset(versions),
+        )

--- a/trials/services/omop/concept_graph_client.py
+++ b/trials/services/omop/concept_graph_client.py
@@ -1,0 +1,235 @@
+"""HTTP client for promop's concept-graph API (#234; promop ADR 0001 / promop#279).
+
+Access is **API + cache**: promop is the single source of truth for vocabulary and
+concept-graph data; EXACT keeps no local copy. This module is slice 1 — the thin API
+client. The cache layer (DB-backed, release-pinned) and the matcher/backfill wiring
+land in follow-up slices of #234.
+
+**Failure contract differs deliberately from `CtomopClient`.** `CtomopClient.fetch_patient`
+returns ``None`` on any failure because a missing patient payload is benign (public trial
+browsing still works). The concept graph instead feeds a PERSISTED eligibility projection
+(trial-side backfill) and per-trial matching; silently returning an empty expansion would
+fail *open* — dropping a required-component constraint or persisting a partial projection.
+So this client **raises** ``ConceptGraphUnavailable`` on any hard failure, and surfaces
+promop's per-source node-cap ``truncated`` signal in the result. Callers apply the
+fail-closed policy explicitly:
+
+- backfill: let ``ConceptGraphUnavailable`` / a non-empty ``truncated`` propagate → fail the
+  run and preserve existing column values (never persist a partial projection);
+- request-time: catch → treat as ``unknown`` (never fail-open to matched).
+
+Config falls back to the ``CTOMOP_*`` settings (same promop host) until the dedicated
+OAuth2 path (#237) lands. Cache identity must eventually key on a promop **release id**
+(promop#279); until promop emits one, callers can only observe per-vocabulary
+``versions`` — see the ``ConceptGraphResult.versions`` TODO.
+"""
+import logging
+from dataclasses import dataclass
+
+import requests
+from django.conf import settings
+
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_TIMEOUT_SECONDS = 10
+# promop's batch graph endpoint accepts at most this many source ids per request.
+GRAPH_MAX_SOURCE_IDS = 200
+_DIRECTIONS = frozenset({'ancestors', 'descendants'})
+
+
+class ConceptGraphError(Exception):
+    """Base class for concept-graph client failures."""
+
+
+class ConceptGraphUnavailable(ConceptGraphError):
+    """promop could not be reached or returned an unusable response.
+
+    Raised for: unconfigured base URL, network error/timeout, non-2xx status,
+    non-JSON body, a non-object payload, or a structurally invalid payload
+    (missing/non-dict ``results``, a non-list node list, a non-object node, or a
+    non-list ``truncated``). Callers fail-closed on this — never fall through to
+    an empty expansion, which would fail open.
+    """
+
+
+@dataclass(frozen=True)
+class ConceptGraphResult:
+    """Outcome of a graph traversal.
+
+    ``groups`` maps each source concept_id to its de-duplicated, sorted list of
+    related concept_ids. ``truncated`` lists source ids whose result hit promop's
+    per-source node cap (their ``groups`` entry is incomplete — treat as
+    fail-closed at the call site). ``versions`` is the set of per-vocabulary
+    versions seen across the returned nodes (observability only; the real cache
+    key is a promop release id once promop#279 emits one).
+    """
+    groups: dict[int, list[int]]
+    truncated: list[int]
+    versions: frozenset[str]
+
+
+def _positive_ints(values):
+    """Coerce an iterable to a de-duplicated, order-preserving list of positive ints.
+
+    Non-integer / non-positive values are dropped (they cannot be concept_ids and
+    must not reach the URL as query params)."""
+    seen: set[int] = set()
+    out: list[int] = []
+    for v in values or []:
+        try:
+            iv = int(v)
+        except (TypeError, ValueError):
+            continue
+        if iv > 0 and iv not in seen:
+            seen.add(iv)
+            out.append(iv)
+    return out
+
+
+def _chunks(seq, size):
+    for i in range(0, len(seq), size):
+        yield seq[i:i + size]
+
+
+class ConceptGraphClient:
+    def __init__(self, base_url: str | None = None, token: str | None = None,
+                 timeout: float = DEFAULT_TIMEOUT_SECONDS):
+        self.base_url = (
+            base_url if base_url is not None
+            else (getattr(settings, 'PROMOP_API_BASE', '')
+                  or getattr(settings, 'CTOMOP_BASE', ''))
+        ).rstrip('/')
+        self.token = (
+            token if token is not None
+            else (getattr(settings, 'PROMOP_SERVICE_TOKEN', '')
+                  or getattr(settings, 'CTOMOP_SERVICE_TOKEN', ''))
+        )
+        self.timeout = timeout
+
+    # ── public API ──────────────────────────────────────────────────────────
+
+    def descendants(self, concept_ids, relationship_ids=None, **kwargs) -> ConceptGraphResult:
+        """Downstream traversal (regimen → components, class → members)."""
+        return self.expand(concept_ids, 'descendants', relationship_ids=relationship_ids, **kwargs)
+
+    def ancestors(self, concept_ids, relationship_ids=None, **kwargs) -> ConceptGraphResult:
+        """Upstream traversal (component → drug class / superclass)."""
+        return self.expand(concept_ids, 'ancestors', relationship_ids=relationship_ids, **kwargs)
+
+    def expand(self, concept_ids, direction, relationship_ids=None,
+               vocabulary_ids=None, concept_class_ids=None,
+               max_levels=None) -> ConceptGraphResult:
+        """Batch-traverse the concept graph via ``GET /api/v1/concepts/graph/``.
+
+        Chunks source ids to promop's ``GRAPH_MAX_SOURCE_IDS`` cap and merges the
+        responses. Raises ``ValueError`` on a bad ``direction`` and
+        ``ConceptGraphUnavailable`` on any transport/payload failure. Returns an
+        empty result (no network call) when no valid source ids are supplied.
+        """
+        if direction not in _DIRECTIONS:
+            raise ValueError(f"direction must be one of {sorted(_DIRECTIONS)}, got {direction!r}")
+
+        source_ids = _positive_ints(concept_ids)
+        if not source_ids:
+            return ConceptGraphResult(groups={}, truncated=[], versions=frozenset())
+        if not self.base_url:
+            raise ConceptGraphUnavailable('PROMOP_API_BASE / CTOMOP_BASE is not configured')
+
+        groups: dict[int, set[int]] = {cid: set() for cid in source_ids}
+        truncated: set[int] = set()
+        versions: set[str] = set()
+
+        for chunk in _chunks(source_ids, GRAPH_MAX_SOURCE_IDS):
+            params: list[tuple[str, object]] = [('direction', direction)]
+            params += [('concept_id', cid) for cid in chunk]
+            params += [('relationship_id', r) for r in (relationship_ids or [])]
+            params += [('vocabulary_id', v) for v in (vocabulary_ids or [])]
+            params += [('concept_class_id', c) for c in (concept_class_ids or [])]
+            if max_levels is not None:
+                params.append(('max_levels', max_levels))
+
+            payload = self._get(params)
+
+            # Strict structural validation. A 2xx body with the wrong shape
+            # (missing/!dict `results`, a non-list node list, a non-object node,
+            # a non-list `truncated`) is an UNUSABLE response — surface it as
+            # ConceptGraphUnavailable so callers keep their fail-closed policy,
+            # rather than letting a raw AttributeError/TypeError escape or a
+            # `results`-less body read as an empty (fail-open) expansion.
+            results = payload.get('results')
+            if not isinstance(results, dict):
+                raise ConceptGraphUnavailable("response is missing a 'results' object")
+            for key, nodes in results.items():
+                try:
+                    src = int(key)
+                except (TypeError, ValueError):
+                    continue
+                if src not in groups:
+                    # Ignore source ids we did not request (echo / injection).
+                    continue
+                if not isinstance(nodes, list):
+                    raise ConceptGraphUnavailable(f"'results[{key}]' is not a list")
+                bucket = groups[src]
+                for node in nodes:
+                    if not isinstance(node, dict):
+                        raise ConceptGraphUnavailable("a graph node is not an object")
+                    ncid = node.get('concept_id')
+                    if ncid is not None:
+                        try:
+                            bucket.add(int(ncid))
+                        except (TypeError, ValueError):
+                            pass
+                    ver = node.get('vocabulary_version')
+                    if ver:
+                        versions.add(ver)
+
+            raw_truncated = payload.get('truncated', [])
+            if not isinstance(raw_truncated, list):
+                raise ConceptGraphUnavailable("'truncated' is not a list")
+            for t in raw_truncated:
+                try:
+                    tv = int(t)
+                except (TypeError, ValueError):
+                    continue
+                if tv in groups:  # only requested ids
+                    truncated.add(tv)
+
+        if truncated:
+            logger.warning('ConceptGraphClient: %d source concept(s) truncated at the '
+                           'node cap (%s): %s', len(truncated), direction, sorted(truncated))
+
+        return ConceptGraphResult(
+            groups={cid: sorted(v) for cid, v in groups.items()},
+            truncated=sorted(truncated),
+            versions=frozenset(versions),
+        )
+
+    # ── internal ────────────────────────────────────────────────────────────
+
+    def _get(self, params) -> dict:
+        url = f'{self.base_url}/api/v1/concepts/graph/'
+        headers = {'Accept': 'application/json'}
+        if self.token:
+            headers['Authorization'] = f'Bearer {self.token}'
+
+        try:
+            resp = requests.get(url, params=params, headers=headers, timeout=self.timeout)
+        except requests.RequestException as exc:
+            logger.warning('ConceptGraphClient network error: %s', exc)
+            raise ConceptGraphUnavailable(f'network error: {exc}') from exc
+
+        if not resp.ok:
+            logger.warning('ConceptGraphClient non-OK response: %s %s',
+                           resp.status_code, resp.reason)
+            raise ConceptGraphUnavailable(f'{resp.status_code} {resp.reason}')
+
+        try:
+            data = resp.json()
+        except ValueError as exc:
+            logger.warning('ConceptGraphClient non-JSON body')
+            raise ConceptGraphUnavailable('non-JSON response') from exc
+
+        if not isinstance(data, dict):
+            raise ConceptGraphUnavailable(f'expected a JSON object, got {type(data).__name__}')
+        return data


### PR DESCRIPTION
## Summary

Foundation for **#234** (promop ADR 0001 / promop#279): consume promop's concept-graph API
via **API + cache**, on the way to dropping EXACT's local OMOP vocab copies. Two slices,
net-new code in `trials/services/omop/`, **not wired into runtime yet** (matcher/backfill
wiring + the Phase T data-model prerequisites are separate — see follow-ups).

## What's here

- **`ConceptGraphClient`** (`concept_graph_client.py`) — thin client over
  `GET /api/v1/concepts/graph/`: batch (≤200 sources), truncation surfaced, dedup+sorted
  groups, version collection. Unlike `CtomopClient` (returns `None`), it **raises
  `ConceptGraphUnavailable`** on any unusable response — missing/non-dict `results`, a
  non-list node list, a non-object node, a non-list `truncated`, or network/non-2xx/non-JSON
  — so callers keep a strict **fail-closed** policy (the graph feeds a persisted eligibility
  projection where a silent-empty expansion would fail open). Echoed unrequested source ids
  are ignored.
- **`CachedConceptGraphClient`** (`concept_graph_cache.py`) — release-pinned, **per-source**
  cache so a regimen recurring across many trials is fetched once. Fail-closed: client
  failures and **truncated** sources are never cached (no partial projection persisted). Key
  = full SHA-256(schema, release, direction, relationship/vocab/class filters, max_levels)
  per source id.
- Settings: `PROMOP_API_BASE` / `PROMOP_SERVICE_TOKEN` (fallback to `CTOMOP_*` until the
  OAuth2 path, #237).
- **45 unit tests.** Each slice reviewed via codex + a fresh-context reviewer; findings
  reconciled before commit and again pre-PR.

## Known limitations / follow-ups (documented in code)

- **Release pin is a cache namespace + TTL, not end-to-end enforced** — promop does not yet
  accept a release param nor stamp a release id (promop#279). A release bump invalidates via
  the new key + TTL expiry, not by verifying the response's release. Close when promop#279
  lands. (Flagged by review; accepted for this unwired slice.)
- **`versions` is batch-level** — a single-source cache hit can report versions of other
  concepts fetched in the same batch. Observability-only; **fix before matcher wiring**
  (superseded by release_id).
- **DB-backed cache alias** — prod must point `CONCEPT_GRAPH_CACHE_ALIAS` at a shared
  DB-backed cache; the `default` alias is per-worker LocMem on Redis-less Cloud Run. Alias +
  cache table is a follow-up (slice 2b).
- **retry/backoff** on transport → tie to #168 (circuit breaker / bulkhead).
- **Wiring** — Phase P (patient-side read of `therapy_component_ids`) and Phase T (trial-side
  backfill) are next; Phase T is blocked on promop data-model prerequisites (line/episode-
  scoped component groups, source-asserted regimen identity, release_id). See #232, #224.

Refs: #234, #232, #233, #224, #237, #168; promop ADR 0001 (promop#279).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
