### PR TITLE
feat(omop): Phase P — patient components from consumer, not local CB graph (#234)

### DIFF
--- a/tests/querysets/test_custom_search_dispatch.py
+++ b/tests/querysets/test_custom_search_dispatch.py
@@ -131,7 +131,7 @@ class TestTherapyLinesOnceFlag:
 
     def test_first_call_applies_filter_and_flips_flag(self):
         scope = MagicMock(spec=TrialQuerySet)
-        ctx = {'is_therapies_filter_applied': False,
+        ctx = {'is_therapies_filter_applied': False, 'patient_info_attr': MagicMock(),
                'user_therapies': {}, 'has_no_prior_therapy': False}
         _filter_therapy_lines_once(scope, None, ctx)
         assert ctx['is_therapies_filter_applied'] is True
@@ -139,7 +139,7 @@ class TestTherapyLinesOnceFlag:
 
     def test_second_call_is_no_op(self):
         scope = MagicMock(spec=TrialQuerySet)
-        ctx = {'is_therapies_filter_applied': True,
+        ctx = {'is_therapies_filter_applied': True, 'patient_info_attr': MagicMock(),
                'user_therapies': {}, 'has_no_prior_therapy': False}
         result = _filter_therapy_lines_once(scope, None, ctx)
         assert ctx['is_therapies_filter_applied'] is True

--- a/tests/services/test_omop_component_type_matching.py
+++ b/tests/services/test_omop_component_type_matching.py
@@ -1,13 +1,13 @@
-"""OMOP component + type matching via the CB graph (#197 design).
+"""OMOP component + type matching under Phase P (#234).
 
 Under EXACT_OMOP_THERAPY:
-- regimen + component match on OMOP concept_ids (omop_* columns);
-- type/category is NOT OMOP-mapped — matched through the CB graph
-  (categories ↔ components ↔ therapies) against the LEGACY therapy_types_* columns.
-
-The matcher reverse-maps the patient's regimen concept_ids to internal Therapies
-(Therapy.omop_concept_id), walks to components (→ their OMOP concept_ids) and to
-categories (→ CB codes).
+- regimen matches on OMOP concept_ids (omop_therapies_* columns);
+- component match-values are the consumer-supplied PRE-EXPANDED concept_ids
+  (PatientInfo.therapy_component_ids), NOT reverse-mapped from the regimen via the
+  local CB graph;
+- type/category is NOT OMOP-mapped — resolved from the patient's component concept_ids
+  via the flat ComponentCategoryOmopLookup (CB category codes), matched against the
+  LEGACY therapy_types_* columns.
 """
 import pytest
 from django.test import override_settings
@@ -36,10 +36,9 @@ def _graph():
     TherapyComponentConnection.objects.create(therapy=vrd, component=bort)
     TherapyComponentConnection.objects.create(therapy=vrd, component=lena)
     TherapyComponentCategoryConnection.objects.create(category=pi_cat, component=bort)
-    # Under OMOP, type resolution reads the flat ComponentCategoryOmopLookup
-    # (a04be17 / ADR 0001-A / #4502), not the M2M graph. Production has no live
-    # post_save sync — the loader/rebuild command populates it explicitly — so the
-    # test must sync after wiring the graph, or type_values come back empty.
+    # Type resolution reads the flat ComponentCategoryOmopLookup (ADR 0001-A / #4502).
+    # Production has no live post_save sync — the loader/rebuild command populates it —
+    # so the test must sync after wiring the graph, or type_values come back empty.
     sync_component_category_lookup()
     return vrd, bort, lena, pi_cat
 
@@ -55,38 +54,42 @@ def test_derive_legacy_codes_when_flag_off():
 
 
 @override_settings(EXACT_OMOP_THERAPY=True)
-def test_derive_concept_ids_for_components_cb_codes_for_types_when_flag_on():
+def test_derive_uses_consumer_supplied_component_ids_when_flag_on():
     _graph()
-    comps, types = derive_component_and_type_values([str(VRD_CID)])  # patient sends regimen concept_id
-    assert sorted(comps) == [str(BORT_CID), str(LEN_CID)]    # component OMOP concept_ids
-    assert types == ['zz_proteasome_inh']                    # types stay CB codes (not OMOP-mapped)
+    # Phase P: components come from the pre-expanded ids, not the regimen.
+    comps, types = derive_component_and_type_values([str(VRD_CID)], [str(BORT_CID), str(LEN_CID)])
+    assert sorted(comps) == [str(BORT_CID), str(LEN_CID)]    # consumer-supplied concept_ids
+    assert types == ['zz_proteasome_inh']                    # types stay CB codes (flat lookup)
 
 
 @override_settings(EXACT_OMOP_THERAPY=True)
-def test_derive_none_when_regimen_concept_unknown():
+def test_derive_none_component_ids_is_unknown():
     _graph()
-    assert derive_component_and_type_values(['99999999']) == (None, None)
+    # Consumer sent no therapy_component_ids → unknown (None), not known-empty.
+    assert derive_component_and_type_values([str(VRD_CID)], None) == (None, None)
 
 
 @override_settings(EXACT_OMOP_THERAPY=True)
-def test_derive_none_for_components_when_all_component_concept_ids_null():
-    """B1 regression: regimen found but all its components have omop_concept_id=NULL.
-    Must return component_values=None (unknown) not [] (no components), so
-    _match_therapy_things treats it as unknown rather than not_matched."""
-    vrd = Therapy.objects.create(code='zz_vrd_b1', title='zz VRd B1', omop_concept_id=900991)
-    comp = TherapyComponent.objects.create(code='zz_bort_b1', title='zz Bort B1', omop_concept_id=None)
-    TherapyComponentConnection.objects.create(therapy=vrd, component=comp)
-
-    component_values, _ = derive_component_and_type_values(['900991'])
-    assert component_values is None
+def test_derive_empty_component_ids_is_known_empty():
+    _graph()
+    assert derive_component_and_type_values([str(VRD_CID)], []) == ([], [])
 
 
-# ── matcher: component level on OMOP concepts ────────────────────────
+@override_settings(EXACT_OMOP_THERAPY=True)
+def test_derive_ignores_regimen_under_omop():
+    _graph()
+    # The regimen list is irrelevant to components under Phase P — only the
+    # supplied component ids drive the result.
+    comps, _ = derive_component_and_type_values(['99999999'], [str(BORT_CID)])
+    assert comps == [str(BORT_CID)]
+
+
+# ── matcher: component level on consumer-supplied concept_ids ─────────
 
 @override_settings(EXACT_OMOP_THERAPY=True)
 def test_component_required_matches_via_concept_id():
     _graph()
-    pi = PatientInfo(disease='multiple myeloma')
+    pi = PatientInfo(disease='multiple myeloma', therapy_component_ids=[BORT_CID, LEN_CID])
     trial = TrialFactory(disease='multiple myeloma', omop_therapy_components_required=[str(BORT_CID)])
     res = UserToTrialAttrMatcher(trial, pi)._match_therapy_related_things([str(VRD_CID)], False)
     assert res == 'matched'
@@ -95,18 +98,18 @@ def test_component_required_matches_via_concept_id():
 @override_settings(EXACT_OMOP_THERAPY=True)
 def test_component_excluded_blocks_via_concept_id():
     _graph()
-    pi = PatientInfo(disease='multiple myeloma')
+    pi = PatientInfo(disease='multiple myeloma', therapy_component_ids=[BORT_CID, LEN_CID])
     trial = TrialFactory(disease='multiple myeloma', omop_therapy_components_excluded=[str(BORT_CID)])
     res = UserToTrialAttrMatcher(trial, pi)._match_therapy_related_things([str(VRD_CID)], False)
     assert res == 'not_matched'
 
 
-# ── matcher: type level via CB category graph (legacy column) ─────────
+# ── matcher: type level via the flat category lookup (legacy column) ──
 
 @override_settings(EXACT_OMOP_THERAPY=True)
-def test_type_required_matches_via_cb_category_graph():
+def test_type_required_matches_via_component_category_lookup():
     _graph()
-    pi = PatientInfo(disease='multiple myeloma')
+    pi = PatientInfo(disease='multiple myeloma', therapy_component_ids=[BORT_CID])
     # type column stays LEGACY (CB code) even under OMOP
     trial = TrialFactory(disease='multiple myeloma', therapy_types_required=['zz_proteasome_inh'])
     res = UserToTrialAttrMatcher(trial, pi)._match_therapy_related_things([str(VRD_CID)], False)
@@ -114,22 +117,21 @@ def test_type_required_matches_via_cb_category_graph():
 
 
 @override_settings(EXACT_OMOP_THERAPY=True)
-def test_type_excluded_blocks_via_cb_category_graph():
+def test_type_excluded_blocks_via_component_category_lookup():
     _graph()
-    pi = PatientInfo(disease='multiple myeloma')
+    pi = PatientInfo(disease='multiple myeloma', therapy_component_ids=[BORT_CID])
     trial = TrialFactory(disease='multiple myeloma', therapy_types_excluded=['zz_proteasome_inh'])
     res = UserToTrialAttrMatcher(trial, pi)._match_therapy_related_things([str(VRD_CID)], False)
     assert res == 'not_matched'
 
-
-# ── legacy unchanged ─────────────────────────────────────────────────
 
 # ── detail display (therapy_related_things_match_status) under OMOP ───
 
 @override_settings(EXACT_OMOP_THERAPY=True)
 def test_display_component_required_status_via_concept_id():
     _graph()
-    pi = PatientInfo(disease='multiple myeloma', first_line_therapy=str(VRD_CID), prior_therapy='One line')
+    pi = PatientInfo(disease='multiple myeloma', first_line_therapy=str(VRD_CID),
+                     prior_therapy='One line', therapy_component_ids=[BORT_CID])
     trial = TrialFactory(disease='multiple myeloma', omop_therapy_components_required=[str(BORT_CID)])
     out = UserToTrialAttrMatcher(trial, pi).therapy_related_things_match_status()
     assert out['therapyComponentsRequired']['status'] == 'matched'
@@ -138,28 +140,46 @@ def test_display_component_required_status_via_concept_id():
 @override_settings(EXACT_OMOP_THERAPY=True)
 def test_display_component_excluded_status_via_concept_id():
     _graph()
-    pi = PatientInfo(disease='multiple myeloma', first_line_therapy=str(VRD_CID), prior_therapy='One line')
+    pi = PatientInfo(disease='multiple myeloma', first_line_therapy=str(VRD_CID),
+                     prior_therapy='One line', therapy_component_ids=[BORT_CID])
     trial = TrialFactory(disease='multiple myeloma', omop_therapy_components_excluded=[str(BORT_CID)])
     out = UserToTrialAttrMatcher(trial, pi).therapy_related_things_match_status()
     assert out['therapyComponentsExcluded']['status'] == 'not_matched'
 
 
 @override_settings(EXACT_OMOP_THERAPY=True)
-def test_display_type_required_status_via_cb_graph():
+def test_display_type_required_status_via_lookup():
     _graph()
-    pi = PatientInfo(disease='multiple myeloma', first_line_therapy=str(VRD_CID), prior_therapy='One line')
+    pi = PatientInfo(disease='multiple myeloma', first_line_therapy=str(VRD_CID),
+                     prior_therapy='One line', therapy_component_ids=[BORT_CID])
     trial = TrialFactory(disease='multiple myeloma', therapy_types_required=['zz_proteasome_inh'])
     out = UserToTrialAttrMatcher(trial, pi).therapy_related_things_match_status()
     assert out['therapyTypesRequired']['status'] == 'matched'
 
 
 @override_settings(EXACT_OMOP_THERAPY=True)
-def test_display_type_excluded_status_via_cb_graph():
+def test_display_type_excluded_status_via_lookup():
     _graph()
-    pi = PatientInfo(disease='multiple myeloma', first_line_therapy=str(VRD_CID), prior_therapy='One line')
+    pi = PatientInfo(disease='multiple myeloma', first_line_therapy=str(VRD_CID),
+                     prior_therapy='One line', therapy_component_ids=[BORT_CID])
     trial = TrialFactory(disease='multiple myeloma', therapy_types_excluded=['zz_proteasome_inh'])
     out = UserToTrialAttrMatcher(trial, pi).therapy_related_things_match_status()
     assert out['therapyTypesExcluded']['status'] == 'not_matched'
+
+
+@override_settings(EXACT_OMOP_THERAPY=True)
+def test_display_component_title_falls_back_to_concept_id_when_not_local():
+    """Primary Phase P case: promop supplies a component concept_id EXACT holds no
+    local TherapyComponent row for. The display must fall back to the concept_id
+    string (a None title would TypeError in match_required's sorted(set(values)))."""
+    _graph()  # local rows exist for BORT_CID / LEN_CID only
+    unmapped = 999123456
+    pi = PatientInfo(disease='multiple myeloma', first_line_therapy=str(VRD_CID),
+                     prior_therapy='One line', therapy_component_ids=[BORT_CID, unmapped])
+    trial = TrialFactory(disease='multiple myeloma', omop_therapy_components_required=[str(BORT_CID)])
+    out = UserToTrialAttrMatcher(trial, pi).therapy_related_things_match_status()  # must not crash
+    assert out['therapyComponentsRequired']['status'] == 'matched'
+    assert str(unmapped) in out['therapyComponentsRequired']['values']  # shown by concept_id
 
 
 # ── detail response: OMOP code + title (omopConcepts) ────────────────
@@ -168,7 +188,8 @@ def test_display_type_excluded_status_via_cb_graph():
 def test_display_includes_omop_concepts_code_and_title():
     _graph()
     OmopConcept.objects.create(concept_id=BORT_CID, concept_name='bortezomib', vocabulary_id='RxNorm')
-    pi = PatientInfo(disease='multiple myeloma', first_line_therapy=str(VRD_CID), prior_therapy='One line')
+    pi = PatientInfo(disease='multiple myeloma', first_line_therapy=str(VRD_CID),
+                     prior_therapy='One line', therapy_component_ids=[BORT_CID])
     trial = TrialFactory(disease='multiple myeloma', omop_therapy_components_required=[str(BORT_CID)])
     out = UserToTrialAttrMatcher(trial, pi).therapy_related_things_match_status()
     assert out['therapyComponentsRequired']['omopConcepts'] == [
@@ -181,7 +202,8 @@ def test_display_includes_omop_concepts_code_and_title():
 @override_settings(EXACT_OMOP_THERAPY=True)
 def test_omop_concepts_unresolved_keeps_code():
     _graph()  # no OmopConcept row for BORT_CID
-    pi = PatientInfo(disease='multiple myeloma', first_line_therapy=str(VRD_CID), prior_therapy='One line')
+    pi = PatientInfo(disease='multiple myeloma', first_line_therapy=str(VRD_CID),
+                     prior_therapy='One line', therapy_component_ids=[BORT_CID])
     trial = TrialFactory(disease='multiple myeloma', omop_therapy_components_required=[str(BORT_CID)])
     out = UserToTrialAttrMatcher(trial, pi).therapy_related_things_match_status()
     assert out['therapyComponentsRequired']['omopConcepts'] == [
@@ -197,6 +219,8 @@ def test_no_omop_concepts_field_when_flag_off():
     out = UserToTrialAttrMatcher(trial, pi).therapy_related_things_match_status()
     assert 'omopConcepts' not in out['therapyComponentsRequired']
 
+
+# ── legacy unchanged ─────────────────────────────────────────────────
 
 @override_settings(EXACT_OMOP_THERAPY=False)
 def test_legacy_component_and_type_still_match_by_code():

--- a/tests/test_omop_real_concept_ids.py
+++ b/tests/test_omop_real_concept_ids.py
@@ -107,44 +107,29 @@ PI_CAT_DEX  = 'corticosteroid'
 PI_CAT_DARA = 'monoclonal_antibody_(anti_cd38)'
 
 
-# ── component/type derivation from real vocab ────────────────────────────────
+# ── Phase P: components are consumer-supplied (promop pre-expanded), not derived ──
+# Regimen → its component concept_ids, i.e. what promop pre-expands onto the patient.
+REGIMEN_COMPONENTS = {
+    VRD:       [BORT, LEN, DEX],
+    KRD:       [CARF, LEN, DEX],
+    DARA_VRD:  [BORT, LEN, DEX, DARA],
+    DARA_MONO: [DARA],
+    BORT_MONO: [BORT],
+    LEN_MONO:  [LEN],
+    CARF_MONO: [CARF],
+}
 
-def test_vrd_derives_correct_components():
-    comps, types = derive_component_and_type_values([VRD])
+
+def test_derive_uses_supplied_components_and_maps_types():
+    comps, types = derive_component_and_type_values([VRD], REGIMEN_COMPONENTS[VRD])
     assert sorted(comps) == sorted([BORT, LEN, DEX])
     assert PI_CAT_BORT in types
     assert PI_CAT_LEN in types
     assert PI_CAT_DEX in types
 
 
-def test_krd_derives_correct_components():
-    comps, types = derive_component_and_type_values([KRD])
-    assert sorted(comps) == sorted([CARF, LEN, DEX])
-    assert PI_CAT_BORT in types   # carfilzomib is also a proteasome inhibitor
-    assert PI_CAT_LEN in types
-    assert PI_CAT_DEX in types
-
-
-def test_dara_vrd_derives_correct_components():
-    comps, types = derive_component_and_type_values([DARA_VRD])
-    assert BORT in comps
-    assert LEN in comps
-    assert DEX in comps
-    assert DARA in comps
-    assert PI_CAT_DARA in types
-
-
-def test_multiple_lines_derive_union_of_components():
-    # Patient had VRd 1st line, KRd 2nd line → union of all components
-    comps, types = derive_component_and_type_values([VRD, KRD])
-    assert BORT in comps
-    assert CARF in comps
-    assert LEN in comps
-    assert DEX in comps
-
-
-def test_unknown_concept_id_returns_none():
-    assert derive_component_and_type_values(['99999999']) == (None, None)
+def test_derive_none_component_ids_is_unknown():
+    assert derive_component_and_type_values([VRD], None) == (None, None)
 
 
 # ── regimen-level exclusion / requirement (omop_therapies_* columns) ─────────
@@ -158,6 +143,9 @@ def _mm_pi(*therapy_concept_ids):
         pi.second_line_therapy = lines[1]
     if len(lines) > 2:
         pi.later_therapies = [{'therapy': c} for c in lines[2:]]
+    # Phase P (#234): the consumer (promop) pre-expands the patient's regimens to
+    # component concept_ids. Simulate that so component/type matching has its input.
+    pi.therapy_component_ids = sorted({c for r in lines for c in REGIMEN_COMPONENTS.get(r, [])})
     return pi
 
 
@@ -241,22 +229,22 @@ def test_daratumumab_naive_trial_excludes_dara_vrd_patient():
 # path so a vocab-load error is caught at this level, not only end-to-end.
 
 def test_bortezomib_component_concept_id_maps_to_proteasome_inhibitor():
-    _, types = derive_component_and_type_values([BORT_MONO])
+    _, types = derive_component_and_type_values([BORT_MONO], [BORT])
     assert PI_CAT_BORT in types
 
 
 def test_carfilzomib_component_concept_id_also_maps_to_proteasome_inhibitor():
-    _, types = derive_component_and_type_values([CARF_MONO])
+    _, types = derive_component_and_type_values([CARF_MONO], [CARF])
     assert PI_CAT_BORT in types
 
 
 def test_lenalidomide_component_concept_id_maps_to_imid():
-    _, types = derive_component_and_type_values([LEN_MONO])
+    _, types = derive_component_and_type_values([LEN_MONO], [LEN])
     assert PI_CAT_LEN in types
 
 
 def test_daratumumab_component_concept_id_maps_to_anti_cd38():
-    _, types = derive_component_and_type_values([DARA_MONO])
+    _, types = derive_component_and_type_values([DARA_MONO], [DARA])
     assert PI_CAT_DARA in types
 
 

--- a/trials/querysets/trial.py
+++ b/trials/querysets/trial.py
@@ -26,7 +26,7 @@ from trials.services.patient_info.configs import (
     sct_value_is_none,
 )
 from trials.services.receptor_hierarchy import expand_values as expand_receptor_values
-from trials.services.therapy_match_profile import THERAPY_MATCH_PROFILE
+from trials.services.therapy_match_profile import THERAPY_MATCH_PROFILE, omop_therapy_enabled
 from trials.services.omop.demographics_match_profile import DEMOGRAPHICS_MATCH_PROFILE
 from trials.services.patient_info.genetic_mutations import GeneticMutations
 from trials.services.patient_info.patient_info_flipi_score import PatientInfoFlipyScore
@@ -113,7 +113,9 @@ def _filter_prior_therapy(scope, value, ctx):
     # filter_by_patient_info call; ctx tracks the flag.
     if ctx['has_no_prior_therapy'] and not ctx['is_therapies_filter_applied']:
         scope = scope.eligible_for_therapy_related_things_from_lines(
-            ctx['user_therapies'], ctx['has_no_prior_therapy']
+            ctx['user_therapies'], ctx['has_no_prior_therapy'],
+            patient_component_ids=(ctx['patient_info_attr'].get_user_therapy_component_ids()
+                                   if ctx.get('omop_therapy') else None),
         )
         ctx['is_therapies_filter_applied'] = True
     return scope
@@ -137,7 +139,9 @@ def _filter_therapy_lines_once(scope, _value, ctx):
     # most across all of them.
     if not ctx['is_therapies_filter_applied']:
         scope = scope.eligible_for_therapy_related_things_from_lines(
-            ctx['user_therapies'], ctx['has_no_prior_therapy']
+            ctx['user_therapies'], ctx['has_no_prior_therapy'],
+            patient_component_ids=(ctx['patient_info_attr'].get_user_therapy_component_ids()
+                                   if ctx.get('omop_therapy') else None),
         )
         ctx['is_therapies_filter_applied'] = True
     return scope
@@ -1077,7 +1081,7 @@ class TrialQuerySet(models.QuerySet):
             Q(**{f'{excluded_attr_name}__has_any_keys': values})
         )
 
-    def eligible_for_therapy_related_things_from_lines(self, therapy_codes: list[str], has_no_prior_therapy=False) -> models.QuerySet:
+    def eligible_for_therapy_related_things_from_lines(self, therapy_codes: list[str], has_no_prior_therapy=False, patient_component_ids: list[str] | None = None) -> models.QuerySet:
         if has_no_prior_therapy:
             return self.filter(**{
                 f'{THERAPY_MATCH_PROFILE.therapies_required}__exact': [],
@@ -1090,12 +1094,12 @@ class TrialQuerySet(models.QuerySet):
 
         scope = self.eligible_for_therapy_from_lines(therapy_codes)
 
-        # Component + type values from the regimen via the CB graph (shared with the
-        # matcher). Under OMOP: components → their OMOP concept_ids (vs the omop
-        # component column), types → CB category codes (vs the LEGACY therapy_types
-        # column the OMOP profile keeps). See trials/services/omop/therapy_graph.
+        # Component + type values (shared with the matcher). OMOP mode (Phase P, #234):
+        # components are the consumer-supplied pre-expanded concept_ids
+        # (patient_component_ids); types are CB category codes via the flat lookup.
+        # Legacy: derived from the regimen via the CB graph. See omop/therapy_graph.
         from trials.services.omop.therapy_graph import derive_component_and_type_values
-        component_codes, therapy_types = derive_component_and_type_values(therapy_codes)
+        component_codes, therapy_types = derive_component_and_type_values(therapy_codes, patient_component_ids)
 
         if component_codes:
             scope = scope.eligible_for_therapy_components(component_codes)
@@ -1494,6 +1498,7 @@ class TrialQuerySet(models.QuerySet):
                     'has_no_prior_therapy': has_no_prior_therapy,
                     'user_therapies': user_therapies,
                     'is_therapies_filter_applied': is_therapies_filter_applied,
+                    'omop_therapy': omop_therapy_enabled(),
                 }
                 handler = _CUSTOM_SEARCH_DISPATCH.get(user_attr)
                 if handler is not None:

--- a/trials/services/omop/therapy_graph.py
+++ b/trials/services/omop/therapy_graph.py
@@ -7,16 +7,18 @@ trial columns. This is the single shared derivation so the two stay consistent.
 
 Vocabulary by level (see therapy_match_profile):
 - regimen: handled by the caller directly (concept_ids under OMOP / codes legacy).
-- component: OMOP-mapped — under EXACT_OMOP_THERAPY the patient's regimen
-  concept_ids are reverse-mapped to internal Therapies (via Therapy.omop_concept_id),
-  walked to their components, and the components' OMOP concept_ids are returned
-  (to overlap the omop_therapy_components_* columns). Legacy → internal codes.
+- component: OMOP mode (Phase P, #234) — the patient's component concept_ids are
+  supplied PRE-EXPANDED by the consumer (promop) via ``patient_component_ids``;
+  EXACT no longer reverse-maps regimens to components through the local CB graph.
+  Legacy mode → internal component codes via the CB graph (unchanged).
 - type / component-category: NOT OMOP-mapped — always returned as CB category
   CODES (to overlap the legacy therapy_types_* columns), because EXACT keeps CB's
-  own category vocabulary and matches types through this graph (#197).
+  own category vocabulary and matches types through the flat category lookup (#197).
 
-Returns ``(component_values, type_values)``; ``(None, None)`` when the patient
-has no resolvable regimens (preserves the matcher's "unknown" semantics).
+Returns ``(component_values, type_values)``. ``(None, None)`` means unknown
+(preserves the matcher's "unknown" semantics): OMOP → the consumer sent no
+``therapy_component_ids`` (``patient_component_ids is None``); legacy → the patient
+has no resolvable regimens. An empty list is a known-empty component set.
 """
 from trials.services.therapy_match_profile import omop_therapy_enabled
 
@@ -35,7 +37,27 @@ def resolve_regimens(therapy_identifiers):
     return Therapy.objects.filter(code__in=therapy_identifiers)
 
 
-def derive_component_and_type_values(therapy_identifiers):
+def derive_component_and_type_values(therapy_identifiers, patient_component_ids=None):
+    """Return ``(component_values, type_values)`` for the patient's therapies.
+
+    OMOP mode (Phase P, #234): components are the consumer-supplied pre-expanded
+    ``patient_component_ids`` (no local CB-graph walk). ``None`` = unknown (consumer
+    sent nothing) → ``(None, None)``; ``[]`` = known-empty; a list → those component
+    concept_ids, with types via the flat category lookup (CB category codes; types are
+    NOT OMOP-mapped — ADR 0001 decision A / #4502). ``therapy_identifiers`` is used
+    only by the legacy path.
+
+    Legacy mode (flag OFF): the internal CB-graph expansion — byte-identical to CB.
+    """
+    if omop_therapy_enabled():
+        if patient_component_ids is None:
+            return None, None
+        component_values = [str(cid) for cid in patient_component_ids]
+        from trials.services.omop.component_category_lookup import component_concept_ids_to_type_codes
+        type_values = component_concept_ids_to_type_codes(component_values) or []
+        return component_values, type_values
+
+    # ── legacy (flag OFF): internal CB-graph expansion — byte-identical to CB ──
     if not therapy_identifiers:
         return None, None
     from trials.models import TherapyComponent, TherapyComponentCategory
@@ -47,30 +69,10 @@ def derive_component_and_type_values(therapy_identifiers):
     components = TherapyComponent.objects.filter(
         therapycomponentconnection__therapy__in=therapies
     ).order_by('id')
-
-    if omop_therapy_enabled():
-        has_components = False
-        component_concept_ids = []
-        for c in components:
-            has_components = True
-            if c.omop_concept_id is not None:
-                component_concept_ids.append(c.omop_concept_id)
-        # Regimen has components but none are OMOP-mapped yet → unknown, not absent.
-        # Returning None causes _match_therapy_things to treat it as "unknown" rather
-        # than "no components" (which would be not_matched on required-component trials).
-        if has_components and not component_concept_ids:
-            return None, None
-        component_values = [str(cid) for cid in component_concept_ids]
-        # Types via flat ComponentCategoryOmopLookup (CB-generated, EXACT reads).
-        # Decouples from the internal M2M graph; same CB category codes, no concept
-        # mapping needed — types stay CB-vocabulary (ADR 0001 decision A / #4502).
-        from trials.services.omop.component_category_lookup import component_concept_ids_to_type_codes
-        type_values = component_concept_ids_to_type_codes(component_values) or []
-    else:
-        component_values = [c.code for c in components]
-        categories = TherapyComponentCategory.objects.filter(
-            therapycomponentcategoryconnection__component__in=components
-        ).order_by('id')
-        type_values = [cat.code for cat in categories]
+    component_values = [c.code for c in components]
+    categories = TherapyComponentCategory.objects.filter(
+        therapycomponentcategoryconnection__component__in=components
+    ).order_by('id')
+    type_values = [cat.code for cat in categories]
 
     return component_values, type_values

--- a/trials/services/user_to_trial_attr_matcher.py
+++ b/trials/services/user_to_trial_attr_matcher.py
@@ -265,26 +265,52 @@ class UserToTrialAttrMatcher:
 
         mismatch_status = self.therapy_related_things_mismatch_status()
 
-        # Build the patient-side display maps keyed by whatever the trial columns
-        # hold per the active profile, so match_required/excluded overlap correctly:
-        # under OMOP regimen/component keys are concept_ids (reverse-mapped via the
-        # CB graph), type keys are CB category codes (legacy column); legacy → codes.
+        # Build the patient-side display maps keyed by whatever the trial columns hold
+        # per the active profile, so match_required/excluded overlap correctly. Regimen
+        # keys: concept_ids under OMOP, codes legacy. Component/type keys: OMOP (Phase P,
+        # #234) — components are consumer-supplied concept_ids (get_user_therapy_component_ids),
+        # types are CB category codes via the flat lookup; legacy — the CB graph walk.
+        omop = omop_therapy_enabled()
         if therapy_codes:
-            omop = omop_therapy_enabled()
             for therapy in resolve_regimens(therapy_codes).prefetch_related('components__categories'):
                 if omop:
                     if therapy.omop_concept_id is not None:
                         therapies[str(therapy.omop_concept_id)] = therapy.title
                 else:
                     therapies[therapy.code] = therapy.title
-                for component in sorted(therapy.components.all(), key=lambda c: c.id):
-                    if omop:
-                        if component.omop_concept_id is not None:
-                            therapy_components_to_therapy.setdefault(str(component.omop_concept_id), component.title)
-                    else:
+                    for component in sorted(therapy.components.all(), key=lambda c: c.id):
                         therapy_components_to_therapy.setdefault(component.code, component.title)
-                    for category in component.categories.all():
-                        therapy_types_to_therapy.setdefault(category.code, category.title)
+                        for category in component.categories.all():
+                            therapy_types_to_therapy.setdefault(category.code, category.title)
+
+        if omop:
+            # OMOP component/type display maps from the consumer-supplied concept_ids
+            # (no regimen->component graph walk). Titles resolved from the local
+            # TherapyComponent / category tables (transitional, while they still exist).
+            component_ids = self.patient_info_attr.get_user_therapy_component_ids() or []
+            if component_ids:
+                from trials.models import TherapyComponent, TherapyComponentCategory
+                from trials.services.omop.component_category_lookup import component_concept_ids_to_type_codes
+                keys = [str(c) for c in component_ids]
+                int_cids = [int(k) for k in keys if k.isdigit()]
+                title_by_cid = dict(
+                    TherapyComponent.objects.filter(omop_concept_id__in=int_cids)
+                    .values_list('omop_concept_id', 'title')
+                )
+                for key in keys:
+                    # Fall back to the concept_id string when EXACT has no local title
+                    # (promop may supply concepts EXACT holds no local row for) — a None
+                    # value here later TypeErrors in match_required's sorted(set(values)).
+                    title = title_by_cid.get(int(key)) if key.isdigit() else None
+                    therapy_components_to_therapy.setdefault(key, title or key)
+                type_codes = component_concept_ids_to_type_codes(keys) or []
+                if type_codes:
+                    title_by_code = dict(
+                        TherapyComponentCategory.objects.filter(code__in=type_codes)
+                        .values_list('code', 'title')
+                    )
+                    for code in type_codes:
+                        therapy_types_to_therapy.setdefault(code, title_by_code.get(code) or code)
 
         def match_required(trial_values, matching_values, mismatch_status):
             overlap = get_overlap(trial_values, matching_values.keys())
@@ -417,13 +443,17 @@ class UserToTrialAttrMatcher:
             return res
         results.append(res)
 
-        # Component + type (class) values are derived from the regimen via the CB
-        # graph. Under OMOP the regimen concept_ids are reverse-mapped to internal
-        # Therapies, components → their OMOP concept_ids (vs omop_therapy_components_*),
-        # types → CB category codes (vs the LEGACY therapy_types_* columns, which the
-        # OMOP profile keeps — types are not OMOP-mapped). See #197 / therapy_graph.
+        # Component + type (class) values. OMOP mode (Phase P, #234): components are the
+        # consumer-supplied pre-expanded concept_ids (get_user_therapy_component_ids); types
+        # are CB category codes via the flat lookup (types are not OMOP-mapped). Legacy:
+        # derived from the regimen via the CB graph. See #197 / therapy_graph.
         from trials.services.omop.therapy_graph import derive_component_and_type_values
-        component_codes, therapy_types = derive_component_and_type_values(values)
+        from trials.services.therapy_match_profile import omop_therapy_enabled
+        # OMOP only: read the consumer-supplied components. Gated so the legacy path
+        # does no OMOP-specific work (byte-identical to CB).
+        patient_component_ids = (self.patient_info_attr.get_user_therapy_component_ids()
+                                 if omop_therapy_enabled() else None)
+        component_codes, therapy_types = derive_component_and_type_values(values, patient_component_ids)
 
         res = self._match_therapy_things(component_codes, getattr(self.trial, THERAPY_MATCH_PROFILE.therapy_components_required), getattr(self.trial, THERAPY_MATCH_PROFILE.therapy_components_excluded), has_no_prior_therapy)
         if res == 'not_matched':


### PR DESCRIPTION
## Summary

Phase P of **#234**: under the `EXACT_OMOP_THERAPY` flag, the patient's therapy
**component** and **type** match-values now come from the consumer-supplied pre-expanded
concept_ids on `PatientInfo.therapy_component_ids` (promop pre-expansion), instead of EXACT
reverse-mapping the patient's regimens to components through the local CB graph. This removes
EXACT's local regimen→component derivation on the OMOP path.

## Sites (all behind the flag; legacy byte-identical)

- `therapy_graph.derive_component_and_type_values(therapy_identifiers, patient_component_ids)`
  — the seam: OMOP branch uses the supplied ids; the legacy branch is the unchanged CB-graph walk.
- Matcher `_match_therapy_related_things` (eligibility) — passes the consumer ids (flag-gated).
- Matcher `therapy_related_things_match_status` (detail/display) — OMOP component/type maps
  built from the supplied ids; titles resolved from local tables when present, else the concept_id.
- Queryset `eligible_for_therapy_related_things_from_lines` (+ its two ctx callers) — threads the
  ids (flag-gated via `ctx['omop_therapy']`).

Fail-closed semantics preserved: `therapy_component_ids` None = unknown → matcher `unknown`;
`[]` = known-empty → `not_matched` on required components; a list → matched by overlap.

## Review (two-part, per docs/porting-from-cancerbot.md)

codex + a fresh-context reviewer; both confirmed legacy parity and correct fail-closed
semantics. Fixes applied before this PR:
- **[P1] display crash** on a consumer concept_id EXACT holds no local `TherapyComponent` row
  for (title `None` → `TypeError` in `match_required`'s `sorted(set(values))`) — fall back to
  the concept_id string; added a regression test. This is the *primary* Phase P case.
- **[P1] flag-off purity** — the OMOP accessor is now called only when the flag is on
  (no OMOP-specific work on the legacy path).
- **[P2] N+1** in the type-title loop — batched into one query.

## Deferred (tracked)

- Detail-display shows a required-component criterion as `not_matched` (via `mismatch_status`)
  when components are *unknown*, where eligibility returns `unknown` — a **pre-existing**
  display/eligibility inconsistency (not introduced by Phase P), left as a follow-up.
- Component-only patient (no regimen lines, non-empty `therapy_component_ids`) is not filtered
  by the queryset early-return — **#224**.

## Tests

Migrated the OMOP therapy tests to the Phase P model (patient supplies `therapy_component_ids`);
removed the now-obsolete regimen→component derivation tests. Full suite: **1013 passed**;
`makemigrations --check`: clean.

Refs: #234, #224; promop ADR 0001 (promop#279).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
