### PR TITLE
feat(omop): DB-backed shared cache for the concept-graph client (#234)

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -77,6 +77,11 @@ jobs:
           gcloud run jobs execute "$MIGRATE_JOB" \
             --region "$REGION" \
             --wait
+          # Concept-graph cache table (#234) on the default DB — idempotent.
+          gcloud run jobs execute "$MIGRATE_JOB" \
+            --region "$REGION" \
+            --wait \
+            --args=manage.py,createcachetable,--database=default
           # Second pass migrates the split trials DB. The migrate_trials_db
           # command self-gates on settings.TRIALS_DB_MIGRATE inside the
           # container: a no-op (returns before opening the 'trials' connection)

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -8,6 +8,12 @@ case "${RUN_MIGRATIONS:-true}" in
     *)
         echo "Running migrations..."
         python manage.py migrate --run-syncdb
+        # Concept-graph cache table (#234) — idempotent. Tolerate a concurrent-start
+        # race (two containers both passing the exists-check, one losing the CREATE):
+        # migrate above already proved the DB reachable, so the only failure left here
+        # is a harmless duplicate-table, which must not abort startup under `set -e`.
+        python manage.py createcachetable --database=default \
+            || echo "createcachetable: table already exists or concurrent start; continuing"
         ;;
 esac
 

--- a/exact/cache_config.py
+++ b/exact/cache_config.py
@@ -17,6 +17,9 @@ from urllib.parse import urlsplit, urlunsplit, parse_qsl, urlencode
 
 LOCMEM_BACKEND = "django.core.cache.backends.locmem.LocMemCache"
 REDIS_BACKEND = "django.core.cache.backends.redis.RedisCache"
+DB_CACHE_BACKEND = "django.core.cache.backends.db.DatabaseCache"
+# Table for the concept-graph cache (#234); created by `createcachetable`.
+CONCEPT_GRAPH_CACHE_TABLE = "concept_graph_cache"
 
 # redis-py's ConnectionPool.from_url() lets querystring args OVERRIDE kwargs
 # passed via OPTIONS ("querystring arguments always win"). So a deployed
@@ -61,8 +64,20 @@ def build_caches(*, redis_url, debug, environment, force_redis=False, redis_ca_c
     """
     redis_url = (redis_url or "").strip()
     local = (debug or environment == "local") and not force_redis
+
+    # Concept-graph cache (#234): a SHARED, DB-backed cache in deployed envs so the
+    # per-source promop expansion cache survives across Redis-less Cloud Run workers /
+    # instances (a per-process LocMemCache there defeats cross-instance reuse). Local /
+    # test stays on LocMem (no cache table needed). Deployed envs MUST run
+    #     python manage.py createcachetable --database=default
+    # (alongside migrate) to create CONCEPT_GRAPH_CACHE_TABLE.
+    concept_graph = (
+        {"BACKEND": LOCMEM_BACKEND} if local
+        else {"BACKEND": DB_CACHE_BACKEND, "LOCATION": CONCEPT_GRAPH_CACHE_TABLE}
+    )
+
     if not redis_url or local:
-        return {"default": {"BACKEND": LOCMEM_BACKEND}}
+        return {"default": {"BACKEND": LOCMEM_BACKEND}, "concept_graph": concept_graph}
 
     options = {}
     if redis_url.startswith("rediss://"):
@@ -87,4 +102,4 @@ def build_caches(*, redis_url, debug, environment, force_redis=False, redis_ca_c
     }
     if options:
         default["OPTIONS"] = options
-    return {"default": default}
+    return {"default": default, "concept_graph": concept_graph}

--- a/exact/settings.py
+++ b/exact/settings.py
@@ -386,6 +386,12 @@ CTOMOP_SERVICE_TOKEN = os.environ.get('CTOMOP_SERVICE_TOKEN', '')
 PROMOP_API_BASE = os.environ.get('PROMOP_API_BASE', '')
 PROMOP_SERVICE_TOKEN = os.environ.get('PROMOP_SERVICE_TOKEN', '')
 
+# Cache alias CachedConceptGraphClient uses (#234). Points at the shared DB-backed
+# 'concept_graph' cache in deployed envs (see exact/cache_config.py); the client falls
+# back to 'default' if the alias is absent (e.g. tests). Deployed envs must run
+# `python manage.py createcachetable --database=default` to create the cache table.
+CONCEPT_GRAPH_CACHE_ALIAS = os.environ.get('CONCEPT_GRAPH_CACHE_ALIAS', 'concept_graph')
+
 
 # ---------------------------------------------------------------------------
 # OMOP therapy matching (epic #4447 cutover).

--- a/tests/services/omop/test_concept_graph_cache.py
+++ b/tests/services/omop/test_concept_graph_cache.py
@@ -207,3 +207,49 @@ class TestCachedExpand:
         r2 = cached.descendants([1], release='r')
         assert r1.groups == {1: []} == r2.groups
         client.expand.assert_called_once()  # empty result served from cache
+
+    def test_cache_read_error_degrades_to_miss(self):
+        # A broken cache backend (e.g. missing DatabaseCache table) must not raise —
+        # degrade to a miss and call the client.
+        client = _mock_client()
+        client.expand.return_value = _res({1: [10]})
+        cached = CachedConceptGraphClient(client=client)
+        cached.cache = MagicMock()
+        cached.cache.get.side_effect = Exception('cache backend down')
+        r = cached.descendants([1], release='r')
+        assert r.groups == {1: [10]}
+        client.expand.assert_called_once()
+
+    def test_cache_write_error_is_swallowed(self):
+        client = _mock_client()
+        client.expand.return_value = _res({1: [10]})
+        cached = CachedConceptGraphClient(client=client)
+        cached.cache = MagicMock()
+        cached.cache.get.return_value = None
+        cached.cache.set.side_effect = Exception('cache backend down')
+        r = cached.descendants([1], release='r')   # must not raise on the failed set
+        assert r.groups == {1: [10]}
+
+
+@pytest.mark.django_db
+def test_cache_works_over_a_database_cache_backend(settings):
+    """Exercise the real production backend — a DatabaseCache (pickle round-trip via
+    the DB), not just LocMem — using the client's cache_alias param to target it."""
+    from django.core.management import call_command
+    settings.CACHES = {
+        **settings.CACHES,
+        'cg_db': {
+            'BACKEND': 'django.core.cache.backends.db.DatabaseCache',
+            'LOCATION': 'test_concept_graph_cache',
+        },
+    }
+    call_command('createcachetable', 'test_concept_graph_cache')
+
+    client = _mock_client()
+    client.expand.return_value = _res({1: [10, 11]})
+    cached = CachedConceptGraphClient(client=client, cache_alias='cg_db')
+
+    r1 = cached.descendants([1], release='r')
+    r2 = cached.descendants([1], release='r')
+    assert r1.groups == {1: [10, 11]} == r2.groups
+    client.expand.assert_called_once()  # second call served from the DB-backed cache

--- a/tests/test_cache_config.py
+++ b/tests/test_cache_config.py
@@ -117,3 +117,28 @@ class TestSettingsDoesNotHardcodeLocmem:
         ), 'CACHES must be resolved via build_caches(), not a hard-coded LocMemCache.'
         assert 'build_caches(' in source, \
             'settings.py must resolve CACHES through build_caches().'
+
+
+class TestConceptGraphCache:
+    """The concept-graph cache (#234) must be a SHARED, DB-backed cache in deployed
+    envs so the per-source promop expansion cache survives across Redis-less Cloud
+    Run workers/instances; local/test stays on LocMem (no cache table needed)."""
+
+    def test_deployed_no_redis_uses_db_backed_shared_cache(self):
+        from exact.cache_config import DB_CACHE_BACKEND, CONCEPT_GRAPH_CACHE_TABLE
+        caches = build_caches(redis_url='', debug=False, environment='staging')
+        assert caches['concept_graph']['BACKEND'] == DB_CACHE_BACKEND
+        assert caches['concept_graph']['LOCATION'] == CONCEPT_GRAPH_CACHE_TABLE
+
+    def test_deployed_with_redis_still_db_backed_concept_graph(self):
+        from exact.cache_config import DB_CACHE_BACKEND
+        caches = build_caches(redis_url='rediss://h:6379', debug=False,
+                              environment='production')
+        assert caches['default']['BACKEND'] == REDIS_BACKEND     # default is Redis
+        assert caches['concept_graph']['BACKEND'] == DB_CACHE_BACKEND  # graph is DB
+
+    def test_local_concept_graph_is_locmem(self):
+        for local in (dict(debug=True, environment='dev'),
+                      dict(debug=False, environment='local')):
+            caches = build_caches(redis_url='redis://localhost:6379', **local)
+            assert caches['concept_graph']['BACKEND'] == LOCMEM_BACKEND

--- a/trials/services/omop/concept_graph_cache.py
+++ b/trials/services/omop/concept_graph_cache.py
@@ -28,9 +28,14 @@ can report versions from other concepts fetched in the same batch. Harmless whil
 
 Backend: Django's cache framework (``caches[alias]``). Production points the alias at a
 **DB-backed cache** (shared across Redis-less Cloud Run instances); tests use LocMemCache.
+The cache is **best-effort**: a backend failure (e.g. the DatabaseCache table not yet
+created, or a transient connection error) degrades to a cache miss / skipped write and the
+underlying client is called — it never turns a cache problem into a request failure. (The
+client's own fail-closed policy still applies to promop failures.)
 """
 import hashlib
 import json
+import logging
 
 from django.conf import settings
 from django.core.cache import InvalidCacheBackendError, caches
@@ -40,6 +45,8 @@ from trials.services.omop.concept_graph_client import (
     ConceptGraphResult,
     _positive_ints,
 )
+
+logger = logging.getLogger(__name__)
 
 DEFAULT_TTL_SECONDS = 3600  # 1h; a release bump invalidates via the release-pinned key
 _KEY_PREFIX = 'cgc'
@@ -116,7 +123,7 @@ class CachedConceptGraphClient:
         missing: list[int] = []
 
         for cid in source_ids:
-            entry = self.cache.get(f'{_KEY_PREFIX}:{prefix}:{cid}')
+            entry = self._cache_get(f'{_KEY_PREFIX}:{prefix}:{cid}')
             if entry is None:
                 missing.append(cid)
             else:
@@ -141,10 +148,9 @@ class CachedConceptGraphClient:
                     # Incomplete — surface but do NOT cache a partial projection.
                     truncated.add(cid)
                 else:
-                    self.cache.set(
+                    self._cache_set(
                         f'{_KEY_PREFIX}:{prefix}:{cid}',
                         {'groups': g, 'versions': res_versions},
-                        self.ttl,
                     )
 
         return ConceptGraphResult(
@@ -152,3 +158,22 @@ class CachedConceptGraphClient:
             truncated=sorted(truncated),
             versions=frozenset(versions),
         )
+
+    # ── best-effort cache access ─────────────────────────────────────────────
+    # A cache-backend failure (missing DatabaseCache table on a fresh deploy, a
+    # transient connection error) must NOT surface as a request failure — degrade
+    # to a miss / skipped write and let the client run. Distinct from the client's
+    # fail-closed policy, which still applies to promop failures.
+
+    def _cache_get(self, key):
+        try:
+            return self.cache.get(key)
+        except Exception as exc:  # noqa: BLE001 — cache is optional; any backend error = miss
+            logger.warning('concept-graph cache read failed (%s); treating as miss', exc)
+            return None
+
+    def _cache_set(self, key, value):
+        try:
+            self.cache.set(key, value, self.ttl)
+        except Exception as exc:  # noqa: BLE001 — best-effort; never break expansion on a cache write
+            logger.warning('concept-graph cache write failed (%s); skipped', exc)


### PR DESCRIPTION
## Summary

Slice 2b of **#234**: wire the concept-graph client's cache to a SHARED, DB-backed cache in
deployed envs, so the per-source promop expansion cache actually survives across Redis-less
Cloud Run workers/instances (the `default` alias is per-process LocMem there, which defeats
cross-instance reuse).

## Changes

- `cache_config.build_caches` returns a `concept_graph` alias: **DatabaseCache** in deployed
  envs, **LocMemCache** local/test (no cache table needed there).
- `CONCEPT_GRAPH_CACHE_ALIAS` setting (default `concept_graph`); `CachedConceptGraphClient`
  uses it, falling back to `default` if the alias is absent (tests).
- Deploy runs `createcachetable --database=default` (idempotent) — in `docker/entrypoint.sh`
  (after migrate) and the staging migrate job. The table lands on the writable `default` DB;
  the cache's `django_cache` app_label routes to `default` via the DB router, never the
  read-only `trials` DB.
- **The cache is now best-effort**: a backend failure (missing table on a fresh deploy, a
  transient connection error) degrades to a cache miss / skipped write instead of raising —
  distinct from the client's fail-closed policy on *promop* failures.

## Review (two-part, per docs/porting-from-cancerbot.md)

codex + a fresh-context reviewer confirmed split-DB safety (cache table on `default`, never
`trials`), correct deployed-vs-local resolution, and the deploy ordering (migrate →
createcachetable → route traffic). Both P2s fixed before this PR:
- **createcachetable concurrent-start race** — tolerated so `set -e` can't abort startup on a
  harmless duplicate-table (migrate already proved the DB reachable).
- **missing-table → 500** — the cache is best-effort (read error → miss, write error →
  skipped), tested.

## Tests

- `concept_graph` alias resolves to DatabaseCache deployed / LocMem local.
- Client round-trips over a real DatabaseCache backend (pickle → DB → unpickle) under the
  test transaction.
- Cache read/write backend errors degrade gracefully.

Full suite: **1019 passed**; `makemigrations --check`: clean.

Refs: #234.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
