### PR TITLE
feat(omop-types): consumer surface for patient drug-class type concept_ids (#284)

### DIFF
--- a/matcher_app/exact_matching/patient_info/patient_info_attributes.py
+++ b/matcher_app/exact_matching/patient_info/patient_info_attributes.py
@@ -243,7 +243,7 @@ class PatientInfoAttributes:
             return None
         return [str(v) for v in val if v is not None and str(v).strip().isdigit()]
 
-    def get_user_therapy_component_class_ids(self):
+    def get_user_therapy_type_ids(self):
         """Return the patient's drug-class "type" concept_ids (PROMOP-supplied,
         OMOP mode only; promop#370, ADR 0002). Mirror of
         get_user_therapy_component_ids: None when the field is absent (unknown ->
@@ -251,7 +251,7 @@ class PatientInfoAttributes:
         Consumed as the patient's type match-values once EXACT_OMOP_THERAPY_TYPES
         is on (#285); inert before that.
         """
-        val = self.get_value('therapy_component_class_ids')
+        val = self.get_value('therapy_type_ids')
         if val is None:
             return None
         return [str(v) for v in val if v is not None and str(v).strip().isdigit()]

--- a/matcher_app/exact_matching/patient_info/patient_info_attributes.py
+++ b/matcher_app/exact_matching/patient_info/patient_info_attributes.py
@@ -243,6 +243,19 @@ class PatientInfoAttributes:
             return None
         return [str(v) for v in val if v is not None and str(v).strip().isdigit()]
 
+    def get_user_therapy_component_class_ids(self):
+        """Return the patient's drug-class "type" concept_ids (PROMOP-supplied,
+        OMOP mode only; promop#370, ADR 0002). Mirror of
+        get_user_therapy_component_ids: None when the field is absent (unknown ->
+        callers fail-closed), else a normalized (stringified digit) list or [].
+        Consumed as the patient's type match-values once EXACT_OMOP_THERAPY_TYPES
+        is on (#285); inert before that.
+        """
+        val = self.get_value('therapy_component_class_ids')
+        if val is None:
+            return None
+        return [str(v) for v in val if v is not None and str(v).strip().isdigit()]
+
     @cached_property
     def disease_code(self):
         disease = str(self.patient_info.disease).lower()

--- a/tests/services/patient_info/test_therapy_component_class_ids_attr.py
+++ b/tests/services/patient_info/test_therapy_component_class_ids_attr.py
@@ -1,0 +1,42 @@
+"""Unit tests for get_user_therapy_component_class_ids() (promop#370, ADR 0002).
+
+Mirror of test_therapy_component_ids_attr — the None/[] distinction is the same
+load-bearing contract for the OMOP drug-class "type" match-values consumed once
+EXACT_OMOP_THERAPY_TYPES is on (#285):
+  None  = field absent → fail-closed (unknown, don't filter)
+  []    = explicitly empty list sent by PROMOP → known-empty, no class ids
+  [ids] = known list → overlap match
+"""
+import pytest
+
+from trials.services.patient_info.patient_info import PatientInfo
+from trials.services.patient_info.patient_info_attributes import PatientInfoAttributes
+
+pytestmark = pytest.mark.django_db
+
+
+def _attr(**kw):
+    return PatientInfoAttributes(PatientInfo(**kw))
+
+
+def test_absent_returns_none():
+    assert _attr().get_user_therapy_component_class_ids() is None
+
+
+def test_none_value_returns_none():
+    assert _attr(therapy_component_class_ids=None).get_user_therapy_component_class_ids() is None
+
+
+def test_empty_list_returns_empty_list():
+    result = _attr(therapy_component_class_ids=[]).get_user_therapy_component_class_ids()
+    assert result == []
+
+
+def test_valid_ids_returned_as_strings():
+    result = _attr(therapy_component_class_ids=[35807295, 35807403]).get_user_therapy_component_class_ids()
+    assert result == ['35807295', '35807403']
+
+
+def test_non_digit_values_dropped():
+    result = _attr(therapy_component_class_ids=[35807295, None, 'abc']).get_user_therapy_component_class_ids()
+    assert result == ['35807295']

--- a/tests/services/patient_info/test_therapy_type_ids_attr.py
+++ b/tests/services/patient_info/test_therapy_type_ids_attr.py
@@ -1,4 +1,4 @@
-"""Unit tests for get_user_therapy_component_class_ids() (promop#370, ADR 0002).
+"""Unit tests for get_user_therapy_type_ids() (promop#370, ADR 0002).
 
 Mirror of test_therapy_component_ids_attr — the None/[] distinction is the same
 load-bearing contract for the OMOP drug-class "type" match-values consumed once
@@ -20,23 +20,23 @@ def _attr(**kw):
 
 
 def test_absent_returns_none():
-    assert _attr().get_user_therapy_component_class_ids() is None
+    assert _attr().get_user_therapy_type_ids() is None
 
 
 def test_none_value_returns_none():
-    assert _attr(therapy_component_class_ids=None).get_user_therapy_component_class_ids() is None
+    assert _attr(therapy_type_ids=None).get_user_therapy_type_ids() is None
 
 
 def test_empty_list_returns_empty_list():
-    result = _attr(therapy_component_class_ids=[]).get_user_therapy_component_class_ids()
+    result = _attr(therapy_type_ids=[]).get_user_therapy_type_ids()
     assert result == []
 
 
 def test_valid_ids_returned_as_strings():
-    result = _attr(therapy_component_class_ids=[35807295, 35807403]).get_user_therapy_component_class_ids()
+    result = _attr(therapy_type_ids=[35807295, 35807403]).get_user_therapy_type_ids()
     assert result == ['35807295', '35807403']
 
 
 def test_non_digit_values_dropped():
-    result = _attr(therapy_component_class_ids=[35807295, None, 'abc']).get_user_therapy_component_class_ids()
+    result = _attr(therapy_type_ids=[35807295, None, 'abc']).get_user_therapy_type_ids()
     assert result == ['35807295']

--- a/trials/services/patient_info/patient_info.py
+++ b/trials/services/patient_info/patient_info.py
@@ -93,6 +93,10 @@ _FIELDS = [
     # Component concept_ids supplied directly by PROMOP (promop#189) under OMOP mode.
     # None when the consumer has not sent them; used by component_category_lookup for types.
     _f(JSONField, 'therapy_component_ids', default=None),
+    # Drug-class "type" concept_ids pre-expanded by PROMOP (promop#370, ADR 0002).
+    # None when the consumer has not sent them; consumed as the patient's type
+    # match-values once EXACT_OMOP_THERAPY_TYPES is on (#285). Inert until then.
+    _f(JSONField, 'therapy_component_class_ids', default=None),
     _f(DateField, 'later_date'),
     _f(TextField, 'later_outcome'),
     _f(TextField, 'old_supportive_therapies'),

--- a/trials/services/patient_info/patient_info.py
+++ b/trials/services/patient_info/patient_info.py
@@ -96,7 +96,7 @@ _FIELDS = [
     # Drug-class "type" concept_ids pre-expanded by PROMOP (promop#370, ADR 0002).
     # None when the consumer has not sent them; consumed as the patient's type
     # match-values once EXACT_OMOP_THERAPY_TYPES is on (#285). Inert until then.
-    _f(JSONField, 'therapy_component_class_ids', default=None),
+    _f(JSONField, 'therapy_type_ids', default=None),
     _f(DateField, 'later_date'),
     _f(TextField, 'later_outcome'),
     _f(TextField, 'old_supportive_therapies'),


### PR DESCRIPTION
Closes #284. Part of epic #283 (OMOP-native therapy TYPE matching, promop ADR 0002).

## What
Additive **consumer surface** for the patient's pre-expanded drug-class "type" concept_ids (promop#370): promop's PatientRecord now exposes `therapy_component_class_ids`; EXACT projects it and offers a getter, so #285 can consume it. **Fully inert** — nothing reads the field yet; matching is unchanged (flag on or off).

- **Patient projection** (`patient_info.py`): `therapy_component_class_ids` JSONField(default=None), byte-identical mirror of `therapy_component_ids`.
- **PROMOP pass-through:** deliberately **NOT** added to `promop_adapter.JSON_FIELDS` — a `JSON_FIELDS` member's empty `[]` is dropped at the pass-through loop, collapsing `[]`→`None`. Kept out so the load-bearing **None (absent) vs [] (known-empty) vs [ids]** distinction survives, same as `therapy_component_ids`.
- **Getter** (`patient_info_attributes.py`): `get_user_therapy_component_class_ids()` mirrors `get_user_therapy_component_ids` (None→None, []→[], digits stringified, non-digits dropped); rides the `trials.services…` back-compat shim.
- **Tests:** 5 cases mirroring `test_therapy_component_ids_attr` (absent/None/[]/valid/non-digit). patient_info + omop-matching suites green (183).

## Deferred to #285 (activation)
Flag `EXACT_OMOP_THERAPY_TYPES`, `OMOP_THERAPY_MATCH_PROFILE` column override (`therapy_types_* → omop_therapy_types_*`), `derive_component_and_type_values` returning class ids, data_port/caller wiring, re-add trial `omop_therapy_types_*` + migration, and matcher/queryset **fail-closed** (incl. class-only patient paths). Split this way so type_values and the trial columns flip **atomically** behind one flag — avoids a legacy/OMOP mismatch window.

## Review
Two-part self-review (fresh Claude subagent + `codex review --base 2omop`) — both clean, no blockers. Notes carried to #285: (a) confirm promop always delivers this as a native list, not a JSON string (getter would iterate chars; fix is a decode branch, NOT JSON_FIELDS); (b) optional adapter round-trip test (pre-existing gap, `therapy_component_ids` lacks one too).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
