### PR TITLE
feat(omop): Phase-T gating measurement — count regimen-unresolved (#263)

### DIFF
--- a/tests/services/test_phase_t_measurement.py
+++ b/tests/services/test_phase_t_measurement.py
@@ -1,0 +1,79 @@
+"""Phase-T gating measurement (#263).
+
+The regimen-unresolved counter must fire exactly when a regimen is present at
+matching under OMOP but the consumer supplied no components — and never otherwise
+(components supplied, no regimen, or the flag off). Observation only: the return
+value of ``derive_component_and_type_values`` is unchanged by the measurement.
+"""
+import pytest
+from django.test import override_settings
+
+from trials.services.omop.therapy_graph import derive_component_and_type_values
+from trials.services.omop.phase_t_metrics import (
+    record_regimen_unresolved,
+    regimen_unresolved_count,
+    reset_regimen_unresolved_count,
+)
+
+REGIMEN_CID, COMP_CID = 900260, 900825
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture(autouse=True)
+def _reset_counter():
+    reset_regimen_unresolved_count()
+    yield
+    reset_regimen_unresolved_count()
+
+
+# ── the helper itself ────────────────────────────────────────────────────────
+
+def test_record_increments_and_reset_clears():
+    assert regimen_unresolved_count() == 0
+    record_regimen_unresolved([REGIMEN_CID])
+    record_regimen_unresolved([REGIMEN_CID])
+    assert regimen_unresolved_count() == 2
+    reset_regimen_unresolved_count()
+    assert regimen_unresolved_count() == 0
+
+
+def test_record_tolerates_none():
+    record_regimen_unresolved(None)  # must not raise
+    assert regimen_unresolved_count() == 1
+
+
+# ── fired via the derivation chokepoint ──────────────────────────────────────
+
+@override_settings(EXACT_OMOP_THERAPY=True)
+def test_counts_when_regimen_present_and_no_components():
+    result = derive_component_and_type_values([str(REGIMEN_CID)], None)
+    assert result == (None, None)          # behavior unchanged
+    assert regimen_unresolved_count() == 1
+
+
+@override_settings(EXACT_OMOP_THERAPY=True)
+def test_no_count_when_components_supplied():
+    derive_component_and_type_values([str(REGIMEN_CID)], [str(COMP_CID)])
+    assert regimen_unresolved_count() == 0
+
+
+@override_settings(EXACT_OMOP_THERAPY=True)
+def test_no_count_when_components_known_empty():
+    # [] is a known-empty component set (the consumer answered), not unresolved.
+    derive_component_and_type_values([str(REGIMEN_CID)], [])
+    assert regimen_unresolved_count() == 0
+
+
+@override_settings(EXACT_OMOP_THERAPY=True)
+def test_no_count_when_no_regimen():
+    # Nothing to resolve → not a Phase-T-relevant miss.
+    derive_component_and_type_values([], None)
+    assert regimen_unresolved_count() == 0
+
+
+@override_settings(EXACT_OMOP_THERAPY=False)
+def test_no_count_when_flag_off():
+    # Legacy path never involves consumer components; not a Phase-T signal.
+    derive_component_and_type_values([str(REGIMEN_CID)], None)
+    assert regimen_unresolved_count() == 0

--- a/tests/services/test_phase_t_measurement.py
+++ b/tests/services/test_phase_t_measurement.py
@@ -43,37 +43,49 @@ def test_record_tolerates_none():
     assert regimen_unresolved_count() == 1
 
 
-# ── fired via the derivation chokepoint ──────────────────────────────────────
+# ── fired via the derivation chokepoint (only when measure=True) ─────────────
 
 @override_settings(EXACT_OMOP_THERAPY=True)
-def test_counts_when_regimen_present_and_no_components():
-    result = derive_component_and_type_values([str(REGIMEN_CID)], None)
+def test_counts_when_regimen_present_and_no_components(caplog):
+    import logging
+    with caplog.at_level(logging.INFO, logger='omop.phase_t'):
+        result = derive_component_and_type_values([str(REGIMEN_CID)], None, measure=True)
     assert result == (None, None)          # behavior unchanged
     assert regimen_unresolved_count() == 1
+    # the durable signal is the log event — assert it actually fired
+    assert any('regimen_unresolved' in r.message for r in caplog.records)
+
+
+@override_settings(EXACT_OMOP_THERAPY=True)
+def test_no_count_when_measure_off_matcher_path():
+    # The matcher path leaves measure=False → per-trial calls never record, so the
+    # signal stays once-per-search (no log flood).
+    derive_component_and_type_values([str(REGIMEN_CID)], None)  # measure defaults False
+    assert regimen_unresolved_count() == 0
 
 
 @override_settings(EXACT_OMOP_THERAPY=True)
 def test_no_count_when_components_supplied():
-    derive_component_and_type_values([str(REGIMEN_CID)], [str(COMP_CID)])
+    derive_component_and_type_values([str(REGIMEN_CID)], [str(COMP_CID)], measure=True)
     assert regimen_unresolved_count() == 0
 
 
 @override_settings(EXACT_OMOP_THERAPY=True)
 def test_no_count_when_components_known_empty():
     # [] is a known-empty component set (the consumer answered), not unresolved.
-    derive_component_and_type_values([str(REGIMEN_CID)], [])
+    derive_component_and_type_values([str(REGIMEN_CID)], [], measure=True)
     assert regimen_unresolved_count() == 0
 
 
 @override_settings(EXACT_OMOP_THERAPY=True)
 def test_no_count_when_no_regimen():
     # Nothing to resolve → not a Phase-T-relevant miss.
-    derive_component_and_type_values([], None)
+    derive_component_and_type_values([], None, measure=True)
     assert regimen_unresolved_count() == 0
 
 
 @override_settings(EXACT_OMOP_THERAPY=False)
 def test_no_count_when_flag_off():
     # Legacy path never involves consumer components; not a Phase-T signal.
-    derive_component_and_type_values([str(REGIMEN_CID)], None)
+    derive_component_and_type_values([str(REGIMEN_CID)], None, measure=True)
     assert regimen_unresolved_count() == 0

--- a/trials/querysets/trial.py
+++ b/trials/querysets/trial.py
@@ -1105,7 +1105,10 @@ class TrialQuerySet(models.QuerySet):
         # (patient_component_ids); types are CB category codes via the flat lookup.
         # Legacy: derived from the regimen via the CB graph. See omop/therapy_graph.
         from trials.services.omop.therapy_graph import derive_component_and_type_values
-        component_codes, therapy_types = derive_component_and_type_values(therapy_codes, patient_component_ids)
+        # measure=True: this is the once-per-search derivation, so the Phase-T
+        # gating metric (#263) is recorded here, not per-trial in the matcher.
+        component_codes, therapy_types = derive_component_and_type_values(
+            therapy_codes, patient_component_ids, measure=True)
 
         if component_codes:
             scope = scope.eligible_for_therapy_components(component_codes)

--- a/trials/services/omop/phase_t_metrics.py
+++ b/trials/services/omop/phase_t_metrics.py
@@ -10,15 +10,14 @@ type criteria as *unknown* (it does NOT expand the regimen locally). If that
 fail-closed 503s; if it is common, it justifies the flip.
 
 This module is **pure observation** — no behavior change, no eligibility impact. It
-emits a structured, greppable log event (aggregated downstream, where per-request
-context is available) plus a process-local counter for tests/introspection.
+emits a structured, greppable log event plus a process-local counter for tests.
 
-Granularity note: the signal fires at the shared derivation chokepoint
-(:func:`~trials.services.omop.therapy_graph.derive_component_and_type_values`), so it
-counts **per derivation call** — once per search (queryset build), once per trial
-scored (matcher), once per detail/backfill row. It is a rate proxy, not a distinct
-patient count; dedup by request id in the log aggregator if a per-request rate is
-needed.
+Granularity: the signal is recorded **once per search** — the search queryset passes
+``measure=True`` to the shared derivation, while the per-trial matcher leaves it off —
+so one regimen-unresolved patient search emits one log line, not one per trial scored
+(which would flood logs precisely when the metric matters most). It counts identifiers
+**as they arrive** (not resolvable-only), a slight over-count that is fine for a
+"did a regimen arrive without components" proxy.
 """
 import logging
 

--- a/trials/services/omop/phase_t_metrics.py
+++ b/trials/services/omop/phase_t_metrics.py
@@ -1,0 +1,52 @@
+"""Phase-T gating measurement (#263).
+
+Phase-T — wiring live regimen→component graph expansion onto the eligibility path —
+is a **measured** decision, not an automatic one (ADR 0002; epic #246). The gating
+metric is: how often does a regimen arrive at matching **without** consumer-supplied
+components? Under Phase P (#239) the consumer (promop) pre-expands and sends
+``patient_component_ids``; when it doesn't, EXACT currently treats the component /
+type criteria as *unknown* (it does NOT expand the regimen locally). If that
+"regimen-unresolved" case is rare, Phase-T may not be worth the added coupling and
+fail-closed 503s; if it is common, it justifies the flip.
+
+This module is **pure observation** — no behavior change, no eligibility impact. It
+emits a structured, greppable log event (aggregated downstream, where per-request
+context is available) plus a process-local counter for tests/introspection.
+
+Granularity note: the signal fires at the shared derivation chokepoint
+(:func:`~trials.services.omop.therapy_graph.derive_component_and_type_values`), so it
+counts **per derivation call** — once per search (queryset build), once per trial
+scored (matcher), once per detail/backfill row. It is a rate proxy, not a distinct
+patient count; dedup by request id in the log aggregator if a per-request rate is
+needed.
+"""
+import logging
+
+logger = logging.getLogger('omop.phase_t')
+
+# Process-local; for tests/introspection only (not a durable metric — the durable
+# signal is the log event below, counted in the log aggregator).
+_regimen_unresolved_count = 0
+
+
+def record_regimen_unresolved(regimen_identifiers):
+    """Record one regimen-unresolved occurrence: a regimen was present at matching
+    but no components were supplied by the consumer (Phase-T gating metric)."""
+    global _regimen_unresolved_count
+    _regimen_unresolved_count += 1
+    logger.info(
+        'regimen_unresolved: regimen present but no consumer-supplied components '
+        '(Phase-T gating metric); regimen_count=%d',
+        len(regimen_identifiers or []),
+    )
+
+
+def regimen_unresolved_count():
+    """Occurrences recorded in this process since the last reset (tests only)."""
+    return _regimen_unresolved_count
+
+
+def reset_regimen_unresolved_count():
+    """Reset the process-local counter (tests only)."""
+    global _regimen_unresolved_count
+    _regimen_unresolved_count = 0

--- a/trials/services/omop/therapy_graph.py
+++ b/trials/services/omop/therapy_graph.py
@@ -37,7 +37,8 @@ def resolve_regimens(therapy_identifiers):
     return Therapy.objects.filter(code__in=therapy_identifiers)
 
 
-def derive_component_and_type_values(therapy_identifiers, patient_component_ids=None):
+def derive_component_and_type_values(therapy_identifiers, patient_component_ids=None,
+                                     measure=False):
     """Return ``(component_values, type_values)`` for the patient's therapies.
 
     OMOP mode (Phase P, #234): components are the consumer-supplied pre-expanded
@@ -48,13 +49,16 @@ def derive_component_and_type_values(therapy_identifiers, patient_component_ids=
     only by the legacy path.
 
     Legacy mode (flag OFF): the internal CB-graph expansion — byte-identical to CB.
+
+    ``measure=True`` records the Phase-T gating metric (#263) when this call is the
+    per-search derivation (the search queryset passes it) — a regimen present under
+    OMOP with no consumer-supplied components. The matcher leaves it ``False`` so the
+    signal is emitted once per search, not once per trial scored. Observation only —
+    the return value is identical either way.
     """
     if omop_therapy_enabled():
         if patient_component_ids is None:
-            # A regimen with no consumer-supplied components is the Phase-T gating
-            # case (#263): today it stays "unknown" (no local expansion). Record it
-            # for the measured flip decision — observation only, no behavior change.
-            if therapy_identifiers:
+            if measure and therapy_identifiers:
                 from trials.services.omop.phase_t_metrics import record_regimen_unresolved
                 record_regimen_unresolved(therapy_identifiers)
             return None, None

--- a/trials/services/omop/therapy_graph.py
+++ b/trials/services/omop/therapy_graph.py
@@ -51,6 +51,12 @@ def derive_component_and_type_values(therapy_identifiers, patient_component_ids=
     """
     if omop_therapy_enabled():
         if patient_component_ids is None:
+            # A regimen with no consumer-supplied components is the Phase-T gating
+            # case (#263): today it stays "unknown" (no local expansion). Record it
+            # for the measured flip decision — observation only, no behavior change.
+            if therapy_identifiers:
+                from trials.services.omop.phase_t_metrics import record_regimen_unresolved
+                record_regimen_unresolved(therapy_identifiers)
             return None, None
         component_values = [str(cid) for cid in patient_component_ids]
         from trials.services.omop.component_category_lookup import component_concept_ids_to_type_codes


### PR DESCRIPTION
Part of epic #246. **Measurement slice only** — decided with the user; the actual graph-flip is deferred.

## Why measure first
Phase-T = wiring live regimen→component graph expansion onto the **eligibility** path. That would make eligibility depend on the mirror and introduce fail-closed 503s, and it stacks on #262 (PR #264) + #265. The ticket defines Phase-T as a **measured** decision: is a regimen ever seen at matching **without** consumer-supplied components (Phase P pre-expansion)? If that's rare, the flip may not be worth it. This PR instruments exactly that, with **zero behavior change** and no dependency on #262/#265.

## Change
- `phase_t_metrics.record_regimen_unresolved()` — structured log on the `omop.phase_t` logger + a process-local counter (tests).
- Recorded at the shared derivation chokepoint (`derive_component_and_type_values`) when OMOP is on, a regimen is present, and `patient_component_ids is None`.
- **Once per search**: the search queryset passes `measure=True`; the per-trial matcher leaves it `False` — so a regimen-unresolved patient search emits one log line, not one per trial scored.

## Review (two-part, pre-push)
- **codex**: no findings — behavior-neutral, correctly gated.
- **fresh-context subagent**: no merge-blockers. Its P2 (per-trial log flood at the chokepoint) fixed via the `measure` flag (once-per-search). P3s addressed (caplog assertion on the log event; matcher-path no-record test; documented the benign as-arrived over-count).

## Verification
Full suite **1063 passed, 5 skipped**; no migrations (service + metrics only). One unrelated pre-existing flaky (`test_eligible_for_inversed_bool_restriction_value`) passes in isolation and on re-run.

## Deferred (this ticket, post-measurement)
The actual flip — wire `LocalConceptGraph` regimen→component into matcher/backfill behind the flag, switch `_pin` → `active_pinned_release()`, add fail-closed 503 (`MAX_MIRROR_AGE`), accept a context-validated pinned release in the retention window — stays deferred until the metric justifies it AND #262/#265 land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)