### PR TITLE
feat(matcher): QR4a — extranodal str-or-list coercion + orchestrator forwards sane_range

### DIFF
--- a/matcher_app/exact_matching/querysets/trial.py
+++ b/matcher_app/exact_matching/querysets/trial.py
@@ -99,6 +99,20 @@ def _csv_stripped(value):
     return [x.strip() for x in _csv(value)]
 
 
+def _as_list_stripped(value):
+    """Coerce a patient multi-select to a clean list, accepting EITHER a list
+    (EXACT's `extranodal_sites` is a JSONField) OR a CSV string (CB's is a
+    comma-separated TextField). A bare string must be split — passing it raw to
+    `eligible_for_required_lists` iterates CHARACTERS. A list flows through with
+    each element stripped. Empty/None -> []. This is the str-or-list seam that
+    lets CB drain its orchestrator onto this dispatch without a contract change."""
+    if not value:
+        return []
+    if isinstance(value, str):
+        return [x.strip() for x in value.split(",")]
+    return [str(x).strip() for x in value]
+
+
 def _filter_disease(scope, value, _ctx):
     return scope.filter(disease__iexact=value.lower())
 
@@ -214,7 +228,11 @@ _CUSTOM_SEARCH_DISPATCH = {
     'disease_subtype': lambda s, v, _c: s.eligible_for_disease_subtypes(_csv_stripped(v)),
     'mipi_risk': lambda s, v, _c: s.eligible_for_mipi_risks(_csv_stripped(v)),
     'mipi_c_risk': lambda s, v, _c: s.eligible_for_mipi_c_risks(_csv_stripped(v)),
-    'extranodal_sites': lambda s, v, _c: s.eligible_for_extranodal_sites(v),
+    # extranodal_sites is the ONLY list-valued patient attr: EXACT's PatientInfo has it
+    # as a JSONField (list), CB's as a comma-separated TextField (string). _as_list_stripped
+    # accepts both — a list flows through (EXACT, unchanged), a string is split (CB-safe at
+    # drain). Passing a raw string would char-iterate downstream in eligible_for_required_lists.
+    'extranodal_sites': lambda s, v, _c: s.eligible_for_extranodal_sites(_as_list_stripped(v)),
     'bulky_disease_criteria': lambda s, v, _c: s.eligible_for_bulky_disease_criteria(_csv_stripped(v)),
     'high_risk_mcl_criteria': lambda s, v, _c: s.eligible_for_high_risk_mcl_criteria(_csv_stripped(v)),
 }
@@ -1611,7 +1629,11 @@ class TrialQuerySet(models.QuerySet):
                     attr_max_name = trial_attr_meta["attr_max"]
                 else:
                     attr_max_name = f'{trial_attr_meta["attr"]}_max'
-                scope = scope.eligible_for_min_max_value(attr_min_name, attr_max_name, user_attr_value, skip_blank=not allow_blank_values)
+                # Forward sane_range so an out-of-band stored threshold self-heals instead of
+                # excluding on the wrong scale (WBC guard, cb#4559). The helper has accepted it
+                # since #282; CB's retained orchestrator already passes it (QR4a/L1). ULN call
+                # takes no sane_range, matching CB.
+                scope = scope.eligible_for_min_max_value(attr_min_name, attr_max_name, user_attr_value, skip_blank=not allow_blank_values, sane_range=trial_attr_meta.get("sane_range"))
 
                 user_attr_value_uln = patient_info_attr.get_uln_value(user_attr)
                 if user_attr_value_uln:

--- a/tests/querysets/test_custom_search_dispatch.py
+++ b/tests/querysets/test_custom_search_dispatch.py
@@ -108,6 +108,42 @@ class TestDispatchTableExhaustive:
         )
 
 
+class TestExtranodalSitesSplit:
+    """QR4a/L2 regression: `extranodal_sites` must reach `eligible_for_extranodal_sites`
+    as a clean LIST, accepting either input shape. EXACT's PatientInfo has it as a
+    JSONField (list); CB's as a comma-separated TextField (string). A raw STRING would
+    char-iterate downstream ('spleen,liver' -> ['s','p','l',...]); a `_csv`-style split
+    would crash on EXACT's list (`list.split` AttributeError). `_as_list_stripped` handles
+    both — this pins both directions so neither the string nor the list path regresses.
+    """
+
+    def test_list_input_flows_through_stripped(self):
+        # EXACT contract: extranodal_sites arrives as a list. Must NOT crash (the
+        # _csv_stripped mistake did) and must stay a stripped list.
+        handler = _CUSTOM_SEARCH_DISPATCH['extranodal_sites']
+        scope = MagicMock(spec=TrialQuerySet)
+        handler(scope, ['bone_marrow', '  gi_tract  '], {})
+        (arg,), _kwargs = scope.eligible_for_extranodal_sites.call_args
+        assert arg == ['bone_marrow', 'gi_tract']
+
+    def test_string_input_is_split_not_char_iterated(self):
+        # CB contract at drain: a CSV string must be split, never passed raw.
+        handler = _CUSTOM_SEARCH_DISPATCH['extranodal_sites']
+        scope = MagicMock(spec=TrialQuerySet)
+        handler(scope, 'spleen, liver', {})
+        (arg,), _kwargs = scope.eligible_for_extranodal_sites.call_args
+        assert arg == ['spleen', 'liver']
+        assert not isinstance(arg, str)
+
+    def test_empty_value_is_empty_list(self):
+        handler = _CUSTOM_SEARCH_DISPATCH['extranodal_sites']
+        for blank in ('', None, []):
+            scope = MagicMock(spec=TrialQuerySet)
+            handler(scope, blank, {})
+            (arg,), _kwargs = scope.eligible_for_extranodal_sites.call_args
+            assert arg == []
+
+
 class TestCsvHelpers:
     def test_csv_splits_comma(self):
         assert _csv('a,b,c') == ['a', 'b', 'c']

--- a/tests/querysets/test_min_max_sane_range.py
+++ b/tests/querysets/test_min_max_sane_range.py
@@ -7,9 +7,45 @@ patient. Default sane_range=None is an exact no-op.
 import pytest
 
 from trials.models import Trial
+from trials.querysets.trial import TrialQuerySet
+from trials.services.patient_info.patient_info import PatientInfo
+from trials.services.patient_info.configs import USER_TO_TRIAL_ATTRS_MAPPING
 from tests.factories import TrialFactory
 
 _MIN, _MAX = 'white_blood_cell_count_min', 'white_blood_cell_count_max'
+
+
+@pytest.mark.django_db
+def test_orchestrator_forwards_sane_range_from_config(monkeypatch):
+    """QR4a/L1 regression: `filter_by_patient_info` must forward the config's
+    `sane_range` into `eligible_for_min_max_value`. The helper has accepted the
+    kwarg since #282, but the orchestrator previously dropped it — so a stored
+    out-of-band threshold would wrongly exclude the patient, and queryset search
+    would disagree with the detailed matcher / explain. CB's retained orchestrator
+    forwards it; this pins the package to match. (No package config carries a
+    sane_range value yet — ported in QR4b — so we inject one and prove the wiring.)
+    """
+    monkeypatch.setitem(
+        USER_TO_TRIAL_ATTRS_MAPPING['white_blood_cell_count'], 'sane_range', (0, 1_000_000)
+    )
+    TrialFactory(white_blood_cell_count_min=5000)
+    pi = PatientInfo(white_blood_cell_count=3000, white_blood_cell_count_units='cells/L')
+
+    seen = []
+    orig = TrialQuerySet.eligible_for_min_max_value
+
+    def spy(self, attr_min_name, attr_max_name, value, **kwargs):
+        seen.append((attr_min_name, kwargs.get('sane_range')))
+        return orig(self, attr_min_name, attr_max_name, value, **kwargs)
+
+    monkeypatch.setattr(TrialQuerySet, 'eligible_for_min_max_value', spy)
+    Trial.objects.filter_by_patient_info(pi)
+
+    wbc_calls = [sr for (name, sr) in seen if name == _MIN]
+    assert wbc_calls, 'white_blood_cell_count min_max branch never called eligible_for_min_max_value'
+    assert (0, 1_000_000) in wbc_calls, (
+        f'orchestrator dropped sane_range; forwarded values: {wbc_calls}'
+    )
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## QR4a — two package-side dispatch fixes (QR4 plan L1/L2)

First slice of the QR4 config+PIA+dispatch cutover (CB PR #4651). Both are EXACT-side seams so CB can later drain its `filter_by_patient_info` onto this package without a contract change. Each ships a **permanent regression test** (not shadow-only).

### L2 — `extranodal_sites` str-or-list coercion
`extranodal_sites` is the **only list-valued patient attr**: EXACT's `PatientInfo` has it as a JSONField (**list**), CB's as a comma-separated `TextField` (**string**). The dispatch passed it **raw** — correct for EXACT's list, but a bare CB string would char-iterate downstream in `eligible_for_required_lists` (`'spleen,liver'` → `['s','p','l',…]`). New `_as_list_stripped(v)` accepts **both**: a list flows through stripped (EXACT unchanged), a string is split (CB-safe at drain). A plain `_csv` split would instead crash on EXACT's list (`list.split` → AttributeError) — caught in review.

### L1 — orchestrator forwards `sane_range`
`filter_by_patient_info`'s `min_max_value` branch dropped `sane_range`; the helper has accepted it since #282 and CB's retained orchestrator forwards it (CB `trial.py:904`, **only** in `min_max_value`, not `min_value`/`max_value`/ULN — mirrored here). Without it an out-of-band stored threshold excludes on the wrong scale and queryset search disagrees with explain. Inert until QR4b ports the `sane_range` config value; the test injects one to prove the wiring.

## Tests
- `test_custom_search_dispatch.py::TestExtranodalSitesSplit` — list input flows through stripped (guards the AttributeError regression), string split, empty (`''`/`None`/`[]`) → `[]`.
- `test_min_max_sane_range.py::test_orchestrator_forwards_sane_range_from_config` — spies `eligible_for_min_max_value`, asserts the WBC `min_max_value` branch forwards an injected `sane_range`.

## Review
codex clean (caught a P1 on the first pass — `_csv_stripped` broke EXACT's list contract — fixed to `_as_list_stripped`); fresh-context Claude SHIP (traced WBC-branch reachability + monkeypatch dict identity statically; EX312 points at another clone so local run isn't representative — CI validates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)