### PR TITLE
feat(matcher): by_titles also matches study_id (port CB #3547)

### DIFF
--- a/matcher_app/exact_matching/querysets/trial.py
+++ b/matcher_app/exact_matching/querysets/trial.py
@@ -541,12 +541,17 @@ class TrialQuerySet(models.QuerySet):
             return self
 
         # https://docs.djangoproject.com/en/5.1/ref/contrib/postgres/search/#full-text-search
+        # Also match the NCT / study_id so the search box finds a trial by its
+        # identifier, not only by title text (cb#3547). Dropped during the E1
+        # extraction; re-added to keep the two querysets convergent so CB can drain
+        # its by_titles override (QR3).
         return self.annotate(
             search=SearchVector("brief_title", "official_title"),
         ).filter(
             Q(search=SearchQuery(search_title, search_type="plain")) |
             Q(brief_title__icontains=search_title) |
-            Q(official_title__icontains=search_title)
+            Q(official_title__icontains=search_title) |
+            Q(study_id__icontains=search_title)
         )
 
     def by_therapy_id(self, therapy_ids: list[int]) -> models.QuerySet:

--- a/tests/querysets/test_by_titles_study_id.py
+++ b/tests/querysets/test_by_titles_study_id.py
@@ -1,0 +1,24 @@
+"""by_titles matches the NCT / study_id, not only title text (cb#3547).
+
+Regression guard for the study_id clause dropped during the E1 extraction and
+re-added so CB can drain its by_titles override (QR3).
+"""
+import pytest
+
+from trials.models import Trial
+from tests.factories import TrialFactory
+
+
+@pytest.mark.django_db
+def test_by_titles_matches_study_id():
+    t = TrialFactory(study_id='NCT01234567', brief_title='Some Myeloma Trial')
+    other = TrialFactory(study_id='NCT99999999', brief_title='Unrelated')
+    ids = set(Trial.objects.filter(pk__in=[t.pk, other.pk]).by_titles('NCT01234567').values_list('pk', flat=True))
+    assert t.pk in ids and other.pk not in ids
+
+
+@pytest.mark.django_db
+def test_by_titles_still_matches_title_text():
+    t = TrialFactory(study_id='NCT00000001', brief_title='Bortezomib Study')
+    ids = set(Trial.objects.filter(pk=t.pk).by_titles('Bortezomib').values_list('pk', flat=True))
+    assert t.pk in ids


### PR DESCRIPTION
QR3 convergence port. `by_titles` dropped CB's NCT / study_id search clause during the E1 extraction — CB's search box finds a trial by its identifier, not only title text (cb#3547). Re-add `Q(study_id__icontains=search_title)` so the two querysets converge and CB can drain its `by_titles` override.

## Additive, no regression
Adds one disjunct to the existing OR chain → can only broaden matches (a trial matching by title still matches). No new join/annotation, `study_id` is a scalar field → no distinct/count side effects. After this, package `by_titles` is semantically identical to CB's.

## Verification
- New `tests/querysets/test_by_titles_study_id.py` (2): match by study_id (term matches neither title field nor the SearchVector — only the new clause; with a non-matching sibling as negative control); title-text still matches.
- Two-part self-review — both clean: codex ("study_id condition correctly incorporated, covered by a regression test") + fresh-context Claude (semantically identical to CB, field exists + indexed, additive-only, tests meaningful).
- EXACT GitHub CI will run the full backend suite (as it did green on the E1 / sane_range PRs).

Part of EPIC cancerbot#4601 (A2 / QR3). Proposal — cross-team.

🤖 Generated with [Claude Code](https://claude.com/claude-code)