### PR TITLE
fix(omop): filter component-only OMOP patients in the search queryset (#224)

### DIFF
--- a/tests/test_omop_real_concept_ids.py
+++ b/tests/test_omop_real_concept_ids.py
@@ -333,3 +333,89 @@ def test_queryset_pi_naive_trial_only_matches_no_prior_therapy():
     ids = set(qs.values_list('id', flat=True))
     assert naive_only.id in ids
     assert with_req.id not in ids
+
+
+# ── #224: component-only OMOP patient (therapy_component_ids, no regimen lines) ──
+
+def test_component_only_queryset_method_filters_by_components():
+    keep = TrialFactory(disease='multiple myeloma', omop_therapy_components_required=[BORT])
+    drop = TrialFactory(disease='multiple myeloma', omop_therapy_components_required=[CARF])
+    none_req = TrialFactory(disease='multiple myeloma', omop_therapy_components_required=[])
+    # No regimen lines ([]), but the consumer supplied components.
+    ids = set(
+        Trial.objects.eligible_for_therapy_related_things_from_lines(
+            [], patient_component_ids=[BORT, LEN]
+        ).values_list('id', flat=True)
+    )
+    assert keep.id in ids        # patient has bortezomib
+    assert none_req.id in ids    # no component requirement
+    assert drop.id not in ids    # patient lacks carfilzomib
+
+
+def test_component_only_filter_by_patient_info_applies_component_filter():
+    keep = TrialFactory(disease='multiple myeloma', omop_therapy_components_required=[BORT])
+    drop = TrialFactory(disease='multiple myeloma', omop_therapy_components_required=[CARF])
+    # Components supplied, prior therapy declared, but NO regimen-line codes — so the
+    # therapy-line dispatch never fires; the #224 fold must still apply the filter.
+    pi = PatientInfo(disease='multiple myeloma', prior_therapy='One line',
+                     therapy_component_ids=[BORT, LEN])
+    scope, _ = Trial.objects.filter_by_patient_info(pi)
+    ids = set(scope.values_list('id', flat=True))
+    assert keep.id in ids
+    assert drop.id not in ids
+
+
+def test_matcher_component_only_patient_component_match():
+    trial = TrialFactory(disease='multiple myeloma', omop_therapy_components_required=[BORT])
+    pi = PatientInfo(disease='multiple myeloma', therapy_component_ids=[BORT, LEN])
+    res = UserToTrialAttrMatcher(trial, pi)._match_therapy_related_things(None, False)
+    assert res == 'matched'
+
+
+def test_matcher_component_only_patient_component_mismatch():
+    trial = TrialFactory(disease='multiple myeloma', omop_therapy_components_required=[CARF])
+    pi = PatientInfo(disease='multiple myeloma', therapy_component_ids=[BORT, LEN])
+    res = UserToTrialAttrMatcher(trial, pi)._match_therapy_related_things(None, False)
+    assert res == 'not_matched'
+
+
+@override_settings(EXACT_OMOP_THERAPY=False)
+def test_component_only_fold_skipped_when_flag_off():
+    # Legacy: therapy_component_ids is not consulted; the #224 fold is gated off, so a
+    # trial with an omop component requirement is NOT filtered by it.
+    drop_if_omop = TrialFactory(disease='multiple myeloma', omop_therapy_components_required=[CARF])
+    pi = PatientInfo(disease='multiple myeloma', prior_therapy='One line',
+                     therapy_component_ids=[BORT, LEN])
+    scope, _ = Trial.objects.filter_by_patient_info(pi)
+    assert drop_if_omop.id in set(scope.values_list('id', flat=True))
+
+
+def test_component_only_does_not_apply_regimen_filter():
+    # The component-only fold must SKIP the regimen filter (passes [] as therapy_codes):
+    # a trial requiring a regimen the patient lacks must not be dropped here (the matcher
+    # refines regimen matching). This also pins the fix for the supportive-codes leak.
+    requires_regimen = TrialFactory(disease='multiple myeloma', omop_therapies_required=[VRD])
+    pi = PatientInfo(disease='multiple myeloma', prior_therapy='One line',
+                     therapy_component_ids=[BORT, LEN])
+    scope, _ = Trial.objects.filter_by_patient_info(pi)
+    assert requires_regimen.id in set(scope.values_list('id', flat=True))
+
+
+def test_component_only_component_exclusion_filters():
+    excluded = TrialFactory(disease='multiple myeloma', omop_therapy_components_excluded=[BORT])
+    kept = TrialFactory(disease='multiple myeloma', omop_therapy_components_excluded=[CARF])
+    pi = PatientInfo(disease='multiple myeloma', prior_therapy='One line',
+                     therapy_component_ids=[BORT, LEN])
+    ids = set(Trial.objects.filter_by_patient_info(pi)[0].values_list('id', flat=True))
+    assert excluded.id not in ids   # patient had bortezomib → excluded
+    assert kept.id in ids           # patient never had carfilzomib
+
+
+def test_component_only_type_filter_via_lookup():
+    type_match = TrialFactory(disease='multiple myeloma', therapy_types_required=[PI_CAT_BORT])
+    type_other = TrialFactory(disease='multiple myeloma', therapy_types_required=[PI_CAT_DARA])
+    pi = PatientInfo(disease='multiple myeloma', prior_therapy='One line',
+                     therapy_component_ids=[BORT, LEN])
+    ids = set(Trial.objects.filter_by_patient_info(pi)[0].values_list('id', flat=True))
+    assert type_match.id in ids     # bortezomib → proteasome inhibitor
+    assert type_other.id not in ids # patient has no anti-CD38 component

--- a/trials/querysets/trial.py
+++ b/trials/querysets/trial.py
@@ -1089,10 +1089,16 @@ class TrialQuerySet(models.QuerySet):
                 f'{THERAPY_MATCH_PROFILE.therapy_types_required}__exact': [],
             })
 
-        if therapy_codes is None or therapy_codes == []:
+        # The regimen (from-lines) filter needs therapy_codes, but OMOP component-only
+        # patients (#224) have none while still carrying consumer-supplied components —
+        # apply the component/type filter for them. Legacy always has
+        # patient_component_ids=None, so an empty therapy_codes still short-circuits
+        # here, byte-identical to before.
+        scope = self
+        if therapy_codes:
+            scope = self.eligible_for_therapy_from_lines(therapy_codes)
+        elif not patient_component_ids:
             return self
-
-        scope = self.eligible_for_therapy_from_lines(therapy_codes)
 
         # Component + type values (shared with the matcher). OMOP mode (Phase P, #234):
         # components are the consumer-supplied pre-expanded concept_ids
@@ -1573,4 +1579,18 @@ class TrialQuerySet(models.QuerySet):
                     'dropped': count-new_count
                 })
                 count = new_count
+
+        # OMOP component-only (#224): a patient who supplied therapy_component_ids but no
+        # regimen therapy lines never triggers the therapy-line dispatch above (those attrs
+        # are blank and skipped), so the component/type prefilter would be missed. Apply it
+        # once here. Legacy is unaffected (flag off → skipped).
+        if omop_therapy_enabled() and not is_therapies_filter_applied and not has_no_prior_therapy:
+            component_ids = patient_info_attr.get_user_therapy_component_ids()
+            if component_ids:
+                # Pass [] for the regimen codes, not user_therapies: this is the
+                # component-only path (no regimen lines), and user_therapies also folds
+                # in supportive codes — running the regimen filter on those would be wrong.
+                scope = scope.eligible_for_therapy_related_things_from_lines(
+                    [], has_no_prior_therapy, patient_component_ids=component_ids)
+                is_therapies_filter_applied = True
         return scope, traces


### PR DESCRIPTION
## Summary

**#224**: make the search QUERYSET filter a **component-only OMOP patient** — one who
supplied `PatientInfo.therapy_component_ids` (promop pre-expansion) but has NO regimen-level
therapy lines. Such a patient never triggered the therapy-line filter dispatch, so trials
requiring specific components appeared unfiltered in the list. Builds on Phase P — the
matcher already handled component-only.

## Changes (`trials/querysets/trial.py`, behind the flag)

- `eligible_for_therapy_related_things_from_lines`: no longer early-returns on empty
  `therapy_codes` when `patient_component_ids` is present — it skips the regimen (from-lines)
  filter and applies the component/type filters. Legacy (`patient_component_ids=None`) keeps
  the empty-codes short-circuit, byte-identical.
- `filter_by_patient_info`: a post-loop fold applies the therapy filter once when OMOP +
  `therapy_component_ids` present + the therapy-line dispatch never fired. Fully gated off
  under legacy.

## Review (two-part, per docs/porting-from-cancerbot.md)

codex + a fresh-context reviewer confirmed legacy byte-identical and no double-apply. Fix
applied before this PR:
- **[P1] supportive-codes leak** — the fold passed `user_therapies`, which folds in
  supportive-therapy codes, so a supportive-only patient would have run the regimen filter on
  them. Now passes `[]` (component-only → no regimen filter). Tested.

## Notes (documented, per porting semantics)

- A known-empty `therapy_component_ids=[]` is not filtered in the queryset (over-includes; the
  matcher refines) — consistent with the porting rule "patient empty/unknown → do not filter
  in the queryset."
- The fold runs after the `add_traces` loop, so it does not append a trace row (observability
  only).

## Tests

component-only: queryset method, full `filter_by_patient_info` trigger, matcher parity
(match/mismatch), regimen-filter-skipped, component exclusion, type filtering, legacy
flag-off. Full suite: **1027 passed**; `makemigrations --check`: clean.

Refs: #224, #234.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
