### PR TITLE
fix(omop): request-scope the component-lookup cache, not process-global (#266)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,17 +36,17 @@ def django_db_setup(django_db_setup, django_db_blocker):
 
 @pytest.fixture(autouse=True)
 def clear_component_lookup_cache():
-    """Clear the component_category_lookup lru_cache between tests.
+    """Reset the component-lookup request memo between tests.
 
-    The cache is module-level. pytest-django rolls back DB transactions after
-    each test but does NOT clear Python module caches, so a test that seeds
-    TherapyComponent rows and calls _lookup() would leave stale cache entries
-    visible to subsequent tests that assume a clean DB for the same concept_ids.
+    The lookup is no longer a process-global cache (#266) — it's a request-scoped
+    memo (default unset), so there is nothing to clear across tests that don't
+    enter ``component_lookup_request_cache``. This fixture stays as a guard: it
+    resets any memo a test left set, so a stray entry can never leak across tests.
     """
-    from trials.services.omop.component_category_lookup import _lookup
-    _lookup.cache_clear()
+    from trials.services.omop.component_category_lookup import _request_memo
+    _request_memo.set(None)
     yield
-    _lookup.cache_clear()
+    _request_memo.set(None)
 
 
 @pytest.fixture

--- a/tests/test_component_category_lookup.py
+++ b/tests/test_component_category_lookup.py
@@ -9,9 +9,11 @@ from trials.models import (
     TherapyComponentCategory,
     TherapyComponentCategoryConnection,
 )
+from trials.models import TherapyComponentCategoryConnection as _Conn
 from trials.services.omop.component_category_lookup import (
     build_component_category_lookup,
     component_concept_ids_to_type_codes,
+    component_lookup_request_cache,
     sync_component_category_lookup,
 )
 from vocab_mirror.models import ComponentCategoryOmopLookup
@@ -217,6 +219,44 @@ def test_consumer_api_resolves_via_table():
 def test_consumer_api_returns_empty_for_unknown_concept_id():
     result = component_concept_ids_to_type_codes(['9999999'])
     assert result == []
+
+
+# ── request-scoped memo (#266 / ADR 0002 guard #8) ───────────────────────────
+
+def test_request_cache_dedups_repeated_lookups(django_assert_num_queries):
+    _link(_make_component('zz_r1', concept_id=770001), _make_category('zz_rcat'))
+    sync_component_category_lookup()
+    with component_lookup_request_cache():
+        with django_assert_num_queries(1):  # second call served from the memo
+            a = component_concept_ids_to_type_codes(['770001'])
+            b = component_concept_ids_to_type_codes(['770001'])
+    assert a == b == ['zz_rcat']
+
+
+def test_no_memo_outside_request_context(django_assert_num_queries):
+    _link(_make_component('zz_r3', concept_id=770003), _make_category('zz_r3cat'))
+    sync_component_category_lookup()
+    # No request cache active → each call reads the table (no cross-call memo).
+    with django_assert_num_queries(2):
+        component_concept_ids_to_type_codes(['770003'])
+        component_concept_ids_to_type_codes(['770003'])
+
+
+def test_memo_does_not_persist_across_requests():
+    # Simulates a table rebuild between two requests: the second request (a fresh
+    # cache context) must see the new data, never a stale memo — the exact
+    # cross-request/worker staleness a process-global cache had (ADR #8 / #266).
+    comp = _make_component('zz_r2', concept_id=770002)
+    _link(comp, _make_category('zz_before'))
+    sync_component_category_lookup()
+    with component_lookup_request_cache():
+        assert component_concept_ids_to_type_codes(['770002']) == ['zz_before']
+    # rebuild the mapping (as the sync job would, out of band)
+    _Conn.objects.all().delete()
+    _link(comp, _make_category('zz_after'))
+    sync_component_category_lookup()
+    with component_lookup_request_cache():
+        assert component_concept_ids_to_type_codes(['770002']) == ['zz_after']
 
 
 # ── management command ────────────────────────────────────────────────────────

--- a/tests/test_component_category_lookup.py
+++ b/tests/test_component_category_lookup.py
@@ -243,9 +243,10 @@ def test_no_memo_outside_request_context(django_assert_num_queries):
 
 
 def test_memo_does_not_persist_across_requests():
-    # Simulates a table rebuild between two requests: the second request (a fresh
-    # cache context) must see the new data, never a stale memo — the exact
-    # cross-request/worker staleness a process-global cache had (ADR #8 / #266).
+    # A rebuild between two request contexts: the second context must see the new
+    # data, never a stale memo. (This is a same-process behavior guard; the actual
+    # #266 bug was cross-PROCESS — a sync job's flush never reaching a separate web
+    # worker — which a single-process test can't exercise. See the PR for that.)
     comp = _make_component('zz_r2', concept_id=770002)
     _link(comp, _make_category('zz_before'))
     sync_component_category_lookup()

--- a/trials/api/trials_views.py
+++ b/trials/api/trials_views.py
@@ -67,7 +67,11 @@ class TrialsViewSet(viewsets.ReadOnlyModelViewSet):
         # straddle an activation mid-request (#252 / ADR 0002). finalize_response
         # runs inside this block, so the header sees the same context.
         from vocab_mirror.release_context import MatchingReleaseContext
-        with MatchingReleaseContext() as ctx:
+        from trials.services.omop.component_category_lookup import component_lookup_request_cache
+        # component_lookup_request_cache: dedup the per-trial component→type lookups
+        # within this request without a process-global cache that could go stale in
+        # web workers after a sync-job rebuild (ADR 0002 guard #8, #266).
+        with MatchingReleaseContext() as ctx, component_lookup_request_cache():
             self._release_ctx = ctx
             return super().dispatch(request, *args, **kwargs)
 

--- a/trials/services/omop/component_category_lookup.py
+++ b/trials/services/omop/component_category_lookup.py
@@ -12,7 +12,7 @@ Two responsibilities:
    ``load_therapy_omop_concept_ids`` or any vocab change that bypasses post_save.
    Ported from CancerBot (CB owns the upstream; EXACT rebuilds from its local copy).
 """
-import functools
+import contextvars
 
 from django.db import transaction
 
@@ -23,6 +23,17 @@ from vocab_mirror.models import ComponentCategoryOmopLookup, ComponentLookupStam
 
 # ── consumer API ────────────────────────────────────────────────────────────
 
+# Request-scoped memo. The matcher calls the lookup once PER TRIAL scored with the
+# SAME patient component set, so within a request we dedup those to one query. It
+# is deliberately NOT a process-global cache: the table is rebuilt by a separate
+# sync job, and a process-global cache would leave web workers serving stale
+# type-codes until restart (ADR 0002 guard #8, #266). Scoped to a request → a
+# rebuild between requests is always picked up; outside a request (backfill/sync)
+# the memo is unset and every call reads the table directly.
+_request_memo: contextvars.ContextVar = contextvars.ContextVar(
+    'component_lookup_request_memo', default=None)
+
+
 def component_concept_ids_to_type_codes(concept_ids):
     """Patient component concept_ids → list of CB category codes for type matching.
 
@@ -30,17 +41,22 @@ def component_concept_ids_to_type_codes(concept_ids):
     unknown semantics in the matcher). Returns ``[]`` when the lookup yields
     nothing (known-empty → no types to match).
 
-    Input order is ignored; the same concept_id set always hits the same cache
-    entry across N trials on the same request.
+    Input order is ignored. Inside a :class:`component_lookup_request_cache`
+    block the same concept_id set is resolved once and reused for the request.
     """
     if concept_ids is None:
         return None
-    return _lookup(tuple(sorted(concept_ids, key=str)))
+    key = tuple(sorted(concept_ids, key=str))
+    memo = _request_memo.get()
+    if memo is None:
+        return _lookup(key)
+    if key not in memo:
+        memo[key] = _lookup(key)
+    return memo[key]
 
 
-@functools.lru_cache(maxsize=256)
 def _lookup(concept_ids_tuple):
-    """Cached read from ComponentCategoryOmopLookup — keyed on sorted concept_id tuple."""
+    """Read CB category codes for a set of component concept_ids (single query)."""
     if not concept_ids_tuple:
         return []
     cids = [int(v) for v in concept_ids_tuple if str(v).isdigit()]
@@ -52,9 +68,35 @@ def _lookup(concept_ids_tuple):
     return sorted(codes)
 
 
+class component_lookup_request_cache:
+    """Enable the request-scoped lookup memo for a ``with`` block.
+
+    Enter once per request (the trials view does, in ``dispatch``) so repeated
+    per-trial lookups dedup to one query; the memo resets on exit, so nothing
+    persists across requests or workers.
+    """
+
+    def __enter__(self):
+        self._token = _request_memo.set({})
+        return self
+
+    def __exit__(self, *exc):
+        _request_memo.reset(self._token)
+        return False
+
+
 def clear_lookup_cache():
-    """Invalidate the per-process LRU cache after a table rebuild."""
-    _lookup.cache_clear()
+    """Clear the request-scoped memo if one is active.
+
+    There is no longer a process-global cache to flush across workers — the memo
+    is request-scoped (#266), so a table rebuild in the sync job can never strand
+    stale entries in a web worker. Retained (a) so the rebuild path and existing
+    callers/tests need no change, and (b) to drop any memo within the current
+    request after an in-request rebuild.
+    """
+    memo = _request_memo.get()
+    if memo is not None:
+        memo.clear()
 
 
 # ── maintenance (rebuild from local M2M graph) ──────────────────────────────

--- a/trials/services/omop/component_category_lookup.py
+++ b/trials/services/omop/component_category_lookup.py
@@ -74,6 +74,10 @@ class component_lookup_request_cache:
     Enter once per request (the trials view does, in ``dispatch``) so repeated
     per-trial lookups dedup to one query; the memo resets on exit, so nothing
     persists across requests or workers.
+
+    Offline batch matchers (management commands that loop the matcher over many
+    trials for one patient) should also enter this to keep the old cross-trial
+    dedup — tracked as a follow-up (#266 note); without it each trial re-queries.
     """
 
     def __enter__(self):
@@ -175,7 +179,9 @@ def sync_component_category_lookup(release_id=None, dry_run=False):
             )
 
     if not dry_run:
-        # Flush the in-process LRU cache so subsequent calls see the updated table.
+        # Drop any request-scoped memo so a subsequent read in THIS process sees the
+        # rebuilt table (no-op in the sync job, which holds no request context). Web
+        # workers never cache across requests, so no cross-process flush is needed.
         clear_lookup_cache()
 
     return {


### PR DESCRIPTION
Closes #266. Part of epic #246 (ADR 0002 guard #8).

## Problem
The component→category lookup (`component_concept_ids_to_type_codes`) read through a process-global `@lru_cache`; `clear_lookup_cache()` only flushed the calling process. The table is rebuilt by a separate **sync job**, so its flush never reached the gunicorn **web workers** — they served stale type-codes until restart.

## Fix
Replace the process-global cache with a **request-scoped memo** (a `contextvars.ContextVar` dict, enabled by `component_lookup_request_cache`, which `TrialsViewSet.dispatch` enters alongside `MatchingReleaseContext`):
- the matcher calls the lookup once per trial scored with the **same** patient component set → within a request those still dedup to one query;
- nothing persists across requests/workers, so a sync-job rebuild between requests is always picked up — no cross-process flush needed.

Outside a request (backfill/sync) the memo is unset → direct query. `clear_lookup_cache()` is kept (now clears the active memo) so the rebuild path and existing callers/tests are unchanged.

## Review (two-part, pre-push)
- **codex**: no findings — memo correctly entered/reset around dispatch (incl. the `/trials-graph/` subclass); direct callers stay fresh.
- **fresh-context subagent**: no merge-blockers; P1s verified. Fixed its two P3s (stale "LRU" comment; softened a test comment that overclaimed a cross-process guard). Its P2 — offline **batch commands** (`search_trials_for_patients`, `compare_trials`, `evaluate_ethalon_live`) loop the matcher per-trial without entering the memo, so they lose the old cross-trial dedup (N cheap queries per run) — is **consciously deferred** (offline tooling, OMOP default-off, cheap indexed query; the web/production path is fully fixed). Tracked as a follow-up.

## Verification
Within-request dedup (1 query / 2 calls), no memo outside a context (2 queries), no cross-request persistence after a rebuild. Full suite **1076 passed, 5 skipped**; `makemigrations --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)