### PR TITLE
E1.4: ExactMatcher backend implementing CB's MatcherBackend

### DIFF
--- a/matcher_app/exact_matching/backend.py
+++ b/matcher_app/exact_matching/backend.py
@@ -1,0 +1,86 @@
+"""ExactMatcher — the EXACT-published implementation of CB's MatcherBackend (E1.4).
+
+CB installs the ``exact_matching`` package and flips
+``MATCHER_BACKEND = "exact_matching.backend.ExactMatcher"`` (A2). This class
+implements the same interface as CB's ``trials.matching.local.LocalMatcher``, but
+its filter/scoring logic is the package's own ``TrialQuerySet`` (extracted in
+E1.1–E1.3), so CB and EXACT run one matching codebase instead of two drifting
+copies.
+
+Host-agnostic by contract — it never imports CB (no circular dep):
+- ``patient`` / ``prefs`` are consumed **duck-typed** (CB passes its
+  ``ResolvedPatient`` / ``StudyPrefs``; EXACT tests pass equivalents).
+- ``trials`` is whatever the host's ``Trial`` manager produces; both hosts use
+  this package's ``TrialQuerySet``, so ``filtered_trials`` / ``with_*_optimized``
+  resolve identically.
+
+Scoring seam (decision B): the package's ``with_goodness_score_optimized`` is
+**userless** — it takes four explicit weight floats, not a ``UserProfile`` (EXACT
+has no User model). So the goodness weights are read as explicit fields off
+``prefs`` (``benefit_weight`` etc.); the host resolves them from its own profile
+BEFORE calling. Missing fields default to 25.0 each = equal weighting, matching
+the queryset's own defaults, so a host that hasn't populated them yet still gets
+a well-defined (uniform) score rather than a crash.
+"""
+from __future__ import annotations
+from django.conf import settings
+from django.db.models import QuerySet
+
+from exact_matching import __version__
+
+#: goodness-score weight fields read off `prefs`, in the queryset's positional order.
+_WEIGHT_FIELDS = (
+    "benefit_weight",
+    "patient_burden_weight",
+    "risk_weight",
+    "distance_penalty_weight",
+)
+
+
+class ExactMatcher:
+    version = f"exact-{__version__}"
+
+    def search(self, trials: QuerySet, patient, prefs) -> QuerySet:
+        pi = patient.as_patient_info()
+        qs, _traces = trials.filtered_trials(
+            search_options=prefs.query_params,
+            study_info=prefs.study_info,
+            patient_info=pi,
+            add_traces=getattr(settings, "ADD_SEARCH_TRIALS_TRACES", False),
+            search_type=prefs.search_type,
+        )
+        if "distance" not in qs.query.annotations:
+            qs = qs.with_distance_optimized(
+                patient.geo_point,
+                recruitment_status=prefs.recruitment_status,
+            )
+        weights = {f: getattr(prefs, f, 25.0) for f in _WEIGHT_FIELDS}
+        qs = qs.with_goodness_score_optimized(
+            **weights,
+            geo_point=patient.geo_point,
+            recruitment_status=prefs.recruitment_status,
+        )
+        return qs
+
+    # --- per-trial explain: documented contract, NOT view-wired yet (P0 follow-up). ---
+    # Host-signature convergence (same bucket as decision B): the package is
+    # userless, so match_status calls Trial.matching_type with patient_info by
+    # KEYWORD. That is exact for EXACT's `matching_type(self, patient_info)`. CB's
+    # current signature is `matching_type(user, patient_info=...)` with a required
+    # `user`, so THIS CALL WILL NOT WORK IN CB until CB converges it (drop/default
+    # `user`) — the CB companion, tracked with the StudyPrefs-weights change. The
+    # keyword form is deliberate: in CB it fails loudly on the missing `user`
+    # rather than silently binding patient_info into `user`. Nothing routes here
+    # today, so there is no live break. high_risk_breakdown runs the package's own
+    # matcher, so it is host-uniform already.
+    def match_status(self, trial, patient):
+        return trial.matching_type(patient_info=patient.as_patient_info())
+
+    def attrs_to_fill_in(self, trial, patient, counts: dict):
+        return trial.attrs_to_fill_in(counts)
+
+    def high_risk_breakdown(self, trial, patient):
+        from exact_matching.matcher import UserToTrialAttrMatcher
+        return UserToTrialAttrMatcher(
+            trial, patient.as_patient_info()
+        ).high_risk_mcl_criteria_breakdown()

--- a/tests/test_exact_matcher_backend.py
+++ b/tests/test_exact_matcher_backend.py
@@ -1,0 +1,80 @@
+"""E1.4 — ExactMatcher (exact_matching.backend) implements CB's MatcherBackend.
+
+Validates the search() seam end-to-end against EXACT's own Trial queryset, and
+that the goodness-score weights are read as explicit fields off `prefs`
+(decision B — the package is userless, so ExactMatcher passes weight floats, not
+a UserProfile).
+"""
+import pytest
+
+from exact_matching import __version__
+from exact_matching.backend import ExactMatcher
+from trials.models import Trial
+from trials.services.study_preferences import StudyPreferences
+from tests.factories import TrialFactory
+
+_WEIGHTS = ("benefit_weight", "patient_burden_weight", "risk_weight", "distance_penalty_weight")
+
+
+class _Patient:
+    """Duck ResolvedPatient — ExactMatcher only calls as_patient_info() / geo_point."""
+
+    def __init__(self, pi=None, geo_point=None):
+        self._pi = pi
+        self.geo_point = geo_point
+
+    def as_patient_info(self):
+        return self._pi
+
+
+class _Prefs:
+    """Duck StudyPrefs; weight fields set only when provided (to exercise defaults)."""
+
+    def __init__(self, search_type="all", **weights):
+        self.query_params = {}
+        self.study_info = StudyPreferences()
+        self.search_type = search_type
+        self.recruitment_status = None
+        for f, v in weights.items():
+            setattr(self, f, v)
+
+
+def _direct(weights, search_type="all"):
+    """Replicate the LocalMatcher call sequence directly, with explicit weights."""
+    qs, _ = Trial.objects.filtered_trials(
+        search_options={}, study_info=StudyPreferences(),
+        patient_info=None, add_traces=False, search_type=search_type,
+    )
+    return qs.with_goodness_score_optimized(**weights, geo_point=None, recruitment_status=None)
+
+
+@pytest.mark.django_db
+class TestExactMatcherSearch:
+    def test_annotates_goodness_score(self):
+        TrialFactory()
+        TrialFactory()
+        qs = ExactMatcher().search(Trial.objects.all(), _Patient(), _Prefs())
+        assert "goodness_score" in qs.query.annotations
+        assert qs.count() == 2
+
+    def test_explicit_weights_propagate(self):
+        TrialFactory()
+        TrialFactory()
+        weights = dict(benefit_weight=40.0, patient_burden_weight=10.0,
+                       risk_weight=30.0, distance_penalty_weight=20.0)
+        got = {t.id: t.goodness_score
+               for t in ExactMatcher().search(Trial.objects.all(), _Patient(), _Prefs(**weights))}
+        exp = {t.id: t.goodness_score for t in _direct(weights)}
+        assert got == exp and len(got) == 2
+
+    def test_absent_weights_default_to_equal(self):
+        TrialFactory()
+        TrialFactory()
+        # _Prefs() sets no weight attrs → ExactMatcher's getattr defaults to 25.0 each.
+        got = {t.id: t.goodness_score
+               for t in ExactMatcher().search(Trial.objects.all(), _Patient(), _Prefs())}
+        exp = {t.id: t.goodness_score for t in _direct({f: 25.0 for f in _WEIGHTS})}
+        assert got == exp and len(got) == 2
+
+    def test_version_tag(self):
+        assert ExactMatcher().version == f"exact-{__version__}"


### PR DESCRIPTION
**Stacked on #280** (E1.3d) → #279 → #278 → #277 → #276. Rebase down the stack as each base merges.

## What
Adds `exact_matching.backend.ExactMatcher` — the EXACT-published implementation of CB's `MatcherBackend` interface. CB installs the package and flips `MATCHER_BACKEND="exact_matching.backend.ExactMatcher"` (A2) to run CB and EXACT off **one** matching codebase (the `TrialQuerySet` + matcher extracted in E1.1–E1.3), ending the periodic-port drift.

## Host-agnostic by contract (never imports CB)
- `patient` / `prefs` consumed **duck-typed** (CB passes `ResolvedPatient` / `StudyPrefs`; EXACT tests pass equivalents).
- `trials` is the host's `Trial` queryset; both hosts use this package's `TrialQuerySet`, so `filtered_trials` / `with_*_optimized` resolve identically.
- `ADD_SEARCH_TRIALS_TRACES` read via `django.conf.settings`, not `cancerbot.settings`.

## Scoring seam — decision B
The package's `with_goodness_score_optimized` is **userless** (four explicit weight floats, no `UserProfile` — EXACT has no User model). ExactMatcher reads the goodness weights as explicit `prefs` fields (`benefit_weight` …), defaulting to 25.0 each (equal weighting) when absent. **CB companion (tracked):** `StudyPrefs` carries those four weights, resolved from the user's profile before the call — a P0-branch follow-up (contract.py currently carries `user_profile`).

## Reviewer reconciliation (both self-reviews run before push)
- **codex** flagged [P1] `match_status` incompatible with CB's `matching_type(user, patient_info=...)`. **fresh Claude** verified it correct against EXACT's userless `matching_type(self, patient_info)`. Both are right in-frame — it's the same host-signature divergence as the scoring seam. Resolution: the call now passes `patient_info=` **by keyword** (exact for EXACT; in CB fails *loudly* on the missing `user` instead of silently binding pi→`user`), with the CB-convergence requirement documented inline and bucketed with the StudyPrefs-weights companion. The method is **not view-wired** (P0 follow-up), so there is no live break today.
- Otherwise clean: search() call-order/kwargs match LocalMatcher & the package signatures; host-agnostic imports; weight-field names match exactly; tests are non-tautological (weight-sensitive scores, real non-empty results).

## Verification
- New `tests/test_exact_matcher_backend.py` (4): search() annotates `goodness_score` & matches a direct queryset call; explicit weights propagate (non-uniform 40/10/30/20); absent weights default to equal; version tag.
- Full EXACT suite green: **1077 passed, 5 skipped**.

## Follow-ups (tracked, not in this PR)
- CB companion: `StudyPrefs` + 4 weight fields resolved from profile; align `Trial.matching_type` signature; wire the per-trial methods into the view.
- Coverage: the `with_distance_optimized` branch is inert at `geo_point=None`, so not exercised here — add a geo case when the per-trial/geo paths get wired.

Part of EPIC cancerbot#4601 (E1 #272). Proposal — cross-team.

🤖 Generated with [Claude Code](https://claude.com/claude-code)