### PR TITLE
fix(omop): vocab snapshot client offers */* so promop can't 406 the stream

### DIFF
--- a/tests/vocab_mirror/test_promop_vocab_client.py
+++ b/tests/vocab_mirror/test_promop_vocab_client.py
@@ -1,0 +1,62 @@
+"""PromopVocabClient request-contract tests (#250).
+
+Guards the request the client makes to promop's snapshot endpoint — in particular
+the Accept header, which must offer ``*/*`` alongside ``application/x-ndjson`` so
+promop's DRF content negotiation cannot 406 a stream the client parses itself
+(promop's VocabSnapshotView streams ndjson without registering a matching
+renderer). Found by the local vocab-mirror e2e.
+"""
+import json
+
+from vocab_mirror import promop_vocab_client as pvc
+from vocab_mirror.promop_vocab_client import PromopVocabClient
+
+
+class _FakeStreamResp:
+    def __init__(self, lines, status_code=200):
+        self._lines = lines
+        self.status_code = status_code
+        self.ok = 200 <= status_code < 300
+        self.reason = 'OK'
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def iter_lines(self, decode_unicode=False):
+        yield from self._lines
+
+
+def _client():
+    c = PromopVocabClient(
+        base_url='http://promop', oauth_client_id='cid', oauth_client_secret='sec',
+        oauth_token_url='http://promop/o/token/')
+    c._authorization = lambda: 'Bearer t'  # skip the real OAuth mint
+    return c
+
+
+def test_stream_snapshot_accept_offers_ndjson_and_wildcard(monkeypatch):
+    captured = {}
+
+    def fake_get(url, headers=None, stream=None, timeout=None):
+        captured['url'] = url
+        captured['headers'] = headers
+        return _FakeStreamResp([
+            json.dumps({'concept_id': 1}),
+            json.dumps({'__done': True, 'rows': 1}),
+        ])
+
+    monkeypatch.setattr(pvc.requests, 'get', fake_get)
+
+    rows = list(_client().stream_snapshot(2, 'concept'))
+
+    assert rows == [{'concept_id': 1}, {'__done': True, 'rows': 1}]
+    assert captured['url'] == 'http://promop/api/v1/vocab-releases/2/snapshot/concept/'
+    accept = captured['headers']['Accept']
+    # ndjson preference is kept (listed first), but */* must be offered so a server
+    # that streams ndjson without an ndjson renderer cannot 406 the request.
+    assert accept.startswith('application/x-ndjson')
+    assert '*/*' in accept
+    assert captured['headers']['Authorization'] == 'Bearer t'

--- a/vocab_mirror/promop_vocab_client.py
+++ b/vocab_mirror/promop_vocab_client.py
@@ -107,8 +107,14 @@ class PromopVocabClient:
             raise VocabSyncError('PROMOP_VOCAB_BASE / PROMOP_API_BASE is not configured')
         url = f'{self.base_url}/api/v1/vocab-releases/{int(release_id)}/snapshot/{table}/'
         try:
+            # Accept ndjson but also `*/*`: the client parses the NDJSON stream
+            # itself regardless of the response media type, and promop's snapshot
+            # view streams `application/x-ndjson` without registering a matching
+            # DRF renderer — a bare `application/x-ndjson` Accept fails content
+            # negotiation there with 406. Offering `*/*` keeps the client robust
+            # to the server's renderer config.
             resp = requests.get(
-                url, headers=self._headers(accept='application/x-ndjson'),
+                url, headers=self._headers(accept='application/x-ndjson, */*'),
                 stream=True, timeout=STREAM_TIMEOUT_SECONDS,
             )
         except requests.RequestException as exc:


### PR DESCRIPTION
Found by the local **vocab-mirror e2e** (EXACT `sync_vocab_mirror` #250 ↔ promop #334).

## Problem
The first snapshot request 406'd: `PromopVocabClient.stream_snapshot` sent `Accept: application/x-ndjson`, but promop's `VocabSnapshotView` streams ndjson via a raw `StreamingHttpResponse` **without registering a matching DRF renderer**, so DRF content negotiation rejects a bare ndjson Accept before the view runs.

## Fix
The client parses the NDJSON stream itself (`iter_lines` + `json.loads` per line) regardless of the response media type, so it shouldn't demand a specific type. Send `Accept: application/x-ndjson, */*` — ndjson stays the preferred range, and `*/*` matches the server's default renderer so negotiation always passes. The client stays robust to promop's renderer config. Only `stream_snapshot` changes; `get_latest_release` keeps its JSON Accept.

## Verification
- Local e2e: with this fix (plus two promop-side fixes filed separately), `sync_vocab_mirror` completed end-to-end against real HemOnc vocab (14.6k concepts / 290k relationships / 137k ancestors) → READY → gate → **activate**.
- New unit test locks the Accept header (ndjson-first + `*/*`).
- Two-part review (codex + fresh-context subagent): no findings.

## Related (promop-side, filed as issues)
The e2e also surfaced promop bugs that block the same flow in staging: snapshot server-side cursor `NoActiveSqlTransaction`, and manifest `row_counts` ≠ actual `COUNT(*)`. Plus a scope-contract item (vocab client default `system/*.read` vs promop's `patient/*.read`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)