### PR TITLE
feat(omop): pin vocab-mirror release per request + resolve titles from it (#252)

### DIFF
--- a/exact/settings.py
+++ b/exact/settings.py
@@ -109,6 +109,10 @@ CORS_ALLOWED_ORIGINS = [
 CORS_ALLOW_ALL_ORIGINS = (
     os.environ.get('CORS_ALLOW_ALL_ORIGINS', 'false').lower() == 'true'
 )
+# Custom response headers a browser client is allowed to READ cross-origin.
+# X-Exact-OMOP-Release names the vocab-mirror release a response's OMOP titles
+# were resolved from (#252); without exposing it, cross-origin JS can't see it.
+CORS_EXPOSE_HEADERS = ['X-Exact-OMOP-Release']
 
 # ---------------------------------------------------------------------------
 # Security headers (deployed environments)

--- a/tests/services/test_omop_component_type_matching.py
+++ b/tests/services/test_omop_component_type_matching.py
@@ -184,10 +184,33 @@ def test_display_component_title_falls_back_to_concept_id_when_not_local():
 
 # ── detail response: OMOP code + title (omopConcepts) ────────────────
 
+def _activate_mirror(release_id, concepts):
+    """Seed a minimal complete generation (concepts + one gate row per other
+    table) and activate it, so title resolution reads it (#252)."""
+    from vocab_mirror.activation import activate_release
+    from vocab_mirror.models import (
+        MirrorConcept, MirrorConceptAncestor, MirrorConceptRelationship,
+        MirrorRelease, MirrorVocabulary,
+    )
+    MirrorVocabulary.objects.create(release_id=release_id, vocabulary_id='V',
+                                    vocabulary_name='V', vocabulary_concept_id=1)
+    MirrorConceptRelationship.objects.create(release_id=release_id, concept_id_1=1,
+                                             concept_id_2=2, relationship_id='seed')
+    MirrorConceptAncestor.objects.create(release_id=release_id, ancestor_concept_id=1,
+                                         descendant_concept_id=2,
+                                         min_levels_of_separation=1, max_levels_of_separation=1)
+    for cid, name, vocab in concepts:
+        MirrorConcept.objects.create(release_id=release_id, concept_id=cid, concept_name=name,
+                                     domain_id='Drug', vocabulary_id=vocab,
+                                     concept_class_id='Ingredient', concept_code=str(cid))
+    MirrorRelease.objects.create(release_id=release_id, state=MirrorRelease.READY)
+    activate_release(release_id)
+
+
 @override_settings(EXACT_OMOP_THERAPY=True)
 def test_display_includes_omop_concepts_code_and_title():
     _graph()
-    OmopConcept.objects.create(concept_id=BORT_CID, concept_name='bortezomib', vocabulary_id='RxNorm')
+    _activate_mirror(1, [(BORT_CID, 'bortezomib', 'RxNorm')])  # titles come from the mirror now
     pi = PatientInfo(disease='multiple myeloma', first_line_therapy=str(VRD_CID),
                      prior_therapy='One line', therapy_component_ids=[BORT_CID])
     trial = TrialFactory(disease='multiple myeloma', omop_therapy_components_required=[str(BORT_CID)])

--- a/tests/views/test_omop_release_header.py
+++ b/tests/views/test_omop_release_header.py
@@ -1,0 +1,70 @@
+"""API-level test for the X-Exact-OMOP-Release response header (#252).
+
+The header names the vocab-mirror release a response's OMOP titles were resolved
+from — present only when OMOP mode is on AND a release is active.
+"""
+import pytest
+from django.test import override_settings
+from rest_framework.authtoken.models import Token
+from rest_framework.test import APIClient
+
+from accounts.models import Identity
+from tests.factories import TrialFactory
+from vocab_mirror.activation import activate_release
+from vocab_mirror.models import (
+    MirrorConcept,
+    MirrorConceptAncestor,
+    MirrorConceptRelationship,
+    MirrorRelease,
+    MirrorVocabulary,
+)
+
+HEADER = 'X-Exact-OMOP-Release'
+
+
+@pytest.fixture
+def authed_client(db):
+    user, _ = Identity.objects.get_or_create(issuer='urn:local', sub='hdr-tester')
+    token, _ = Token.objects.get_or_create(user=user)
+    client = APIClient()
+    client.credentials(HTTP_AUTHORIZATION=f'Token {token.key}')
+    return client
+
+
+def _activate(rid=3):
+    MirrorVocabulary.objects.create(release_id=rid, vocabulary_id='V', vocabulary_name='V',
+                                    vocabulary_concept_id=1)
+    MirrorConcept.objects.create(release_id=rid, concept_id=1, concept_name='c', domain_id='D',
+                                 vocabulary_id='V', concept_class_id='C', concept_code='1')
+    MirrorConceptRelationship.objects.create(release_id=rid, concept_id_1=1, concept_id_2=2,
+                                             relationship_id='seed')
+    MirrorConceptAncestor.objects.create(release_id=rid, ancestor_concept_id=1, descendant_concept_id=2,
+                                         min_levels_of_separation=1, max_levels_of_separation=1)
+    MirrorRelease.objects.create(release_id=rid, state=MirrorRelease.READY)
+    activate_release(rid)
+
+
+@override_settings(EXACT_OMOP_THERAPY=True)
+def test_header_present_when_omop_on_with_active_release(authed_client):
+    _activate(3)
+    TrialFactory(disease='Multiple Myeloma')
+    resp = authed_client.get('/trials/')
+    assert resp.status_code == 200
+    assert resp[HEADER] == '3'
+
+
+@override_settings(EXACT_OMOP_THERAPY=True)
+def test_header_absent_when_no_active_release(authed_client):
+    TrialFactory(disease='Multiple Myeloma')
+    resp = authed_client.get('/trials/')
+    assert resp.status_code == 200
+    assert HEADER not in resp
+
+
+@override_settings(EXACT_OMOP_THERAPY=False)
+def test_header_absent_when_omop_off(authed_client):
+    _activate(3)  # a release is active, but OMOP matching is off
+    TrialFactory(disease='Multiple Myeloma')
+    resp = authed_client.get('/trials/')
+    assert resp.status_code == 200
+    assert HEADER not in resp

--- a/tests/vocab_mirror/test_release_context.py
+++ b/tests/vocab_mirror/test_release_context.py
@@ -1,0 +1,110 @@
+"""Per-request release pin + mirror title resolution tests (#252 / ADR 0002)."""
+import pytest
+from django.test import override_settings
+
+from vocab_mirror.activation import activate_release
+from vocab_mirror.models import (
+    MirrorConcept,
+    MirrorConceptAncestor,
+    MirrorConceptRelationship,
+    MirrorRelease,
+    MirrorVocabulary,
+)
+from vocab_mirror.release_context import (
+    MatchingReleaseContext,
+    _pinned_release,
+    active_pinned_release,
+)
+
+pytestmark = pytest.mark.django_db
+
+
+def _activate(rid=5, concepts=()):
+    MirrorVocabulary.objects.create(release_id=rid, vocabulary_id='V', vocabulary_name='V',
+                                    vocabulary_concept_id=1)
+    MirrorConceptRelationship.objects.create(release_id=rid, concept_id_1=1, concept_id_2=2,
+                                             relationship_id='seed')
+    MirrorConceptAncestor.objects.create(release_id=rid, ancestor_concept_id=1, descendant_concept_id=2,
+                                         min_levels_of_separation=1, max_levels_of_separation=1)
+    MirrorConcept.objects.create(release_id=rid, concept_id=1, concept_name='c', domain_id='D',
+                                 vocabulary_id='V', concept_class_id='C', concept_code='1')
+    for cid, name, vocab in concepts:
+        MirrorConcept.objects.create(release_id=rid, concept_id=cid, concept_name=name,
+                                     domain_id='D', vocabulary_id=vocab, concept_class_id='C',
+                                     concept_code=str(cid))
+    MirrorRelease.objects.create(release_id=rid, state=MirrorRelease.READY)
+    activate_release(rid)
+
+
+class TestActivePinnedRelease:
+    def test_falls_back_to_active_release_when_unpinned(self):
+        _activate(5)
+        assert active_pinned_release() == 5  # no context -> active_release_id()
+
+    def test_none_when_nothing_active_and_unpinned(self):
+        assert active_pinned_release() is None
+
+    def test_context_pin_wins_over_active(self):
+        _activate(5)
+        token = _pinned_release.set(99)
+        try:
+            assert active_pinned_release() == 99
+        finally:
+            _pinned_release.reset(token)
+
+
+class TestMatchingReleaseContext:
+    @override_settings(EXACT_OMOP_THERAPY=False)
+    def test_omop_off_pins_none_and_no_header(self):
+        _activate(5)  # active release exists, but OMOP is off
+        with MatchingReleaseContext() as ctx:
+            assert ctx.omop_active is False
+            assert ctx.release_id is None
+            assert ctx.header is None
+            # pinned to None (not the sentinel) -> readers get None, NOT the live 5
+            assert active_pinned_release() is None
+
+    @override_settings(EXACT_OMOP_THERAPY=True)
+    def test_omop_on_pins_active_release_and_sets_header(self):
+        _activate(5)
+        with MatchingReleaseContext() as ctx:
+            assert ctx.omop_active is True
+            assert ctx.release_id == 5
+            assert ctx.header == '5'
+            assert active_pinned_release() == 5
+        # pin is reset after the block -> unpinned, falls back to active_release_id()
+        assert active_pinned_release() == 5
+
+    @override_settings(EXACT_OMOP_THERAPY=True)
+    def test_omop_on_no_active_release_pins_none(self):
+        with MatchingReleaseContext() as ctx:
+            assert ctx.release_id is None
+            assert ctx.header is None
+            assert active_pinned_release() is None
+
+
+class TestMirrorTitleResolution:
+    """_resolve_omop_concepts reads the release-pinned mirror, fail-soft."""
+
+    def _resolve(self, *a, **kw):
+        from trials.services.user_to_trial_attr_matcher import _resolve_omop_concepts
+        return _resolve_omop_concepts(*a, **kw)
+
+    def test_no_active_release_is_code_only(self):
+        assert self._resolve([100]) == [{'code': 100, 'title': None, 'vocab': None}]
+
+    def test_active_release_resolves_titles(self):
+        _activate(5, concepts=[(100, 'Bortezomib', 'RxNorm')])
+        assert self._resolve([100]) == [{'code': 100, 'title': 'Bortezomib', 'vocab': 'RxNorm'}]
+
+    def test_unresolved_concept_in_active_release_is_code_only(self):
+        _activate(5, concepts=[(100, 'Bortezomib', 'RxNorm')])
+        assert self._resolve([999]) == [{'code': 999, 'title': None, 'vocab': None}]
+
+    def test_explicit_release_id_overrides_the_pin(self):
+        _activate(5, concepts=[(100, 'active-name', 'RxNorm')])
+        MirrorConcept.objects.create(release_id=7, concept_id=100, concept_name='other-release',
+                                     domain_id='D', vocabulary_id='HemOnc', concept_class_id='C',
+                                     concept_code='100')
+        assert self._resolve([100], release_id=7) == [
+            {'code': 100, 'title': 'other-release', 'vocab': 'HemOnc'}]

--- a/trials/api/trials_views.py
+++ b/trials/api/trials_views.py
@@ -61,6 +61,24 @@ class TrialsViewSet(viewsets.ReadOnlyModelViewSet):
     search_fields = ['brief_title', 'official_title']
     pagination_class = TrialsPagination
 
+    def dispatch(self, request, *args, **kwargs):
+        # Pin one vocab-mirror release for the whole request (OMOP mode only), so
+        # every mirror read (title resolution) sees one generation and can never
+        # straddle an activation mid-request (#252 / ADR 0002). finalize_response
+        # runs inside this block, so the header sees the same context.
+        from vocab_mirror.release_context import MatchingReleaseContext
+        with MatchingReleaseContext() as ctx:
+            self._release_ctx = ctx
+            return super().dispatch(request, *args, **kwargs)
+
+    def finalize_response(self, request, response, *args, **kwargs):
+        response = super().finalize_response(request, response, *args, **kwargs)
+        ctx = getattr(self, '_release_ctx', None)
+        if ctx is not None and ctx.header:
+            from vocab_mirror.release_context import RELEASE_HEADER
+            response[RELEASE_HEADER] = ctx.header
+        return response
+
     def _resolve_patient_info(self) -> Optional['PatientInfo']:
         # Resolve at most once per request: get_queryset and
         # get_serializer_context both call this, and `search` can hit it

--- a/trials/services/user_to_trial_attr_matcher.py
+++ b/trials/services/user_to_trial_attr_matcher.py
@@ -129,7 +129,11 @@ def _resolve_omop_concepts(concept_id_values, release_id=None):
     """
     if not concept_id_values:
         return []
-    from django.db import DatabaseError
+    # django.db.Error is the base of the whole DB-API exception tree, incl.
+    # InterfaceError ("connection already closed"), which is a sibling of
+    # DatabaseError — not a subclass — so it must be caught here too, else a
+    # dropped mirror connection would 500 instead of degrading to code-only.
+    from django.db import Error as DBError
 
     from vocab_mirror.models import MirrorConcept
     from vocab_mirror.release_context import active_pinned_release
@@ -144,7 +148,7 @@ def _resolve_omop_concepts(concept_id_values, release_id=None):
                 for c in MirrorConcept.objects.filter(release_id=rid, concept_id__in=cids)
                 .values('concept_id', 'concept_name', 'vocabulary_id')
             }
-        except DatabaseError:
+        except DBError:
             # Presentation must never break the response — a mirror DB hiccup
             # degrades to code-only titles, not a 500.
             logger.warning('vocab mirror title lookup failed; returning code-only',

--- a/trials/services/user_to_trial_attr_matcher.py
+++ b/trials/services/user_to_trial_attr_matcher.py
@@ -1,9 +1,12 @@
 import itertools
 import datetime as dt
+import logging
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal, Optional
 
 from trials.services.therapy_match_profile import THERAPY_MATCH_PROFILE
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from trials.models import Trial
@@ -113,22 +116,48 @@ def min_max_match(
         return 'matched'
 
 
-def _resolve_omop_concepts(concept_id_values):
-    """Resolve a list of OMOP concept_id strings to [{code, title, vocab}] via
-    OmopConcept. Unresolved concept_ids still return their code (title/vocab None)."""
+def _resolve_omop_concepts(concept_id_values, release_id=None):
+    """Resolve OMOP concept_id strings to ``[{code, title, vocab}]`` from the
+    release-pinned local vocab mirror (#252 / ADR 0002).
+
+    Reads the mirror ``concept`` table for the pinned release — explicit
+    ``release_id`` overrides the request pin, which falls back to the active
+    release. This is **presentation** (the trial detail ``omopConcepts`` block),
+    so it fails **soft**: an unresolved concept_id (or no active release at all)
+    still returns its ``code`` with ``title``/``vocab`` = ``None``, exactly as
+    before — a missing title never affects eligibility.
+    """
     if not concept_id_values:
         return []
-    from trials.models import OmopConcept
-    cids = [int(v) for v in concept_id_values if str(v).isdigit()]
-    by_id = {c.concept_id: c for c in OmopConcept.objects.filter(concept_id__in=cids)}
+    from django.db import DatabaseError
+
+    from vocab_mirror.models import MirrorConcept
+    from vocab_mirror.release_context import active_pinned_release
+
+    rid = release_id if release_id is not None else active_pinned_release()
+    by_id = {}
+    if rid is not None:
+        cids = [int(v) for v in concept_id_values if str(v).isdigit()]
+        try:
+            by_id = {
+                c['concept_id']: c
+                for c in MirrorConcept.objects.filter(release_id=rid, concept_id__in=cids)
+                .values('concept_id', 'concept_name', 'vocabulary_id')
+            }
+        except DatabaseError:
+            # Presentation must never break the response — a mirror DB hiccup
+            # degrades to code-only titles, not a 500.
+            logger.warning('vocab mirror title lookup failed; returning code-only',
+                           exc_info=True)
+            by_id = {}
     out = []
     for v in concept_id_values:
         code = int(v) if str(v).isdigit() else v
         c = by_id.get(code) if isinstance(code, int) else None
         out.append({
             'code': code,
-            'title': c.concept_name if c else None,
-            'vocab': c.vocabulary_id if c else None,
+            'title': c['concept_name'] if c else None,
+            'vocab': c['vocabulary_id'] if c else None,
         })
     return out
 

--- a/vocab_mirror/release_context.py
+++ b/vocab_mirror/release_context.py
@@ -1,0 +1,70 @@
+"""Per-request pin of the active vocab-mirror release (#252 / ADR 0002).
+
+When OMOP therapy matching is on, everything that reads the mirror in one request
+must see ONE release generation. `MatchingReleaseContext` resolves
+`active_release_id()` **once** at the request boundary and stashes it in a
+request-scoped contextvar; mirror readers (e.g. title resolution) pick it up via
+`active_pinned_release()`. A reader may also take an explicit `release_id` that
+overrides the contextvar (the hybrid contract):
+``rid = release_id if release_id is not None else active_pinned_release()``.
+
+Scope of this slice: **presentation only** — the pinned release drives title /
+vocabulary resolution and the ``X-Exact-OMOP-Release`` response header. Eligibility
+still reads the materialized trial ``omop_*`` columns, not the mirror, so there is
+deliberately **no fail-closed 503 here** — that lands with Phase-T, when the graph
+traversal goes on the eligibility path.
+"""
+import contextvars
+
+from vocab_mirror.activation import active_release_id
+from trials.services.therapy_match_profile import omop_therapy_enabled
+
+# Header naming the release a response's OMOP titles were resolved from (obs.).
+RELEASE_HEADER = 'X-Exact-OMOP-Release'
+
+# Request-scoped pin. The default sentinel means "not inside a pinned request"
+# (non-HTTP callers) — distinct from a context that pins ``None`` (OMOP off / no
+# active release), which must NOT fall back to the live active release.
+_UNSET = object()
+_pinned_release: contextvars.ContextVar = contextvars.ContextVar(
+    'vocab_mirror_pinned_release', default=_UNSET)
+
+
+def active_pinned_release():
+    """The release mirror readers should use: the request pin if a
+    ``MatchingReleaseContext`` set one (an int, or ``None`` when OMOP is off / no
+    release is active), else — for callers outside any request (mgmt commands,
+    model helpers) — the current active release. ``None`` ⇒ readers fail soft."""
+    pinned = _pinned_release.get()
+    if pinned is _UNSET:
+        return active_release_id()
+    return pinned
+
+
+class MatchingReleaseContext:
+    """Context manager that pins the active release for a request.
+
+    Resolves the active release once (only when OMOP mode is on) and binds it to
+    the request-scoped contextvar for the ``with`` block, so a single request
+    never straddles an activation. Exposes ``header`` for ``X-Exact-OMOP-Release``.
+    """
+
+    def __init__(self):
+        self.omop_active = omop_therapy_enabled()
+        self.release_id = active_release_id() if self.omop_active else None
+        self._token = None
+
+    def __enter__(self):
+        self._token = _pinned_release.set(self.release_id if self.omop_active else None)
+        return self
+
+    def __exit__(self, *exc):
+        if self._token is not None:
+            _pinned_release.reset(self._token)
+        return False
+
+    @property
+    def header(self):
+        if self.omop_active and self.release_id is not None:
+            return str(self.release_id)
+        return None

--- a/vocab_mirror/release_context.py
+++ b/vocab_mirror/release_context.py
@@ -55,7 +55,8 @@ class MatchingReleaseContext:
         self._token = None
 
     def __enter__(self):
-        self._token = _pinned_release.set(self.release_id if self.omop_active else None)
+        # release_id is already None whenever omop is off (see __init__).
+        self._token = _pinned_release.set(self.release_id)
         return self
 
     def __exit__(self, *exc):

--- a/vocab_mirror/traversal.py
+++ b/vocab_mirror/traversal.py
@@ -81,6 +81,11 @@ class LocalConceptGraph:
 
     def _pin(self, release_id=None):
         if self._pinned is None:
+            # Phase-T note (#252 review): when this traversal is wired onto the
+            # eligibility path, resolve via `release_context.active_pinned_release()`
+            # (or an explicitly threaded release_id) so it honors the per-request
+            # pin, not the live active release — else a graph expansion could
+            # straddle an activation mid-request despite the request pin.
             rid = (release_id if release_id is not None
                    else self._release_id if self._release_id is not None
                    else active_release_id())


### PR DESCRIPTION
First slice of the wiring epic **#246** (ADR 0002). Advances **#252**. Base `2omop` (the mirror epic #248–#251 is merged).

## What — presentation integration (no eligibility change)
- **`MatchingReleaseContext`** (`vocab_mirror/release_context.py`): resolves `active_release_id()` **once** per request (only when `omop_therapy_enabled()`) into a request-scoped **contextvar**, so every mirror read in one request sees one generation. `active_pinned_release()` returns the pin (int, or `None` when OMOP-off/no-active via an `_UNSET` sentinel; non-HTTP callers fall back to the active release).
- **`TrialsViewSet.dispatch`** wraps the request; **`finalize_response`** adds **`X-Exact-OMOP-Release`** (+ `CORS_EXPOSE_HEADERS`). Zero mirror queries when OMOP is off.
- **`_resolve_omop_concepts`** reads the release-pinned mirror `concept` table (was `OmopConcept`); explicit `release_id` overrides. **Fail-soft**: a miss / no release / a DB error → code-only titles, never a 500, never an eligibility change (`omopConcepts` is additive detail).

**Deliberately no fail-closed 503** — eligibility still reads the materialized trial `omop_*` columns (Phase-T deferred), so nothing eligibility-critical reads the mirror yet.

## Review & tests
Two-part self-review (fresh-context agent + codex), **no P1**: both confirmed no behavior change when OMOP off, no contextvar leak (ContextVar is the right primitive; token reset sound), titles never feed eligibility, `OmopConcept` has no remaining eligibility reader. Addressed: `DatabaseError` guard on the mirror query (presentation never 500s), `CORS_EXPOSE_HEADERS`, an **API-level header test** (present / no-release / off), a Phase-T note on `traversal._pin`, and a docstring fix. Tests: full suite **1055 passed / 5 skipped**; `makemigrations --check` clean.

## Remaining #252 scope (split out)
- `ComponentCategoryOmopLookup` release-versioning + cross-artifact readiness gate (bigger, eligibility-adjacent).
- Phase-T graph flip (separate measured decision; `LocalConceptGraph` is ready).

🤖 Generated with [Claude Code](https://claude.com/claude-code)