### PR TITLE
feat(omop-types): #286 release-consistency — validate_concept_ids + Gate 2 asymmetric per-concept validation

### DIFF
--- a/matcher_app/exact_matching/matcher.py
+++ b/matcher_app/exact_matching/matcher.py
@@ -354,22 +354,36 @@ class UserToTrialAttrMatcher:
                 "values": sorted(list(set(values)))
             }
 
-        # FAIL-CLOSED types (#285): under OMOP-types, unknown patient class ids
-        # (getter None) against a required type is a hard not_matched — the rendered
-        # status must agree with the _match_therapy_related_things verdict even when
-        # the therapy-line mismatch_status is 'unknown' (e.g. a blank first line).
+        # FAIL-CLOSED types (#285/#286): under OMOP-types a required-type miss is a
+        # hard not_matched (never 'unknown'), and the patient's class ids are
+        # release-validated so the rendered status agrees with the verdict. Stale /
+        # invalid keys are dropped from the required/excluded type map (so a stale
+        # required id can't render 'matched'); if the patient carries any unvalidated
+        # id, an excluded-type constraint renders not_matched (conservative, parity
+        # with _match_omop_type_things). See type_release_gate.
         type_mismatch_status = mismatch_status
-        if omop_therapy_types_enabled() and self.patient_info_attr.get_user_therapy_type_ids() is None:
+        types_map = therapy_types_to_therapy
+        types_excluded_conservative = False
+        if omop_therapy_types_enabled():
             type_mismatch_status = 'not_matched'
+            raw_class_ids = self.patient_info_attr.get_user_therapy_type_ids()
+            if raw_class_ids is not None:
+                from trials.services.omop.type_release_gate import resolve_type_validation
+                validated, has_unvalidated = resolve_type_validation(raw_class_ids)
+                types_map = {k: v for k, v in therapy_types_to_therapy.items() if k in validated}
+                types_excluded_conservative = has_unvalidated
 
         out = {
             "therapiesRequired": match_required(getattr(self.trial, THERAPY_MATCH_PROFILE.therapies_required), therapies, mismatch_status),
             "therapiesExcluded": match_excluded(getattr(self.trial, THERAPY_MATCH_PROFILE.therapies_excluded), therapies),
-            "therapyTypesRequired": match_required(getattr(self.trial, THERAPY_MATCH_PROFILE.therapy_types_required), therapy_types_to_therapy, type_mismatch_status),
-            "therapyTypesExcluded": match_excluded(getattr(self.trial, THERAPY_MATCH_PROFILE.therapy_types_excluded), therapy_types_to_therapy),
+            "therapyTypesRequired": match_required(getattr(self.trial, THERAPY_MATCH_PROFILE.therapy_types_required), types_map, type_mismatch_status),
+            "therapyTypesExcluded": match_excluded(getattr(self.trial, THERAPY_MATCH_PROFILE.therapy_types_excluded), types_map),
             "therapyComponentsRequired": match_required(getattr(self.trial, THERAPY_MATCH_PROFILE.therapy_components_required), therapy_components_to_therapy, mismatch_status),
             "therapyComponentsExcluded": match_excluded(getattr(self.trial, THERAPY_MATCH_PROFILE.therapy_components_excluded), therapy_components_to_therapy),
         }
+        # excluded: never drop an unvalidated id → conservative not_matched (parity).
+        if types_excluded_conservative and getattr(self.trial, THERAPY_MATCH_PROFILE.therapy_types_excluded):
+            out['therapyTypesExcluded']['status'] = 'not_matched'
 
         # OMOP code + title per criterion (additive). Only the OMOP-mapped levels
         # (regimen + component) hold concept_ids; resolve the TRIAL's required/excluded
@@ -448,6 +462,41 @@ class UserToTrialAttrMatcher:
 
         return 'matched'
 
+    def _match_omop_type_things(self, type_values, required_list, excluded_list, has_no_prior_therapy):
+        """OMOP drug-class TYPE overlap under EXACT_OMOP_THERAPY_TYPES (#285) with
+        #286 per-concept release validation applied ASYMMETRICALLY.
+
+        ``type_values`` is the patient's RAW class concept_ids: ``None`` = unknown,
+        ``[]`` = known-empty, a list = the ids. Required uses only ids validated at
+        the pinned vocab-mirror release (stale dropped → fail-closed); excluded never
+        drops an unvalidated id (dropping would re-open the exclusion = fail-OPEN), so
+        a trial that excludes types is not_matched when the patient carries any
+        unvalidated id. See trials.services.omop.type_release_gate.
+        """
+        if required_list == [] and excluded_list == []:
+            return 'matched'
+        # #285: unknown patient class ids (None). A required type is a hard
+        # not_matched; otherwise preserve the prior 'unknown' vs (no-prior →)
+        # 'matched' semantics — there are no concrete ids to validate.
+        if type_values is None:
+            if required_list:
+                return 'not_matched'
+            if not has_no_prior_therapy:
+                return 'unknown'
+            return 'matched'
+        # Concrete patient class ids ([] or a list) → #286 per-concept validation.
+        from trials.services.omop.type_release_gate import resolve_type_validation
+        validated, has_unvalidated = resolve_type_validation(type_values)
+        # excluded: never drop an unvalidated id → conservatively reject.
+        if excluded_list and has_unvalidated:
+            return 'not_matched'
+        if len(get_overlap(sorted(validated), excluded_list)) > 0:
+            return 'not_matched'
+        # required: only validated ids count (stale dropped → fail-closed).
+        if len(required_list) > 0 and len(get_overlap(sorted(validated), required_list)) == 0:
+            return 'not_matched'
+        return 'matched'
+
     def _match_therapy_related_things(self, values, has_no_prior_therapy):
         results = []
         res = self._match_therapy_things(values, getattr(self.trial, THERAPY_MATCH_PROFILE.therapies_required), getattr(self.trial, THERAPY_MATCH_PROFILE.therapies_excluded), has_no_prior_therapy)
@@ -477,13 +526,13 @@ class UserToTrialAttrMatcher:
 
         type_required = getattr(self.trial, THERAPY_MATCH_PROFILE.therapy_types_required)
         type_excluded = getattr(self.trial, THERAPY_MATCH_PROFILE.therapy_types_excluded)
-        # FAIL-CLOSED types (#285): under EXACT_OMOP_THERAPY_TYPES, unknown patient
-        # class ids (therapy_types is None) against a trial that REQUIRES a type must
-        # be a hard not_matched — never fall through to 'unknown'/matched. (A
-        # known-empty [] already resolves to not_matched via the overlap check.)
-        if omop_therapy_types_enabled() and therapy_types is None and type_required:
-            return 'not_matched'
-        res = self._match_therapy_things(therapy_types, type_required, type_excluded, has_no_prior_therapy)
+        # OMOP-types (#285/#286): class-concept_id overlap, FAIL-CLOSED on unknown
+        # patient classes, with per-concept release validation applied asymmetrically
+        # (see _match_omop_type_things). Legacy path is byte-identical to before.
+        if omop_therapy_types_enabled():
+            res = self._match_omop_type_things(therapy_types, type_required, type_excluded, has_no_prior_therapy)
+        else:
+            res = self._match_therapy_things(therapy_types, type_required, type_excluded, has_no_prior_therapy)
         if res == 'not_matched':
             return res
         results.append(res)

--- a/matcher_app/exact_matching/querysets/trial.py
+++ b/matcher_app/exact_matching/querysets/trial.py
@@ -1174,17 +1174,35 @@ class TrialQuerySet(models.QuerySet):
         (``[]``) patient class set keeps ONLY trials that require no types: a trial
         with a required type is NOT eligible for a patient carrying no / unknown
         class ids. Excluded never rejects an empty patient set.
+
+        #286: the patient's class ids are validated against the pinned vocab-mirror
+        release and applied ASYMMETRICALLY (parity with the matcher verdict) —
+        required overlaps only VALIDATED ids (stale dropped → fail-closed); if the
+        patient carries ANY unvalidated id, trials that exclude types are rejected
+        (never drop an unvalidated exclusion = fail-OPEN). See type_release_gate.
         """
         req = THERAPY_MATCH_PROFILE.therapy_types_required   # omop_therapy_types_required under the flag
         exc = THERAPY_MATCH_PROFILE.therapy_types_excluded
         if not type_values:                                  # None (unknown) or [] (known-empty)
             return self.filter(**{f'{req}__exact': []})
-        values = [str(x).strip() for x in type_values]
-        return self.filter(
-            Q(**{f'{req}__has_any_keys': values}) | Q(**{f'{req}__exact': []})
-        ).exclude(
-            Q(**{f'{exc}__has_any_keys': values})
-        )
+        from trials.services.omop.type_release_gate import resolve_type_validation
+        validated, has_unvalidated = resolve_type_validation(type_values)
+        values = sorted(validated)
+        # required: overlap validated ids, or trials that require no types. All ids
+        # stale (validated empty) → keep only no-required-type trials (fail-closed).
+        if values:
+            scope = self.filter(
+                Q(**{f'{req}__has_any_keys': values}) | Q(**{f'{req}__exact': []})
+            )
+        else:
+            scope = self.filter(**{f'{req}__exact': []})
+        # excluded: never drop an unvalidated id → if the patient carries any, keep
+        # only trials that exclude no types; else reject overlap on validated ids.
+        if has_unvalidated:
+            scope = scope.filter(**{f'{exc}__exact': []})
+        elif values:
+            scope = scope.exclude(Q(**{f'{exc}__has_any_keys': values}))
+        return scope
 
     def eligible_for_pre_existing_condition(self, pre_existing_conditions: list[str]) -> models.QuerySet:
         if pre_existing_conditions is None or pre_existing_conditions == []:

--- a/tests/services/test_omop_therapy_types_matching.py
+++ b/tests/services/test_omop_therapy_types_matching.py
@@ -27,9 +27,32 @@ PI_CLASS = '35807295'    # proteasome inhibitor
 IMID_CLASS = '35807403'  # IMiD
 BORT_CID = '900825'      # a component concept_id (only needs to be non-empty)
 REG = '900260'           # a regimen concept_id
+STALE_CLASS = '35800001'    # a class concept_id ABSENT from the mirror (stale)
+INVALID_CLASS = '35800002'  # present in the mirror but invalidated (invalid_reason)
+_RID = 1                    # the seeded active mirror release_id
 
 
 OMOP_TYPES = dict(EXACT_OMOP_THERAPY=True, EXACT_OMOP_THERAPY_TYPES=True)
+
+
+def _mirror_concept(concept_id, invalid_reason=None):
+    from vocab_mirror.models import MirrorConcept
+    MirrorConcept.objects.create(
+        release_id=_RID, concept_id=int(concept_id), concept_name=f'c{concept_id}',
+        domain_id='Drug', vocabulary_id='HemOnc', concept_class_id='Component Class',
+        concept_code=str(concept_id), invalid_reason=invalid_reason)
+
+
+@pytest.fixture(autouse=True)
+def _active_mirror(db):
+    """Seed an ACTIVE vocab-mirror release with the test class ids present + valid,
+    so #286 per-concept validation admits them (an absent/invalidated id is stale).
+    The derive-only tests don't read the mirror; the extra rows are harmless."""
+    from vocab_mirror.models import MirrorRelease
+    MirrorRelease.objects.create(release_id=_RID, state=MirrorRelease.ACTIVE)
+    _mirror_concept(PI_CLASS)
+    _mirror_concept(IMID_CLASS)
+    _mirror_concept(INVALID_CLASS, invalid_reason='D')
 
 
 # ── profile selection ────────────────────────────────────────────────
@@ -227,3 +250,129 @@ def test_queryset_overlap_and_exclusion():
     assert match.id in ids           # required overlap
     assert other.id not in ids       # required miss
     assert excl.id not in ids        # excluded hit rejects
+
+
+# ── #286 Gate 2: per-concept release validation (asymmetric) ─────────
+
+@override_settings(**OMOP_TYPES)
+def test_type_required_stale_class_dropped_not_matched():
+    # An absent (stale) class id is DROPPED → a required-type trial for it is
+    # not_matched, even though the patient carries it on the wire.
+    pi = PatientInfo(disease='multiple myeloma', therapy_component_ids=[int(BORT_CID)],
+                     therapy_type_ids=[int(STALE_CLASS)])
+    trial = TrialFactory(disease='multiple myeloma', omop_therapy_types_required=[STALE_CLASS])
+    assert _match(trial, pi) == 'not_matched'
+
+
+@override_settings(**OMOP_TYPES)
+def test_type_required_invalidated_class_dropped_not_matched():
+    # Present but invalidated (invalid_reason set) is stale too → dropped.
+    pi = PatientInfo(disease='multiple myeloma', therapy_component_ids=[int(BORT_CID)],
+                     therapy_type_ids=[int(INVALID_CLASS)])
+    trial = TrialFactory(disease='multiple myeloma', omop_therapy_types_required=[INVALID_CLASS])
+    assert _match(trial, pi) == 'not_matched'
+
+
+@override_settings(**OMOP_TYPES)
+def test_type_required_partial_stale_valid_id_still_matches():
+    # A stale sibling must NOT sink an otherwise-valid required match.
+    pi = PatientInfo(disease='multiple myeloma', therapy_component_ids=[int(BORT_CID)],
+                     therapy_type_ids=[int(PI_CLASS), int(STALE_CLASS)])
+    trial = TrialFactory(disease='multiple myeloma', omop_therapy_types_required=[PI_CLASS])
+    assert _match(trial, pi) == 'matched'
+
+
+@override_settings(**OMOP_TYPES)
+def test_type_excluded_unvalidated_is_conservative_not_matched():
+    # FAIL-OPEN guard: the patient carries a stale id and the trial excludes SOME
+    # type — we cannot prove the stale id doesn't hit the exclusion, so not_matched,
+    # even though the excluded id differs from the validated one.
+    pi = PatientInfo(disease='multiple myeloma', therapy_component_ids=[int(BORT_CID)],
+                     therapy_type_ids=[int(PI_CLASS), int(STALE_CLASS)])
+    trial = TrialFactory(disease='multiple myeloma', omop_therapy_types_excluded=[IMID_CLASS])
+    assert _match(trial, pi) == 'not_matched'
+
+
+@override_settings(**OMOP_TYPES)
+def test_no_active_release_fails_closed_required_and_excluded():
+    # No active mirror release → validate fails closed: required drops to empty
+    # (not_matched) and any excluded constraint is conservatively rejected.
+    from vocab_mirror.models import MirrorRelease
+    MirrorRelease.objects.filter(state=MirrorRelease.ACTIVE).update(state=MirrorRelease.SUPERSEDED)
+    pi = PatientInfo(disease='multiple myeloma', therapy_component_ids=[int(BORT_CID)],
+                     therapy_type_ids=[int(PI_CLASS)])
+    req = TrialFactory(disease='multiple myeloma', omop_therapy_types_required=[PI_CLASS])
+    exc = TrialFactory(disease='multiple myeloma', omop_therapy_types_excluded=[IMID_CLASS])
+    assert _match(req, pi) == 'not_matched'
+    assert _match(exc, pi) == 'not_matched'
+
+
+@override_settings(**OMOP_TYPES)
+def test_queryset_stale_class_parity_with_matcher():
+    # Queryset prefilter and matcher verdict agree under a stale patient id.
+    needs_stale = TrialFactory(disease='multiple myeloma', omop_therapy_types_required=[STALE_CLASS])
+    needs_valid = TrialFactory(disease='multiple myeloma', omop_therapy_types_required=[PI_CLASS])
+    excl_other = TrialFactory(disease='multiple myeloma', omop_therapy_types_excluded=[IMID_CLASS])
+    pi = PatientInfo(disease='multiple myeloma', therapy_component_ids=[int(BORT_CID)],
+                     therapy_type_ids=[int(PI_CLASS), int(STALE_CLASS)])
+    qs = set(
+        Trial.objects.filter(id__in=[needs_stale.id, needs_valid.id, excl_other.id])
+        .eligible_for_omop_therapy_types([PI_CLASS, STALE_CLASS]).values_list('id', flat=True)
+    )
+    assert qs == {needs_valid.id}                    # stale-required dropped; excluded-trial rejected
+    assert _match(needs_valid, pi) == 'matched'
+    assert _match(needs_stale, pi) == 'not_matched'
+    assert _match(excl_other, pi) == 'not_matched'
+
+
+@override_settings(**OMOP_TYPES)
+def test_display_type_required_stale_dropped_not_matched():
+    # Detail parity with the verdict: a stale required class id must NOT render
+    # 'matched' in the criterion breakdown (was the display/verdict divergence).
+    pi = PatientInfo(disease='multiple myeloma', first_line_therapy=REG, prior_therapy='One line',
+                     therapy_component_ids=[int(BORT_CID)], therapy_type_ids=[int(STALE_CLASS)])
+    trial = TrialFactory(disease='multiple myeloma', omop_therapy_types_required=[STALE_CLASS])
+    out = UserToTrialAttrMatcher(trial, pi).therapy_related_things_match_status()
+    assert out['therapyTypesRequired']['status'] == 'not_matched'
+
+
+@override_settings(**OMOP_TYPES)
+def test_display_type_excluded_unvalidated_conservative_not_matched():
+    # Detail parity: patient carries a stale id + the trial excludes some type →
+    # conservative not_matched (never render an unvalidated exclusion as matched).
+    pi = PatientInfo(disease='multiple myeloma', first_line_therapy=REG, prior_therapy='One line',
+                     therapy_component_ids=[int(BORT_CID)], therapy_type_ids=[int(PI_CLASS), int(STALE_CLASS)])
+    trial = TrialFactory(disease='multiple myeloma', omop_therapy_types_excluded=[IMID_CLASS])
+    out = UserToTrialAttrMatcher(trial, pi).therapy_related_things_match_status()
+    assert out['therapyTypesExcluded']['status'] == 'not_matched'
+
+
+@override_settings(**OMOP_TYPES)
+def test_queryset_no_active_release_fails_closed():
+    # Queryset-side parity with the matcher no-release case: no active mirror →
+    # required dropped + excluded-type trials rejected → only the no-constraint trial.
+    from vocab_mirror.models import MirrorRelease
+    MirrorRelease.objects.filter(state=MirrorRelease.ACTIVE).update(state=MirrorRelease.SUPERSEDED)
+    needs = TrialFactory(disease='multiple myeloma', omop_therapy_types_required=[PI_CLASS])
+    open_ = TrialFactory(disease='multiple myeloma', omop_therapy_types_required=[])
+    excl = TrialFactory(disease='multiple myeloma', omop_therapy_types_excluded=[IMID_CLASS])
+    qs = set(
+        Trial.objects.filter(id__in=[needs.id, open_.id, excl.id])
+        .eligible_for_omop_therapy_types([PI_CLASS]).values_list('id', flat=True)
+    )
+    assert qs == {open_.id}
+
+
+@override_settings(**OMOP_TYPES)
+def test_memo_dedups_validation_to_one_query(django_assert_num_queries):
+    # The per-request memo collapses repeated per-trial validation of the same
+    # class-id set to a single mirror query (order-independent key).
+    from vocab_mirror.release_context import MatchingReleaseContext
+    from trials.services.omop.type_release_gate import (
+        resolve_type_validation, type_validation_request_cache)
+    with MatchingReleaseContext(), type_validation_request_cache():
+        with django_assert_num_queries(1):
+            v1, u1 = resolve_type_validation([PI_CLASS, IMID_CLASS])
+            v2, u2 = resolve_type_validation([IMID_CLASS, PI_CLASS])  # same set, different order
+    assert v1 == v2 == {PI_CLASS, IMID_CLASS}
+    assert u1 is False and u2 is False

--- a/tests/vocab_mirror/test_validate.py
+++ b/tests/vocab_mirror/test_validate.py
@@ -1,0 +1,61 @@
+"""Release-consistency validator tests (#286).
+
+validate_concept_ids returns the subset of concept_ids that are PRESENT and VALID
+(invalid_reason IS NULL) in the mirror at the given release. release_id is required
+(None -> fail closed). Per-concept: a stale/absent concept drops out; the rest stay.
+"""
+import pytest
+
+from vocab_mirror.models import MirrorConcept
+from vocab_mirror.traversal import ConceptGraphUnavailable
+from vocab_mirror.validate import validate_concept_ids
+
+pytestmark = pytest.mark.django_db
+
+RID = 1
+
+
+def _concept(concept_id, invalid_reason=None, release_id=RID):
+    MirrorConcept.objects.create(
+        release_id=release_id, concept_id=concept_id, concept_name=f'c{concept_id}',
+        domain_id='Drug', vocabulary_id='HemOnc', concept_class_id='Component Class',
+        concept_code=str(concept_id), invalid_reason=invalid_reason)
+
+
+def test_present_and_valid_kept():
+    _concept(35807295)
+    assert validate_concept_ids(['35807295'], RID) == {35807295}
+
+
+def test_invalidated_concept_dropped():
+    _concept(35807295, invalid_reason='D')      # deprecated
+    assert validate_concept_ids(['35807295'], RID) == set()
+
+
+def test_absent_concept_dropped():
+    # nothing created -> concept not in mirror
+    assert validate_concept_ids(['35807295'], RID) == set()
+
+
+def test_mixed_keeps_only_valid_present():
+    _concept(35807295)                          # valid
+    _concept(35807403, invalid_reason='U')      # invalid
+    # 35807345 absent
+    assert validate_concept_ids(['35807295', '35807403', '35807345'], RID) == {35807295}
+
+
+def test_release_scoped_other_release_not_seen():
+    _concept(35807295, release_id=2)            # valid but in a DIFFERENT release
+    assert validate_concept_ids(['35807295'], RID) == set()
+
+
+def test_none_release_fails_closed():
+    _concept(35807295)
+    with pytest.raises(ConceptGraphUnavailable):
+        validate_concept_ids(['35807295'], None)
+
+
+def test_empty_and_non_digit_input():
+    assert validate_concept_ids([], RID) == set()
+    assert validate_concept_ids(None, RID) == set()
+    assert validate_concept_ids(['abc', '0', '-5', None], RID) == set()

--- a/trials/api/trials_views.py
+++ b/trials/api/trials_views.py
@@ -68,10 +68,13 @@ class TrialsViewSet(viewsets.ReadOnlyModelViewSet):
         # runs inside this block, so the header sees the same context.
         from vocab_mirror.release_context import MatchingReleaseContext
         from trials.services.omop.component_category_lookup import component_lookup_request_cache
+        from trials.services.omop.type_release_gate import type_validation_request_cache
         # component_lookup_request_cache: dedup the per-trial component→type lookups
         # within this request without a process-global cache that could go stale in
         # web workers after a sync-job rebuild (ADR 0002 guard #8, #266).
-        with MatchingReleaseContext() as ctx, component_lookup_request_cache():
+        # type_validation_request_cache: same, for the #286 per-concept class-id
+        # release validation (one mirror query per class-id set per request).
+        with MatchingReleaseContext() as ctx, component_lookup_request_cache(), type_validation_request_cache():
             self._release_ctx = ctx
             return super().dispatch(request, *args, **kwargs)
 

--- a/trials/services/omop/type_release_gate.py
+++ b/trials/services/omop/type_release_gate.py
@@ -1,0 +1,109 @@
+"""#286 Gate 2 — per-concept release-consistency for OMOP drug-class TYPE ids.
+
+Validates the patient's OWN drug-class concept_ids against the pinned vocab-mirror
+release (present + ``invalid_reason IS NULL``, via :mod:`vocab_mirror.validate`) and
+reports them ASYMMETRICALLY to the two therapy-matching seams (matcher + queryset):
+
+- **required**: a stale/absent class id is DROPPED → fail-closed for that id (a
+  required-type trial whose only patient match was stale resolves to not_matched).
+- **excluded**: a stale/unvalidated class id is NEVER dropped — dropping it would
+  turn a real exclusion hit into a match (fail-OPEN). If the patient carries ANY
+  unvalidated class id, the caller must conservatively reject a trial that excludes
+  types (see ``has_unvalidated``).
+
+This lives here, NOT in ``derive_component_and_type_values``: derive must keep
+returning the RAW class ids so the excluded side can still see the unvalidated ones
+(filtering inside derive would lose them and re-open the exclusion). See #286 design.
+
+Release resolution + memo mirror the component-lookup gate
+(:class:`component_category_lookup.component_lookup_request_cache`): the pinned
+release comes from :func:`active_pinned_release` (the per-request pin, or the live
+active release for non-HTTP callers), and validation is memoized per-request via
+:class:`type_validation_request_cache` — one mirror query per (release, class-id set)
+per request, never a process-global cache (a mirror rebuild between requests is
+always picked up; outside a request the memo is unset and every call reads directly).
+
+Fail-closed: when no release is pinned/active (``active_pinned_release()`` is None),
+every id is treated as unvalidated — required drops to empty (→ not_matched for a
+required-type trial) and any excluded constraint is conservatively rejected. Never a
+silent fallback to the unvalidated raw ids.
+"""
+import contextvars
+import logging
+
+from vocab_mirror.release_context import active_pinned_release
+from vocab_mirror.validate import validate_concept_ids
+
+logger = logging.getLogger(__name__)
+
+# Request-scoped memo (see module docstring). None outside a request → no caching.
+_request_memo: contextvars.ContextVar = contextvars.ContextVar(
+    'type_validation_request_memo', default=None)
+
+
+def _normalized(type_ids):
+    """Stable, hashable key for a patient class-id set (order-independent)."""
+    return tuple(sorted((str(x).strip() for x in type_ids), key=str))
+
+
+def resolve_type_validation(type_ids):
+    """Validate the patient's raw class ``type_ids`` at the pinned release.
+
+    Returns ``(validated, has_unvalidated)`` where ``validated`` is the set (of
+    ``str``) of ids present + valid in the mirror, and ``has_unvalidated`` is True
+    when ANY input id is absent/invalid — including the no-release fail-closed case.
+
+    ``type_ids`` None/``[]`` → ``(set(), False)``: nothing to validate here; the
+    existing #285 unknown/empty fail-closed handles those patient sets upstream.
+    """
+    if not type_ids:
+        return set(), False
+    key = _normalized(type_ids)
+    release_id = active_pinned_release()
+    memo = _request_memo.get()
+    if memo is None:
+        validated = _validate(key, release_id)
+    else:
+        cache_key = (release_id, key)
+        if cache_key not in memo:
+            memo[cache_key] = _validate(key, release_id)
+        validated = memo[cache_key]
+    has_unvalidated = any(cid not in validated for cid in key)
+    return validated, has_unvalidated
+
+
+def _validate(normalized_ids, release_id):
+    """One mirror query → the set of validated ids (as ``str``).
+
+    No release (``release_id is None``) → fail closed: the empty set, so every id
+    counts as unvalidated. Never falls back to the raw ids.
+    """
+    if release_id is None:
+        # Fail closed, but loudly: with OMOP-types on and no active mirror release,
+        # EVERY required-type trial drops to not_matched and every excluded-type
+        # trial is conservatively rejected — a large, otherwise-invisible drop in a
+        # clinical matcher. Memoized upstream, so this fires ~once per request.
+        logger.warning(
+            'OMOP-types release validation requested with no active vocab-mirror '
+            'release; failing closed — all patient class ids treated as unvalidated '
+            '(required types dropped, excluded-type trials rejected).')
+        return set()
+    return {str(c) for c in validate_concept_ids(normalized_ids, release_id)}
+
+
+class type_validation_request_cache:
+    """Enable the request-scoped type-validation memo for a ``with`` block.
+
+    Enter once per request (the trials view does, alongside
+    ``component_lookup_request_cache``) so the per-trial matcher dedups the
+    patient's class-id validation to one mirror query; the memo resets on exit, so
+    nothing persists across requests/workers or straddles a mirror rebuild.
+    """
+
+    def __enter__(self):
+        self._token = _request_memo.set({})
+        return self
+
+    def __exit__(self, *exc):
+        _request_memo.reset(self._token)
+        return False

--- a/vocab_mirror/validate.py
+++ b/vocab_mirror/validate.py
@@ -1,0 +1,40 @@
+"""Release-consistency validator for OMOP concept_ids (#286).
+
+Narrow read-port over the mirror so the therapy matcher can check that the
+concept_ids a patient carries are PRESENT and VALID in the pinned vocab release,
+without spreading `MirrorConcept` ORM access through therapy-graph code.
+
+Per the #286 design (per-concept staleness, not per-release equality): only the
+stability of the SPECIFIC concept_ids a patient carries matters for concept_id
+overlap. A concept that is absent or invalidated (`invalid_reason` set) in the
+active release is stale for that patient.
+
+The caller MUST resolve and pass the pinned release_id (typically
+`release_context.active_pinned_release()` — the per-request pin, NOT a live read).
+Passing `release_id=None` raises `ConceptGraphUnavailable` so the caller fails
+closed — never a silent fallback to the live active release (which could straddle
+an activation mid-request, or run unpinned for non-HTTP callers).
+"""
+from vocab_mirror.models import MirrorConcept
+from vocab_mirror.traversal import ConceptGraphUnavailable, _positive_ints, _DB
+
+
+def validate_concept_ids(concept_ids, release_id):
+    """Return the set (of ints) of ``concept_ids`` that are present and valid
+    (``invalid_reason IS NULL``) in the mirror at ``release_id``.
+
+    ``release_id`` is required — ``None`` raises ``ConceptGraphUnavailable`` so the
+    caller fails closed. Non-digit / non-positive inputs are ignored. An empty or
+    all-invalid input returns an empty set.
+    """
+    if release_id is None:
+        raise ConceptGraphUnavailable(
+            'no active vocab mirror release; refusing to validate concept ids')
+    ids = _positive_ints(concept_ids)
+    if not ids:
+        return set()
+    return set(
+        MirrorConcept.objects.using(_DB)
+        .filter(release_id=release_id, concept_id__in=ids, invalid_reason__isnull=True)
+        .values_list('concept_id', flat=True)
+    )


### PR DESCRIPTION
Closes the #286 release-consistency slices for OMOP drug-class **type** matching. Ships **DISABLED** (`EXACT_OMOP_THERAPY_TYPES` stays OFF).

## What
Two commits:
1. **`validate_concept_ids` read-port** (`vocab_mirror/validate.py`) — present + `invalid_reason IS NULL` at a pinned release; `release_id` required → fail-closed, no live fallback. (step 1)
2. **Gate 2 — asymmetric per-concept validation** wired into the matcher verdict, the queryset prefilter, **and** the detail criterion breakdown, via a new `type_release_gate` (release from `active_pinned_release()`, per-request memo mirroring `component_lookup_request_cache`, wired in the trials view).

## The asymmetry (the safety core)
- **required**: a stale/absent/invalidated class id is **dropped** → fail-closed for that id (a required-type trial whose only patient match was stale → `not_matched`).
- **excluded**: an unvalidated id is **never dropped** (dropping re-opens the exclusion = fail-OPEN) → a trial excluding types is `not_matched` when the patient carries any unvalidated id.
- **no active release** → fail-closed (all ids unvalidated) with a `WARNING` (otherwise-invisible mass drop).
- `derive_component_and_type_values` is **untouched** — it must keep returning the RAW class ids so the excluded side can see the unvalidated ones.

## Two gates — this PR is Gate 2 only
- **Gate 2 (here)**: per-concept validity of the patient's OWN class ids in the mirror. Needs only the mirror EXACT already has.
- **Gate 1 (NOT here)**: the mirror↔trial materialization invariant (strict release equality vs the release the trial `omop_therapy_types_*` columns were built against) — depends on CancerBot per-trial `release_id`+`digest` (cancerbot#4646). Enforced separately before the flag flips.

## Review
- **codex review** (`--base 2omop`): found a display/verdict divergence **[P2]** (detail status built on raw ids could show a stale required type as matched) — **fixed** (display now validates + renders the conservative excluded).
- **Fresh cold Claude review** (separate subagent): **no Critical/High**; fail-open, queryset↔matcher parity, and the per-request memo all verified. Low/observability findings addressed (L1 warning log; L4 added queryset no-release + memo-dedup tests). L2 (single-stale-id blast radius) is the intended conservative choice — noted for the #286 design.

## Tests
Full suite **1098 passed, 5 skipped**. New: stale-required-dropped, invalidated-dropped, partial-stale-valid-matches, excluded-unvalidated-conservative, no-release-fail-closed (matcher + queryset), queryset/matcher parity, memo-dedup, 2× display-parity; active-mirror fixture seeded in the #285 suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)