### PR TITLE
chore(omop): vocab-mirror generation retention/GC reaper (#259)

### DIFF
--- a/tests/vocab_mirror/test_reaper.py
+++ b/tests/vocab_mirror/test_reaper.py
@@ -1,0 +1,103 @@
+"""Vocab-mirror generation reaper tests (#259).
+
+Policy under test: keep the ACTIVE generation, the ``keep`` most-recent non-active
+ones, and anything younger than ``min_age``; drop the rest (mirror rows + the
+MirrorRelease row). Time is controlled via the ``now`` argument.
+"""
+from datetime import timedelta
+
+import pytest
+from django.utils import timezone
+
+from vocab_mirror.models import (
+    MirrorConcept,
+    MirrorConceptAncestor,
+    MirrorConceptRelationship,
+    MirrorRelease,
+    MirrorVocabulary,
+)
+from vocab_mirror.reaper import reap_old_generations
+
+pytestmark = pytest.mark.django_db
+
+_TABLES = (MirrorVocabulary, MirrorConcept, MirrorConceptRelationship, MirrorConceptAncestor)
+
+
+def _gen(rid, state):
+    rel = MirrorRelease.objects.create(release_id=rid, state=state)
+    MirrorVocabulary.objects.create(release_id=rid, vocabulary_id='V', vocabulary_name='V',
+                                    vocabulary_concept_id=1)
+    MirrorConcept.objects.create(release_id=rid, concept_id=rid, concept_name='c',
+                                 domain_id='D', vocabulary_id='V', concept_class_id='X',
+                                 concept_code='c')
+    MirrorConceptRelationship.objects.create(release_id=rid, concept_id_1=1, concept_id_2=2,
+                                             relationship_id='r')
+    MirrorConceptAncestor.objects.create(release_id=rid, ancestor_concept_id=1,
+                                         descendant_concept_id=2,
+                                         min_levels_of_separation=1, max_levels_of_separation=1)
+    return rel
+
+
+def _rows(rid):
+    return sum(m.objects.filter(release_id=rid).count() for m in _TABLES)
+
+
+def _past_window():
+    # A `now` far enough ahead that any just-created generation is beyond min_age.
+    return timezone.now() + timedelta(days=1)
+
+
+def test_active_is_never_reaped():
+    _gen(1, MirrorRelease.ACTIVE)
+    assert reap_old_generations(keep=0, min_age=timedelta(0), now=_past_window()) == []
+    assert MirrorRelease.objects.filter(release_id=1).exists()
+    assert _rows(1) == 4
+
+
+def test_reaps_old_superseded_beyond_keep():
+    _gen(1, MirrorRelease.ACTIVE)
+    _gen(2, MirrorRelease.SUPERSEDED)   # older / lower release_id
+    _gen(3, MirrorRelease.SUPERSEDED)   # kept as the most-recent non-active
+
+    reaped = reap_old_generations(keep=1, min_age=timedelta(hours=6), now=_past_window())
+
+    assert {r['release_id'] for r in reaped} == {2}
+    assert not MirrorRelease.objects.filter(release_id=2).exists()
+    assert _rows(2) == 0
+    assert MirrorRelease.objects.filter(release_id=3).exists()  # protected by keep=1
+    assert MirrorRelease.objects.filter(release_id=1).exists()  # ACTIVE
+
+
+def test_retention_window_protects_young_generations():
+    _gen(1, MirrorRelease.ACTIVE)
+    _gen(2, MirrorRelease.SUPERSEDED)
+    # now == creation time, so gen 2 is younger than min_age → protected despite keep=0.
+    assert reap_old_generations(keep=0, min_age=timedelta(hours=6), now=timezone.now()) == []
+    assert MirrorRelease.objects.filter(release_id=2).exists()
+    assert _rows(2) == 4
+
+
+def test_reaps_stranded_failed_ready_staging():
+    _gen(1, MirrorRelease.ACTIVE)
+    _gen(2, MirrorRelease.FAILED)
+    _gen(3, MirrorRelease.READY)
+    _gen(4, MirrorRelease.STAGING)
+
+    reaped = reap_old_generations(keep=0, min_age=timedelta(hours=6), now=_past_window())
+
+    assert {r['release_id'] for r in reaped} == {2, 3, 4}
+    assert MirrorRelease.objects.filter(state=MirrorRelease.ACTIVE).count() == 1
+    assert all(_rows(rid) == 0 for rid in (2, 3, 4))
+
+
+def test_dry_run_reports_without_deleting():
+    _gen(1, MirrorRelease.ACTIVE)
+    _gen(2, MirrorRelease.FAILED)
+
+    reaped = reap_old_generations(keep=0, min_age=timedelta(hours=6),
+                                  now=_past_window(), dry_run=True)
+
+    assert {r['release_id'] for r in reaped} == {2}
+    assert reaped[0]['rows']['MirrorConcept'] == 1  # reports real counts
+    assert MirrorRelease.objects.filter(release_id=2).exists()  # nothing deleted
+    assert _rows(2) == 4

--- a/tests/vocab_mirror/test_reaper.py
+++ b/tests/vocab_mirror/test_reaper.py
@@ -101,3 +101,64 @@ def test_dry_run_reports_without_deleting():
     assert reaped[0]['rows']['MirrorConcept'] == 1  # reports real counts
     assert MirrorRelease.objects.filter(release_id=2).exists()  # nothing deleted
     assert _rows(2) == 4
+
+
+def test_keep_two_protects_two_most_recent():
+    _gen(1, MirrorRelease.ACTIVE)
+    _gen(2, MirrorRelease.SUPERSEDED)   # oldest non-active
+    _gen(3, MirrorRelease.SUPERSEDED)
+    _gen(4, MirrorRelease.SUPERSEDED)   # newest (release_id tiebreak under updated_at ties)
+
+    reaped = reap_old_generations(keep=2, min_age=timedelta(hours=6), now=_past_window())
+
+    # ACTIVE(1) + the 2 most-recent non-active (4, 3) protected → only 2 reaped.
+    assert {r['release_id'] for r in reaped} == {2}
+
+
+def test_end_to_end_activate_supersede_reap():
+    # Exercise the REAL activation → SUPERSEDED path (updated_at bumped on supersede)
+    # that the keep/recency ordering actually protects.
+    from vocab_mirror.activation import activate_release
+    _gen(1, MirrorRelease.READY)
+    _gen(2, MirrorRelease.READY)
+    activate_release(1)
+    activate_release(2)  # supersedes release 1
+    assert MirrorRelease.objects.get(release_id=1).state == MirrorRelease.SUPERSEDED
+
+    reaped = reap_old_generations(keep=0, min_age=timedelta(0), now=_past_window())
+
+    assert {r['release_id'] for r in reaped} == {1}
+    assert MirrorRelease.objects.get(release_id=2).state == MirrorRelease.ACTIVE
+    assert _rows(1) == 0 and _rows(2) == 4
+
+
+def test_reap_under_lock_runs_when_uncontended():
+    from vocab_mirror.reaper import reap_under_lock
+    _gen(1, MirrorRelease.ACTIVE)
+    _gen(2, MirrorRelease.FAILED)
+
+    result = reap_under_lock(keep=0, min_age=timedelta(0), now=_past_window())
+
+    assert result is not None  # acquired the lock and ran
+    assert {r['release_id'] for r in result} == {2}
+    assert not MirrorRelease.objects.filter(release_id=2).exists()
+
+
+def test_reap_best_effort_swallows_reaper_errors(monkeypatch):
+    # A reaper failure must never fail the sync.
+    import vocab_mirror.reaper as reaper_mod
+    from vocab_mirror.sync import _reap_best_effort
+
+    def boom(*a, **k):
+        raise RuntimeError('reaper blew up')
+
+    monkeypatch.setattr(reaper_mod, 'reap_old_generations', boom)
+    _reap_best_effort()  # must not raise
+
+
+def test_command_rejects_negative_options():
+    from django.core.management import CommandError, call_command
+    with pytest.raises(CommandError):
+        call_command('reap_vocab_mirror', min_age_hours=-6)  # cutoff in the future
+    with pytest.raises(CommandError):
+        call_command('reap_vocab_mirror', keep=-1)  # slice semantics, not a count

--- a/vocab_mirror/management/commands/reap_vocab_mirror.py
+++ b/vocab_mirror/management/commands/reap_vocab_mirror.py
@@ -1,0 +1,46 @@
+"""Prune old vocab-mirror generations (#259).
+
+Drops mirror rows + the MirrorRelease row for stale non-ACTIVE generations,
+keeping the ACTIVE one, the ``--keep`` most-recent non-active generations, and
+anything younger than ``--min-age-hours``. Safe to run on a schedule (Cloud
+Scheduler → Cloud Run Job); holds the sync singleton advisory lock so it never
+races a sync/activation.
+
+    python manage.py reap_vocab_mirror [--keep N] [--min-age-hours H] [--dry-run]
+"""
+from django.core.management.base import BaseCommand
+
+from vocab_mirror.reaper import DEFAULT_KEEP, reap_under_lock
+
+
+class Command(BaseCommand):
+    help = 'Prune old (non-ACTIVE, past-retention) vocab-mirror generations.'
+
+    def add_arguments(self, parser):
+        parser.add_argument('--keep', type=int, default=DEFAULT_KEEP,
+                            help='Keep this many most-recent non-active generations '
+                                 f'(default {DEFAULT_KEEP}).')
+        parser.add_argument('--min-age-hours', type=float, default=6.0,
+                            help='Never reap a generation younger than this (default 6).')
+        parser.add_argument('--dry-run', action='store_true',
+                            help='Report what would be reaped without deleting.')
+
+    def handle(self, *args, **opts):
+        from datetime import timedelta
+        result = reap_under_lock(
+            keep=opts['keep'],
+            min_age=timedelta(hours=opts['min_age_hours']),
+            dry_run=opts['dry_run'],
+        )
+        if result is None:
+            self.stdout.write('reap skipped: another sync/reap holds the lock')
+            return
+        prefix = '[dry-run] ' if opts['dry_run'] else ''
+        if not result:
+            self.stdout.write(f'{prefix}nothing to reap')
+            return
+        for r in result:
+            total = sum(r['rows'].values())
+            self.stdout.write(
+                f"{prefix}reaped release {r['release_id']} [{r['state']}] — {total} rows")
+        self.stdout.write(f'{prefix}reaped {len(result)} generation(s)')

--- a/vocab_mirror/management/commands/reap_vocab_mirror.py
+++ b/vocab_mirror/management/commands/reap_vocab_mirror.py
@@ -8,7 +8,7 @@ races a sync/activation.
 
     python manage.py reap_vocab_mirror [--keep N] [--min-age-hours H] [--dry-run]
 """
-from django.core.management.base import BaseCommand
+from django.core.management.base import BaseCommand, CommandError
 
 from vocab_mirror.reaper import DEFAULT_KEEP, reap_under_lock
 
@@ -27,6 +27,13 @@ class Command(BaseCommand):
 
     def handle(self, *args, **opts):
         from datetime import timedelta
+        # Guard the destructive path against typos that would defeat retention:
+        # a negative age puts the cutoff in the future (reap everything), and a
+        # negative keep would hit Python slice semantics instead of a count.
+        if opts['keep'] < 0:
+            raise CommandError('--keep must be >= 0')
+        if opts['min_age_hours'] < 0:
+            raise CommandError('--min-age-hours must be >= 0')
         result = reap_under_lock(
             keep=opts['keep'],
             min_age=timedelta(hours=opts['min_age_hours']),

--- a/vocab_mirror/reaper.py
+++ b/vocab_mirror/reaper.py
@@ -1,0 +1,110 @@
+"""Retention / GC for old vocab-mirror generations (#259; ADR 0002).
+
+Activation supersedes-and-**retains** the previous generation (its rows stay so
+in-flight readers finish), and the sync only deletes rows for the release it
+(re)stages. So SUPERSEDED generations — plus any stranded READY / FAILED / STAGING
+ones left when promop's ``latest`` jumps to a newer release id — accumulate
+forever, at ~18M ``concept_relationship`` rows each. This reaper prunes them.
+
+Policy (all of these are KEPT; everything else is dropped):
+- the current **ACTIVE** generation — always;
+- the ``keep`` most-recently-touched non-active generations — so a reader still
+  finishing on the just-superseded generation is not pulled out from under;
+- any generation younger than ``min_age`` — the retention window.
+
+Dropping a generation deletes its rows in all four mirror tables **and** its
+``MirrorRelease`` row. Runs under the sync singleton advisory lock (via
+``reap_under_lock``) so it never races a sync/activation writer.
+"""
+import logging
+from datetime import timedelta
+
+from django.db import connections
+from django.utils import timezone
+
+from vocab_mirror.models import (
+    MirrorConcept,
+    MirrorConceptAncestor,
+    MirrorConceptRelationship,
+    MirrorRelease,
+    MirrorVocabulary,
+)
+
+logger = logging.getLogger(__name__)
+
+_DB = 'default'
+# The four generation-tagged data tables (not MirrorRelease, which is the pointer).
+_REAP_MODELS = (
+    MirrorVocabulary, MirrorConcept, MirrorConceptRelationship, MirrorConceptAncestor,
+)
+# Reuse the #250 sync singleton lock so a reap never races a sync/activation.
+_SYNC_ADVISORY_LOCK_KEY = 8234502250
+
+DEFAULT_KEEP = 1
+DEFAULT_MIN_AGE = timedelta(hours=6)
+
+
+def _recency(rel):
+    return rel.updated_at or rel.created_at
+
+
+def reap_old_generations(keep=DEFAULT_KEEP, min_age=DEFAULT_MIN_AGE, now=None,
+                         dry_run=False):
+    """Drop stale non-ACTIVE generations. See the module docstring for the policy.
+
+    Returns a list of ``{'release_id', 'state', 'rows'}`` for the generations
+    reaped (or that *would* be reaped when ``dry_run``). ``rows`` maps each mirror
+    model name to its deleted row count (0s under ``dry_run``).
+    """
+    now = now or timezone.now()
+    cutoff = now - min_age
+
+    active_ids = set(
+        MirrorRelease.objects.using(_DB)
+        .filter(state=MirrorRelease.ACTIVE).values_list('release_id', flat=True))
+    # Most-recently-touched first, so `keep` protects the freshest non-active ones.
+    non_active = list(
+        MirrorRelease.objects.using(_DB).exclude(state=MirrorRelease.ACTIVE)
+        .order_by('-updated_at', '-release_id'))
+    keep_ids = set(active_ids) | {r.release_id for r in non_active[:keep]}
+
+    reaped = []
+    for rel in non_active:
+        if rel.release_id in keep_ids:
+            continue
+        ts = _recency(rel)
+        if ts is not None and ts > cutoff:
+            continue  # inside the retention window
+        rows = {}
+        for model in _REAP_MODELS:
+            if dry_run:
+                rows[model.__name__] = (
+                    model.objects.using(_DB).filter(release_id=rel.release_id).count())
+            else:
+                deleted, _ = (
+                    model.objects.using(_DB).filter(release_id=rel.release_id).delete())
+                rows[model.__name__] = deleted
+        if not dry_run:
+            rel.delete(using=_DB)
+        reaped.append({'release_id': rel.release_id, 'state': rel.state, 'rows': rows})
+        logger.info('vocab reaper: %s generation %s (%s)',
+                    'would reap' if dry_run else 'reaped', rel.release_id, rel.state)
+    return reaped
+
+
+def reap_under_lock(**kwargs):
+    """Run :func:`reap_old_generations` holding the sync singleton advisory lock.
+
+    Returns ``None`` (skipped) if another sync/reap holds the lock, else the reap
+    result. Use this for the standalone command; the sync job, already holding the
+    lock, calls :func:`reap_old_generations` directly.
+    """
+    with connections[_DB].cursor() as cur:
+        cur.execute('SELECT pg_try_advisory_lock(%s)', [_SYNC_ADVISORY_LOCK_KEY])
+        if not cur.fetchone()[0]:
+            logger.info('vocab reaper: another sync/reap holds the lock; skipping')
+            return None
+        try:
+            return reap_old_generations(**kwargs)
+        finally:
+            cur.execute('SELECT pg_advisory_unlock(%s)', [_SYNC_ADVISORY_LOCK_KEY])

--- a/vocab_mirror/reaper.py
+++ b/vocab_mirror/reaper.py
@@ -63,6 +63,13 @@ def reap_old_generations(keep=DEFAULT_KEEP, min_age=DEFAULT_MIN_AGE, now=None,
         MirrorRelease.objects.using(_DB)
         .filter(state=MirrorRelease.ACTIVE).values_list('release_id', flat=True))
     # Most-recently-touched first, so `keep` protects the freshest non-active ones.
+    # NOTE: `keep` protects the most-recently-*touched* non-active generations,
+    # which is not strictly the previously-active one — a later STAGING→FAILED
+    # restage bumps a different generation's updated_at and can steal the slot.
+    # Reader safety therefore rests on the time-based `min_age` retention window,
+    # not on `keep`; `keep` is a belt-and-braces buffer for the common no-churn
+    # case (on supersession activation bumps the old-active row's updated_at, so it
+    # is the freshest non-active row and keep>=1 covers it).
     non_active = list(
         MirrorRelease.objects.using(_DB).exclude(state=MirrorRelease.ACTIVE)
         .order_by('-updated_at', '-release_id'))
@@ -76,15 +83,24 @@ def reap_old_generations(keep=DEFAULT_KEEP, min_age=DEFAULT_MIN_AGE, now=None,
         if ts is not None and ts > cutoff:
             continue  # inside the retention window
         rows = {}
-        for model in _REAP_MODELS:
-            if dry_run:
+        if dry_run:
+            for model in _REAP_MODELS:
                 rows[model.__name__] = (
                     model.objects.using(_DB).filter(release_id=rel.release_id).count())
-            else:
+        else:
+            # Deliberately NOT one big transaction: a generation's
+            # concept_relationship alone can be ~18M rows, and wrapping all four
+            # tables in a single txn holds a long-running transaction (WAL bloat,
+            # blocks vacuum, holds the advisory lock longer). Safety instead comes
+            # from (a) the retention window — `min_age` guarantees no live reader is
+            # still on a reaped generation, so a partial delete is never observed —
+            # and (b) deleting the data tables first and the `MirrorRelease` pointer
+            # LAST, so an interrupted reap leaves recoverable data+pointer (never
+            # orphan data) that the next run re-selects and finishes idempotently.
+            for model in _REAP_MODELS:
                 deleted, _ = (
                     model.objects.using(_DB).filter(release_id=rel.release_id).delete())
                 rows[model.__name__] = deleted
-        if not dry_run:
             rel.delete(using=_DB)
         reaped.append({'release_id': rel.release_id, 'state': rel.state, 'rows': rows})
         logger.info('vocab reaper: %s generation %s (%s)',

--- a/vocab_mirror/sync.py
+++ b/vocab_mirror/sync.py
@@ -191,6 +191,24 @@ def _load_table(client, release_id, table, expected_count):
     return count
 
 
+def _reap_best_effort():
+    """Prune old generations after a successful activation — best-effort, non-fatal.
+
+    Runs inside the sync advisory lock, so it calls ``reap_old_generations``
+    directly (not the self-locking wrapper). A reaper failure must never fail the
+    sync, so it is logged and swallowed. Lazy import keeps ``sync`` free of a
+    load-time reaper dependency (#259).
+    """
+    try:
+        from vocab_mirror.reaper import reap_old_generations
+        reaped = reap_old_generations()
+        if reaped:
+            logger.info('vocab sync: reaped %d old generation(s): %s',
+                        len(reaped), [r['release_id'] for r in reaped])
+    except Exception as exc:
+        logger.warning('vocab sync: reaper failed (non-fatal): %s', exc)
+
+
 def _do_sync(client, tables, activate):
     # Only a full-table load may be activated — activating a subset would put an
     # incomplete generation live (empty relationship/ancestor tables → traversal
@@ -232,6 +250,7 @@ def _do_sync(client, tables, activate):
                                  release_id, exc)
                     return SyncOutcome(status='loaded_not_activated', release_id=release_id)
                 logger.info('vocab sync: recovered + activated READY release %s', release_id)
+                _reap_best_effort()
                 return SyncOutcome(status='activated', release_id=release_id)
             return SyncOutcome(status='already_synced', release_id=release_id)
         # STAGING / FAILED — fall through to restage below.
@@ -282,6 +301,7 @@ def _do_sync(client, tables, activate):
                          release_id, exc)
             return SyncOutcome(status='loaded_not_activated', release_id=release_id,
                                counts=counts)
+        _reap_best_effort()
     return SyncOutcome(status='synced', release_id=release_id, counts=counts)
 
 


### PR DESCRIPTION
Closes #259. Part of epic #246.

## Problem
Activation supersedes-and-**retains** the previous generation, and the sync only deletes rows for the release it (re)stages — so SUPERSEDED generations (plus stranded READY/FAILED/STAGING left when promop's `latest` jumps release ids) piled up forever at ~18M `concept_relationship` rows each. The ADR promised a retention window; nothing pruned.

## Fix
`vocab_mirror.reaper.reap_old_generations(keep, min_age, now, dry_run)` drops the mirror rows (4 tables) + the `MirrorRelease` row for stale non-ACTIVE generations, **keeping**: the ACTIVE one, the `keep` most-recent non-active, and anything younger than `min_age`.
- `reap_vocab_mirror` management command (`--keep` / `--min-age-hours` / `--dry-run`), holding the #250 sync singleton advisory lock so it never races a sync/activation.
- The sync job also reaps **best-effort after a successful activation** (non-fatal, already under the lock), so pruning happens automatically — no dependency on separate scheduling (#260).

Deletes are deliberately **not** wrapped in one big transaction (a generation's `concept_relationship` alone is ~18M rows → long txn / WAL bloat / holds the lock longer). Safety instead: the retention window guarantees no live reader is on a reaped generation, and data tables are deleted before the `MirrorRelease` pointer, so an interrupted reap is recoverable + idempotent on re-run.

## Review (two-part, pre-push)
- **codex**: two P2s — reject negative CLI options (applied + tested); wrap per-generation deletes in a transaction.
- **fresh-context subagent**: verified policy/lock/sync-integration/DB-usage correct; **rebutted** codex's atomic suggestion (worse for 18M-row deletes; retention window + delete-order already make it safe) — sided with the subagent. Applied its other findings: documented `keep`-vs-retention semantics (the time window is the reader guard), and added the missing tests (real activate→SUPERSEDED→reap, keep>1, `reap_under_lock`, `_reap_best_effort` error-swallow).
- Noted (accepted): the standalone reaper can delete a stranded-but-recoverable READY generation past the window, forcing a re-download rather than a cheap re-activation — not a correctness issue (ETag advances only on ACTIVE; the gate stays fail-closed).

## Verification
Full suite **1083 passed, 5 skipped**; `makemigrations --check` clean (no schema change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)