### PR TITLE
feat(omop): CtomopClient v1 patient-records + OAuth2 client_credentials (#237)

### DIFF
--- a/exact/settings.py
+++ b/exact/settings.py
@@ -378,6 +378,17 @@ ADD_SEARCH_TRIALS_TRACES = os.environ.get('ADD_SEARCH_TRIALS_TRACES', 'false') =
 CTOMOP_BASE = os.environ.get('CTOMOP_BASE', '')
 CTOMOP_SERVICE_TOKEN = os.environ.get('CTOMOP_SERVICE_TOKEN', '')
 
+# OAuth2 client_credentials for the v1 patient endpoint (#237). When client id +
+# secret are set, CtomopClient reads /api/v1/patient-records/ with an OAuth bearer
+# (scope patient/*.read) minted at {CTOMOP_BASE}/o/token/ — replacing the static
+# CTOMOP_SERVICE_TOKEN + legacy /api/patient-info/ endpoint (sunsets 2026-09-01).
+# Register the client in promop with `manage.py create_service_client`.
+CTOMOP_OAUTH_CLIENT_ID = os.environ.get('CTOMOP_OAUTH_CLIENT_ID', '')
+CTOMOP_OAUTH_CLIENT_SECRET = os.environ.get('CTOMOP_OAUTH_CLIENT_SECRET', '')
+CTOMOP_OAUTH_SCOPE = os.environ.get('CTOMOP_OAUTH_SCOPE', 'patient/*.read')
+# Defaults to {CTOMOP_BASE}/o/token/ when unset.
+CTOMOP_OAUTH_TOKEN_URL = os.environ.get('CTOMOP_OAUTH_TOKEN_URL', '')
+
 # promop concept-graph API (#234; promop ADR 0001 / promop#279) — API + cache
 # source of truth for vocabulary/concept-graph data. Falls back to the CTOMOP_*
 # settings (same promop host) until the dedicated OAuth2 path (#237) lands.

--- a/tests/services/patient_info/test_ctomop_client.py
+++ b/tests/services/patient_info/test_ctomop_client.py
@@ -99,6 +99,8 @@ class TestCtomopClientFetch:
         None,                   # null
         0,                      # non-positive integer
         -1,
+        float('inf'),           # int(inf) raises OverflowError, not ValueError
+        float('nan'),           # int(nan) raises ValueError
     ])
     def test_rejects_non_positive_integer_person_id(self, bad_id):
         """URL path injection / Bearer token leakage guard (#102 self-review):
@@ -177,3 +179,156 @@ class TestCtomopClientFetch:
         call_args = mock_get.call_args
         assert call_args.args[0].startswith('https://settings.example.com/')
         assert call_args.kwargs['headers']['Authorization'] == 'Bearer settingstoken'
+
+
+# ── #237: v1 + OAuth2 client_credentials ─────────────────────────────
+from trials.services.patient_info.ctomop_client import _clear_token_cache
+
+_GET = 'trials.services.patient_info.ctomop_client.requests.get'
+_POST = 'trials.services.patient_info.ctomop_client.requests.post'
+
+
+@pytest.fixture(autouse=True)
+def _clear_service_tokens():
+    _clear_token_cache()
+    yield
+    _clear_token_cache()
+
+
+def _token_response(access_token='svc-tok', expires_in=3600, status_code=200):
+    resp = MagicMock()
+    resp.ok = 200 <= status_code < 300
+    resp.status_code = status_code
+    resp.reason = 'OK' if resp.ok else 'Bad'
+    resp.json.return_value = {'access_token': access_token, 'expires_in': expires_in,
+                              'token_type': 'Bearer'}
+    return resp
+
+
+def _oauth_client():
+    return CtomopClient(base_url='https://promop.example.com',
+                        oauth_client_id='cid', oauth_client_secret='sec')
+
+
+class TestOAuthV1:
+    def test_oauth_mode_hits_v1_with_minted_bearer(self):
+        client = _oauth_client()
+        with patch(_POST, return_value=_token_response('svc-tok')) as mpost, \
+             patch(_GET, return_value=_ok_response({'patient_info': {'person_id': 9001}})) as mget:
+            result = client.fetch_patient(9001)
+        assert result == {'person_id': 9001}
+        assert mget.call_args.args[0] == 'https://promop.example.com/api/v1/patient-records/9001/'
+        assert mget.call_args.kwargs['headers']['Authorization'] == 'Bearer svc-tok'
+        # token minted via client_credentials + HTTP Basic against /o/token/
+        assert mpost.call_args.args[0] == 'https://promop.example.com/o/token/'
+        assert mpost.call_args.kwargs['data']['grant_type'] == 'client_credentials'
+        assert mpost.call_args.kwargs['data']['scope'] == 'patient/*.read'
+        assert mpost.call_args.kwargs['auth'] == ('cid', 'sec')
+
+    def test_token_is_cached_across_calls(self):
+        client = _oauth_client()
+        with patch(_POST, return_value=_token_response()) as mpost, \
+             patch(_GET, return_value=_ok_response({'patient_info': {'person_id': 1}})):
+            client.fetch_patient(9001)
+            client.fetch_patient(9002)
+        assert mpost.call_count == 1  # token reused, not re-minted per fetch
+
+    def test_oauth_token_non_ok_returns_none_no_patient_call(self):
+        client = _oauth_client()
+        with patch(_POST, return_value=_token_response(status_code=401)), patch(_GET) as mget:
+            assert client.fetch_patient(9001) is None
+        mget.assert_not_called()
+
+    def test_oauth_token_network_error_returns_none(self):
+        client = _oauth_client()
+        with patch(_POST, side_effect=requests.ConnectionError('boom')), patch(_GET) as mget:
+            assert client.fetch_patient(9001) is None
+        mget.assert_not_called()
+
+    def test_v1_envelope_with_user_sibling_unwraps(self):
+        client = _oauth_client()
+        body = {'patient_info': {'person_id': 9005, 'disease': 'MM'}, 'user': {'id': 'u1'}}
+        with patch(_POST, return_value=_token_response()), patch(_GET, return_value=_ok_response(body)):
+            assert client.fetch_patient(9005) == {'person_id': 9005, 'disease': 'MM'}
+
+    def test_legacy_mode_uses_v0_url_and_static_token(self):
+        client = CtomopClient(base_url='https://ctomop.example.com', token='static')
+        assert client.use_oauth is False
+        with patch(_POST) as mpost, patch(_GET, return_value=_ok_response({'person_id': 1})) as mget:
+            client.fetch_patient(9001)
+        mpost.assert_not_called()
+        assert mget.call_args.args[0] == 'https://ctomop.example.com/api/patient-info/9001/'
+        assert mget.call_args.kwargs['headers']['Authorization'] == 'Bearer static'
+
+    def test_token_url_defaults_to_base_o_token(self):
+        client = CtomopClient(base_url='https://p.example.com',
+                              oauth_client_id='c', oauth_client_secret='s')
+        assert client.oauth_token_url == 'https://p.example.com/o/token/'
+
+    def test_oauth_failure_never_falls_back_to_legacy_token(self):
+        """Adversarial fail-closed: a client configured with BOTH OAuth creds
+        and a legacy static token must NOT send the static token when the OAuth
+        token can't be minted. OAuth mode is strict — token failure ⇒ None, no
+        patient request, and the legacy Bearer is never exposed on the v1 path.
+        """
+        client = CtomopClient(base_url='https://promop.example.com', token='legacy-static',
+                              oauth_client_id='cid', oauth_client_secret='sec')
+        assert client.use_oauth is True
+        with patch(_POST, return_value=_token_response(status_code=503)), patch(_GET) as mget:
+            assert client.fetch_patient(9001) is None
+        mget.assert_not_called()  # no request at all — legacy token never used
+
+    def test_token_response_missing_access_token_returns_none(self):
+        client = _oauth_client()
+        resp = MagicMock()
+        resp.ok = True
+        resp.status_code = 200
+        resp.reason = 'OK'
+        resp.json.return_value = {'expires_in': 3600, 'token_type': 'Bearer'}  # no access_token
+        with patch(_POST, return_value=resp), patch(_GET) as mget:
+            assert client.fetch_patient(9001) is None
+        mget.assert_not_called()
+
+    def test_malformed_expires_in_falls_back_to_default_ttl(self):
+        """A non-numeric expires_in must not crash token minting; the token is
+        still used (default TTL) so the fetch proceeds."""
+        client = _oauth_client()
+        with patch(_POST, return_value=_token_response('t', expires_in='not-a-number')), \
+             patch(_GET, return_value=_ok_response({'patient_info': {'person_id': 1}})) as mget:
+            assert client.fetch_patient(9001) == {'person_id': 1}
+        assert mget.call_args.kwargs['headers']['Authorization'] == 'Bearer t'
+
+    def test_token_post_disallows_redirects(self):
+        """The token request must not follow redirects — a redirect could bounce
+        the Basic-auth client_secret to another host/scheme."""
+        client = _oauth_client()
+        with patch(_POST, return_value=_token_response()) as mpost, \
+             patch(_GET, return_value=_ok_response({'patient_info': {'person_id': 1}})):
+            client.fetch_patient(9001)
+        assert mpost.call_args.kwargs['allow_redirects'] is False
+
+    def test_partial_oauth_config_is_legacy(self):
+        """Only client_id (no secret) must not enable OAuth — it falls back to
+        the legacy static-token transport rather than half-authenticating."""
+        client = CtomopClient(base_url='https://promop.example.com', token='static',
+                              oauth_client_id='cid')  # secret missing
+        assert client.use_oauth is False
+        with patch(_POST) as mpost, patch(_GET, return_value=_ok_response({'person_id': 1})) as mget:
+            client.fetch_patient(9001)
+        mpost.assert_not_called()
+        assert mget.call_args.args[0] == 'https://promop.example.com/api/patient-info/9001/'
+        assert mget.call_args.kwargs['headers']['Authorization'] == 'Bearer static'
+
+    def test_settings_drive_oauth_config(self, settings):
+        settings.CTOMOP_BASE = 'https://s.example.com'
+        settings.CTOMOP_OAUTH_CLIENT_ID = 'scid'
+        settings.CTOMOP_OAUTH_CLIENT_SECRET = 'ssec'
+        settings.CTOMOP_OAUTH_SCOPE = 'patient/*.read'
+        settings.CTOMOP_OAUTH_TOKEN_URL = ''
+        client = CtomopClient()
+        assert client.use_oauth
+        with patch(_POST, return_value=_token_response('t')) as mpost, \
+             patch(_GET, return_value=_ok_response({'patient_info': {'person_id': 1}})) as mget:
+            client.fetch_patient(1)
+        assert mget.call_args.args[0] == 'https://s.example.com/api/v1/patient-records/1/'
+        assert mpost.call_args.args[0] == 'https://s.example.com/o/token/'

--- a/trials/services/patient_info/ctomop_client.py
+++ b/trials/services/patient_info/ctomop_client.py
@@ -1,22 +1,30 @@
-"""HTTP client for CTOMOP's `patient-info` endpoint.
+"""HTTP client for CTOMOP/promop's patient endpoint.
 
-Used by `resolve_patient_info` when a request carries `?person_id=` (or
-a body field `person_id`) instead of an inline `patient_info` payload.
+Used by `resolve_patient_info` when a request carries `?person_id=` (or a body
+field `person_id`) instead of an inline `patient_info` payload.
 
-Keeps the surface minimal: one method `fetch_patient(person_id)` that
-returns the flat row dict (matching the shape `normalize_ctomop_row`
-expects) or `None` on any error path (network failure, 4xx/5xx, malformed
-JSON, missing settings). Returning `None` rather than raising lets the
-resolver treat the failure the same as a missing payload — the caller
-can proceed without patient context (e.g. public trial browsing).
+Two transport modes, chosen by configuration (#237):
+- **v1 + OAuth2** (preferred): when `CTOMOP_OAUTH_CLIENT_ID` / `_SECRET` are set,
+  the client authenticates via OAuth2 `client_credentials` against promop
+  `/o/token/` (scope `patient/*.read`) and reads
+  `GET /api/v1/patient-records/{person_id}/`.
+- **legacy** (deprecated, sunsets 2026-09-01): otherwise it falls back to the
+  static `CTOMOP_SERVICE_TOKEN` and `GET /api/patient-info/{person_id}/`.
 
-`CTOMOP_BASE` and `CTOMOP_SERVICE_TOKEN` come from Django settings (each
-read from the corresponding env var with empty-string defaults). Uses
-`requests` rather than `httpx` per the original issue spec because
-`requests` is already in `requirements.txt`; adding `httpx` solely for
-this endpoint isn't justified.
+Either way `fetch_patient(person_id)` returns the flat row dict (the shape
+`normalize_ctomop_row` expects) or `None` on any error path (network failure,
+4xx/5xx, malformed JSON, missing config, OAuth token failure). Returning `None`
+rather than raising lets the resolver treat the failure like a missing payload —
+the caller can proceed without patient context (e.g. public trial browsing).
+
+Config comes from Django settings (each read from the matching env var, empty
+defaults): `CTOMOP_BASE`, `CTOMOP_SERVICE_TOKEN` (legacy), and
+`CTOMOP_OAUTH_CLIENT_ID` / `_CLIENT_SECRET` / `_SCOPE` / `_TOKEN_URL` (OAuth).
+Uses `requests` (already in requirements) rather than adding `httpx`.
 """
 import logging
+import threading
+import time
 
 import requests
 from django.conf import settings
@@ -26,41 +34,143 @@ logger = logging.getLogger(__name__)
 
 
 DEFAULT_TIMEOUT_SECONDS = 10
+# Refresh a service token this many seconds before its stated expiry, so an
+# in-flight request never rides a just-expired token.
+_TOKEN_EXPIRY_MARGIN_SECONDS = 30
+
+# Process-local cache of service access tokens, keyed by (token_url, client_id,
+# scope). Tokens are short-lived; a per-process cache is enough (no need to
+# share across workers) and avoids a token round-trip on every patient fetch.
+_token_lock = threading.Lock()
+_token_cache: dict[tuple, tuple[str, float]] = {}
+
+
+def _clear_token_cache() -> None:
+    """Drop all cached service tokens (used by tests)."""
+    with _token_lock:
+        _token_cache.clear()
+
+
+def _get_service_access_token(token_url, client_id, client_secret, scope, timeout):
+    """Return a cached-or-freshly-minted OAuth2 client_credentials access token.
+
+    Returns `None` (never raises) on any failure so callers fail closed to a
+    missing-patient result. The token endpoint is hit at most once per token
+    lifetime per process; the fetch is serialized under a lock to avoid a
+    refresh stampede.
+    """
+    key = (token_url, client_id, scope)
+    now = time.time()
+    with _token_lock:
+        cached = _token_cache.get(key)
+        if cached and cached[1] > now:
+            return cached[0]
+
+        # HTTP Basic client auth + grant_type=client_credentials (RFC 6749 §4.4).
+        # allow_redirects=False: never let the token endpoint bounce the request
+        # (and the Basic-auth client_secret) to another host/scheme.
+        try:
+            resp = requests.post(
+                token_url,
+                data={'grant_type': 'client_credentials', 'scope': scope},
+                auth=(client_id, client_secret),
+                timeout=timeout,
+                allow_redirects=False,
+            )
+        except requests.RequestException as exc:
+            logger.warning('CtomopClient OAuth token request failed: %s', exc)
+            return None
+        if not resp.ok:
+            logger.warning('CtomopClient OAuth token non-OK response: %s %s',
+                           resp.status_code, resp.reason)
+            return None
+        try:
+            data = resp.json()
+        except ValueError:
+            logger.warning('CtomopClient OAuth token non-JSON body')
+            return None
+
+        access_token = data.get('access_token') if isinstance(data, dict) else None
+        if not access_token:
+            logger.warning('CtomopClient OAuth token response missing access_token')
+            return None
+        try:
+            ttl = float(data.get('expires_in') or 3600)
+        except (TypeError, ValueError):
+            ttl = 3600.0
+        _token_cache[key] = (access_token, now + max(0.0, ttl - _TOKEN_EXPIRY_MARGIN_SECONDS))
+        return access_token
 
 
 class CtomopClient:
     def __init__(self, base_url: str | None = None, token: str | None = None,
-                 timeout: float = DEFAULT_TIMEOUT_SECONDS):
+                 timeout: float = DEFAULT_TIMEOUT_SECONDS,
+                 oauth_client_id: str | None = None, oauth_client_secret: str | None = None,
+                 oauth_scope: str | None = None, oauth_token_url: str | None = None):
         self.base_url = (base_url if base_url is not None
                          else getattr(settings, 'CTOMOP_BASE', '')).rstrip('/')
         self.token = token if token is not None else getattr(settings, 'CTOMOP_SERVICE_TOKEN', '')
         self.timeout = timeout
+        self.oauth_client_id = (oauth_client_id if oauth_client_id is not None
+                                else getattr(settings, 'CTOMOP_OAUTH_CLIENT_ID', ''))
+        self.oauth_client_secret = (oauth_client_secret if oauth_client_secret is not None
+                                    else getattr(settings, 'CTOMOP_OAUTH_CLIENT_SECRET', ''))
+        self.oauth_scope = (oauth_scope if oauth_scope is not None
+                            else getattr(settings, 'CTOMOP_OAUTH_SCOPE', 'patient/*.read'))
+        self.oauth_token_url = (
+            (oauth_token_url if oauth_token_url is not None
+             else getattr(settings, 'CTOMOP_OAUTH_TOKEN_URL', ''))
+            or (f'{self.base_url}/o/token/' if self.base_url else '')
+        )
+        # A half-configured OAuth setup (exactly one of id/secret) silently
+        # drops to the legacy path — surface it so the misconfiguration isn't
+        # mistaken for a working OAuth deployment.
+        if bool(self.oauth_client_id) != bool(self.oauth_client_secret):
+            logger.warning(
+                'CtomopClient: partial OAuth config (only %s set); falling back '
+                'to legacy static-token transport.',
+                'client_id' if self.oauth_client_id else 'client_secret',
+            )
+
+    @property
+    def use_oauth(self) -> bool:
+        """v1 + OAuth when both client credentials are configured; else legacy."""
+        return bool(self.oauth_client_id and self.oauth_client_secret)
+
+    def _patient_url(self, person_id_int: int) -> str:
+        if self.use_oauth:
+            return f'{self.base_url}/api/v1/patient-records/{person_id_int}/'
+        return f'{self.base_url}/api/patient-info/{person_id_int}/'
+
+    def _authorization(self) -> str | None:
+        """Bearer header value, or None when it can't be built (caller fails closed)."""
+        if self.use_oauth:
+            tok = _get_service_access_token(
+                self.oauth_token_url, self.oauth_client_id,
+                self.oauth_client_secret, self.oauth_scope, self.timeout,
+            )
+            return f'Bearer {tok}' if tok else None
+        return f'Bearer {self.token}' if self.token else None
 
     def fetch_patient(self, person_id) -> dict | None:
-        """GET {base}/api/patient-info/{person_id}/ and return the flat JSON row.
+        """Fetch the patient row and return the flat JSON row (or None on any error).
 
-        The endpoint wraps the row in a `{"patient_info": {...}}` envelope (the
-        same shape the inline-payload request body uses). This method unwraps
-        that envelope so callers always receive a flat row — matching the shape
-        `normalize_ctomop_row`/`build_patient_info_from_ctomop_row` expect and
-        the psql management-command path already yields. Without unwrapping,
-        every real field would be nested one level too deep, silently dropped
-        by the model-field filter in `_build_in_memory`, and the PatientInfo
-        would be built entirely from defaults (#144).
+        v1 (`/api/v1/patient-records/{id}/`) and legacy (`/api/patient-info/{id}/`)
+        both wrap the row in a `{"patient_info": {...}}` envelope; v1 additionally
+        carries a sibling `user` block and drops `patient_info_id`. This method
+        unwraps the `patient_info` envelope (ignoring siblings), so callers always
+        receive a flat row matching `normalize_ctomop_row` — without unwrapping,
+        every real field would be nested one level too deep and silently dropped
+        (#144).
 
-        `person_id` MUST be a positive integer (CTOMOP's primary key shape);
-        anything else returns None without making a network call. This guards
-        against URL path injection — without the check, a caller could send
-        `person_id='../some-other-endpoint'` and the Bearer service token
-        would leak to that path along with the request.
+        `person_id` MUST be a positive integer (the patient primary-key shape);
+        anything else returns None without a network call — a guard against URL
+        path injection that would otherwise leak the Bearer token to a crafted path.
 
-        Also returns None when:
-        - `CTOMOP_BASE` is unset (the endpoint isn't configured).
-        - The network call fails (connection error, timeout).
-        - The HTTP status is non-2xx.
-        - The response body isn't a JSON object.
-        Logs at WARNING level so failures surface in Sentry / log
-        aggregation without short-circuiting the caller.
+        Returns None when: `CTOMOP_BASE` is unset; the OAuth token can't be
+        obtained (OAuth mode); the network call fails; the status is non-2xx; or
+        the body isn't a JSON object. Logs at WARNING so failures surface without
+        short-circuiting the caller.
         """
         if not self.base_url:
             logger.warning(
@@ -71,7 +181,7 @@ class CtomopClient:
 
         try:
             person_id_int = int(person_id)
-        except (TypeError, ValueError):
+        except (TypeError, ValueError, OverflowError):
             logger.warning(
                 'CtomopClient.fetch_patient rejected non-integer person_id %r', person_id,
             )
@@ -82,11 +192,18 @@ class CtomopClient:
             )
             return None
 
-        url = f'{self.base_url}/api/patient-info/{person_id_int}/'
         headers = {'Accept': 'application/json'}
-        if self.token:
-            headers['Authorization'] = f'Bearer {self.token}'
+        authorization = self._authorization()
+        if self.use_oauth and authorization is None:
+            logger.warning(
+                'CtomopClient could not obtain an OAuth token; returning None (person_id=%s)',
+                person_id,
+            )
+            return None
+        if authorization:
+            headers['Authorization'] = authorization
 
+        url = self._patient_url(person_id_int)
         try:
             response = requests.get(url, headers=headers, timeout=self.timeout)
         except requests.RequestException as exc:
@@ -113,16 +230,12 @@ class CtomopClient:
             )
             return None
 
-        # Unwrap the `{"patient_info": {...}}` envelope the HTTP endpoint emits
+        # Unwrap the `{"patient_info": {...}}` envelope (both v0 and v1 emit it)
         # so the adapter receives a flat row. Unwrap whenever a dict-valued
-        # `patient_info` key is present — NOT only when it is the sole key. This
-        # mirrors the inline request-body contract (`resolve_patient_info` reads
-        # `data['patient_info']` and ignores siblings like `person_id`), so any
-        # envelope metadata CTOMOP adds alongside the row (status, pagination,
-        # request id) still unwraps correctly instead of silently reverting to
-        # the all-defaults bug. A flat psql-path row has no `patient_info`
-        # column, so it passes straight through. Logged at debug so future
-        # envelope drift stays observable (#144).
+        # `patient_info` key is present — not only when it is the sole key — so
+        # v1's sibling `user` block (and any other envelope metadata) is ignored
+        # rather than reverting to the all-defaults bug. A flat psql-path row has
+        # no `patient_info` key and passes straight through (#144).
         inner = data.get('patient_info')
         if isinstance(inner, dict):
             logger.debug(


### PR DESCRIPTION
## What

Migrate the CTOMOP/promop patient client off the deprecated static-token `/api/patient-info/{id}/` endpoint (**sunsets 2026-09-01**) to the OAuth2 `/api/v1/patient-records/{id}/` transport. Transport is chosen by configuration — legacy stays byte-identical until creds are set.

## Changes
- **OAuth2 client_credentials** against promop `/o/token/` (HTTP Basic, scope `patient/*.read`), process-local token cache (30s expiry margin, single serialized refresh — no stampede). `allow_redirects=False` on the token POST so the Basic-auth `client_secret` can't be redirected to another host.
- **Dual-path**: falls back byte-identically to legacy static-token `/api/patient-info/{id}/` when OAuth creds are absent (legacy path unchanged).
- **Fail-closed**: an OAuth token that can't be minted → `None`, no patient request; the legacy token is never used on the v1 path.
- **Guards**: non-positive / non-finite `person_id` (now also `OverflowError`) rejected with no network call (URL path-injection / token-leak guard). Warn on half-configured OAuth (only one of id/secret) instead of silently degrading.
- **Settings**: `CTOMOP_OAUTH_CLIENT_ID` / `_SECRET` / `_SCOPE` / `_TOKEN_URL` (token_url defaults to `{base}/o/token/`).

## Envelope
Both v0 and v1 wrap the row in `{"patient_info": {...}}`; v1 adds a sibling `user` block and drops `patient_info_id`. The existing unwrap ignores siblings, so callers still get a flat row for `normalize_ctomop_row`.

## Review
Two-part self-review (fresh-context subagent + codex). Addressed: token-redirect exfil vector (`allow_redirects=False`), `OverflowError` on `person_id`, the OAuth-never-falls-back-to-legacy test gap, and partial-config degradation. Deliberately deferred: HTTPS-scheme allowlist on the token URL (env-config controlled by ops; would break `http://localhost` dev) and moving the token POST outside the lock (the serialized refresh is intentional anti-stampede; the `?person_id=` path is IDOR-gated OFF in prod, so contention exposure is minimal).

## Tests
`tests/services/patient_info/test_ctomop_client.py`: +7 (`TestOAuthV1` now covers v1 URL + minted bearer, token caching, token failure → None/no-call, adversarial no-legacy-fallback, missing `access_token`, malformed `expires_in` default, `allow_redirects=False`, partial-config → legacy). Full patient_info slice: 160 passed. `makemigrations --check`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)