### PR TITLE
feat(matcher): port CB's sane_range guard into eligible_for_min_max_value

### DIFF
--- a/matcher_app/exact_matching/querysets/trial.py
+++ b/matcher_app/exact_matching/querysets/trial.py
@@ -859,21 +859,35 @@ class TrialQuerySet(models.QuerySet):
             goodness_score=score_expr,
         )
 
-    def eligible_for_min_max_value(self, attr_min_name, attr_max_name, value, skip_blank=True):
+    def eligible_for_min_max_value(self, attr_min_name, attr_max_name, value, skip_blank=True, sane_range=None):
         if value is None:
             return self
         if skip_blank and value == 0:
             return self
 
+        # sane_range=(low, high): a stored threshold outside this band is not in the
+        # attribute's canonical unit yet (e.g. WBC thresholds mid-migration, cb#4559/
+        # #4561), so treat it as "no constraint" rather than comparing on a wrong scale
+        # and wrongly excluding the patient. Self-heals once the threshold is
+        # re-normalized into the band. Ported from CB to keep the two querysets
+        # convergent: CB's retained orchestrator already passes sane_range, and the
+        # package orchestrator (filter_by_patient_info) will pass it at the QR4 cutover.
+        # Default None = exact no-op, so EXACT's current behaviour is unchanged.
+        def out_of_band(attr_name):
+            low, high = sane_range
+            return Q(**{f'{attr_name}__lt': low}) | Q(**{f'{attr_name}__gt': high})
+
         scope = self
         if attr_min_name is not None:
-            scope = scope.filter(
-                Q(**{f'{attr_min_name}__lte': value}) | Q(**{f'{attr_min_name}__isnull': True})
-            )
+            cond = Q(**{f'{attr_min_name}__lte': value}) | Q(**{f'{attr_min_name}__isnull': True})
+            if sane_range is not None:
+                cond |= out_of_band(attr_min_name)
+            scope = scope.filter(cond)
         if attr_max_name is not None:
-            scope = scope.filter(
-                Q(**{f'{attr_max_name}__gte': value}) | Q(**{f'{attr_max_name}__isnull': True})
-            )
+            cond = Q(**{f'{attr_max_name}__gte': value}) | Q(**{f'{attr_max_name}__isnull': True})
+            if sane_range is not None:
+                cond |= out_of_band(attr_max_name)
+            scope = scope.filter(cond)
 
         return scope
 

--- a/tests/querysets/test_min_max_sane_range.py
+++ b/tests/querysets/test_min_max_sane_range.py
@@ -1,0 +1,39 @@
+"""eligible_for_min_max_value sane_range guard (ported from CB, cb#4559/#4561).
+
+A stored threshold outside the sane band is treated as "no constraint" (self-heals
+once re-normalized) instead of comparing on a wrong scale and wrongly excluding the
+patient. Default sane_range=None is an exact no-op.
+"""
+import pytest
+
+from trials.models import Trial
+from tests.factories import TrialFactory
+
+_MIN, _MAX = 'white_blood_cell_count_min', 'white_blood_cell_count_max'
+
+
+@pytest.mark.django_db
+def test_out_of_band_min_threshold_is_no_constraint():
+    t_out = TrialFactory(white_blood_cell_count_min=2_000_000_000)  # not yet in canonical units
+    t_in = TrialFactory(white_blood_cell_count_min=5000)            # in-band
+    value = 3000  # below the in-band min -> would exclude t_in
+    qs = Trial.objects.filter(pk__in=[t_out.pk, t_in.pk]).eligible_for_min_max_value(
+        _MIN, _MAX, value, sane_range=(0, 1_000_000))
+    ids = set(qs.values_list('pk', flat=True))
+    assert t_out.pk in ids       # out-of-band threshold -> guard fires -> kept
+    assert t_in.pk not in ids    # in-band, value < min -> genuinely excluded
+
+
+@pytest.mark.django_db
+def test_no_sane_range_excludes_out_of_band_threshold():
+    t_out = TrialFactory(white_blood_cell_count_min=2_000_000_000)
+    qs = Trial.objects.filter(pk=t_out.pk).eligible_for_min_max_value(_MIN, _MAX, 3000)  # no guard
+    assert t_out.pk not in set(qs.values_list('pk', flat=True))  # excluded on the wrong scale
+
+
+@pytest.mark.django_db
+def test_in_band_threshold_matches_normally():
+    t_ok = TrialFactory(white_blood_cell_count_min=1000)  # value >= min -> eligible
+    qs = Trial.objects.filter(pk=t_ok.pk).eligible_for_min_max_value(
+        _MIN, _MAX, 3000, sane_range=(0, 1_000_000))
+    assert t_ok.pk in set(qs.values_list('pk', flat=True))


### PR DESCRIPTION
First safe step of QR3 (CB↔EXACT queryset reconciliation). The package's `eligible_for_min_max_value` had dropped CB's **sane_range / out-of-band threshold guard** (cb#4559/#4561): a stored min/max threshold outside the sane band is not yet in the attribute's canonical unit (e.g. WBC thresholds mid-migration), so it must be treated as **no constraint** rather than compared on a wrong scale and wrongly excluding the patient. Re-added **verbatim** from CB.

## Safe
`sane_range=None` (the default, and how every current caller invokes it) is an **exact no-op** — the guard branches are skipped and `cond` reduces to the old filter. EXACT's behaviour is unchanged (full suite **1080 passed**).

## Why (unblocks CB QR3)
Restores parity so CB can drain its own `eligible_for_min_max_value` override and inherit this one — CB's retained orchestrator already passes `sane_range`. **Tracked for QR4:** the package orchestrator (`filter_by_patient_info`) must also carry+pass `sane_range` from the mapping/config before *full-search* equivalence can be certified (per the plan-review — porting the method alone isn't the whole cutover).

## Verification
- New `tests/querysets/test_min_max_sane_range.py` (3): out-of-band min threshold → no-constraint (guard fires); no-`sane_range` → excludes on the wrong scale; in-band → matches normally.
- Two-part self-review — both clean: codex ("optional guard preserves existing behaviour when unset, correctly treats out-of-band thresholds as unconstrained") + fresh-context Claude (byte-identical to CB, exact no-op default, guard semantics correct, tests discriminate; one inherited P3 — half-open `(low, None)` band — no current caller, no action).

Part of EPIC cancerbot#4601 (A2 / QR3). Proposal — cross-team.

🤖 Generated with [Claude Code](https://claude.com/claude-code)