### PR TITLE
feat(omop): stream vocab-mirror snapshots into COPY, not ORM bulk_create (#256)

### DIFF
--- a/tests/vocab_mirror/test_sync.py
+++ b/tests/vocab_mirror/test_sync.py
@@ -224,3 +224,36 @@ class TestSingletonLock:
             outcome = sync_vocab_mirror(client=FakeVocabClient())
         assert outcome.status == 'locked'
         assert not MirrorRelease.objects.exists()  # never touched the release table
+
+
+class TestCopyLoad:
+    """COPY-load correctness (#256): escaping + NULL-vs-empty distinction."""
+
+    def test_copy_escapes_special_chars_and_null_vs_empty(self):
+        tricky = [{
+            'concept_id': 200,
+            'concept_name': 'a\tb\nc\\d',       # tab, newline, backslash must survive
+            'domain_id': 'Drug',
+            'vocabulary_id': 'RxNorm',
+            'concept_class_id': '',             # empty string must NOT become NULL
+            'standard_concept': None,           # NULL must stay NULL
+            'concept_code': '2',
+            'valid_start_date': '1970-01-01',   # ISO date -> DateField
+            'valid_end_date': None,             # NULL date
+            'invalid_reason': None,
+            'source': None,
+        }]
+        snapshots = dict(_SNAPSHOTS, concept=tricky)
+        row_counts = {t: len(r) for t, r in snapshots.items()}
+        client = FakeVocabClient(manifest=_manifest(row_counts=row_counts),
+                                 snapshots=snapshots)
+
+        outcome = sync_vocab_mirror(client=client)
+
+        assert outcome.status == 'synced'
+        c = MirrorConcept.objects.get(concept_id=200)
+        assert c.concept_name == 'a\tb\nc\\d'   # special chars round-tripped
+        assert c.concept_class_id == ''          # empty string, not NULL
+        assert c.standard_concept is None        # NULL preserved
+        assert c.valid_start_date == date(1970, 1, 1)
+        assert c.valid_end_date is None          # NULL date preserved

--- a/vocab_mirror/models.py
+++ b/vocab_mirror/models.py
@@ -54,8 +54,10 @@ class MirrorRelease(models.Model):
     promop release manifest (promop#334); the loader (#250) fills them and moves
     STAGING → READY. Completeness is enforced at load by the ``__done`` sentinel
     + ``row_counts`` cross-check; the ``checksums`` are recorded for provenance —
-    byte-integrity verification against them is a tracked follow-up (#256), not
-    yet enforced.
+    byte-integrity verification against them is blocked cross-repo (promop's
+    ``checksums`` are ``{count, min_ctid, max_ctid}``, and ctids are meaningless to
+    a consumer, so real verification needs promop to emit a content hash; see the
+    ``sync`` module docstring), not yet enforced.
     """
 
     STAGING = 'staging'

--- a/vocab_mirror/sync.py
+++ b/vocab_mirror/sync.py
@@ -219,6 +219,8 @@ def _load_table(client, release_id, table, expected_count):
     conn = connections[_DB]
     conn.ensure_connection()
     try:
+        # copy_expert is psycopg2-specific (the pinned driver); a psycopg3 move
+        # would use `cursor.copy(...)` instead.
         with conn.connection.cursor() as cur:
             cur.copy_expert(sql, _CopyStream(_lines()))
     except Exception as exc:

--- a/vocab_mirror/sync.py
+++ b/vocab_mirror/sync.py
@@ -20,16 +20,20 @@ Flow (one run of :func:`sync_vocab_mirror`):
    via the #249 control plane.
 
 Enforced completeness is the ``__done`` sentinel count plus the manifest
-``row_counts`` cross-check. Two follow-ups (recorded, not blocking):
-- **Checksum verification** of the manifest ``checksums`` — needs promop's exact
-  per-table row canonicalization pinned before it can enforce without false
-  mismatches; until then the sentinel + row-count gate rejects truncated/partial
-  loads and the checksums are recorded for provenance only.
-- **COPY for the large tables** — ``concept_relationship`` (~18M rows) currently
-  loads via batched ``bulk_create`` into a table with live indexes; a
-  ``psycopg.copy`` path (optionally dropping/rebuilding indexes per generation)
-  will be much faster.
+``row_counts`` cross-check. Each table streams into ``COPY … FROM STDIN`` (#256),
+so ``concept_relationship`` (~18M rows in prod RxNorm) loads without materializing
+millions of ORM objects. Indexes stay live during the load — dropping the shared
+release_id-leading indexes would degrade the concurrently-ACTIVE generation's reads.
+
+Remaining follow-up (blocked, not a blocker): **byte-level checksum verification**
+of the manifest ``checksums``. It would catch *silent corruption* (same count,
+altered bytes) beyond the sentinel + row-count gate, but promop's ``checksums`` are
+currently ``{count, min_ctid, max_ctid}`` — physical ctids are meaningless to a
+consumer (EXACT's copy has different ctids), so only ``count`` is verifiable (and
+already is). Real verification needs promop to emit a content hash over a pinned
+per-table row canonicalization; tracked cross-repo.
 """
+import io
 import logging
 from dataclasses import dataclass, field
 from datetime import date
@@ -52,7 +56,6 @@ logger = logging.getLogger(__name__)
 _DB = 'default'  # the mirror lives on `default` (db_router / ADR §Placement)
 # Fixed 64-bit key for the sync singleton advisory lock.
 _SYNC_ADVISORY_LOCK_KEY = 8234502250
-_BATCH_SIZE = 5000
 
 # promop#334 table slug -> mirror model. EXACT syncs exactly the tables it needs.
 TABLE_MODELS = {
@@ -76,28 +79,62 @@ class SyncOutcome:
     counts: dict = field(default_factory=dict)
 
 
-def _row_projector(model):
-    """Build a fast row → model-kwargs projector for a mirror model.
-
-    Keeps only the model's own columns (promop may send extra columns; unknown
-    keys are dropped) and coerces ISO date strings to ``date`` for DateFields.
+def _copy_columns(model):
+    """COPY target columns (``release_id`` first, then the model's own columns
+    minus the surrogate ``id``) plus a ``(row_key, is_date)`` list for projecting
+    each snapshot row's values in that same order. ``field.name == field.column``
+    for the mirror models (no ``db_column`` overrides), and the snapshot keys are
+    the OMOP column names = the field names, so one name serves both.
     """
+    columns = ['release_id']
     fields = []
     for f in model._meta.concrete_fields:
         if f.name in ('id', 'release_id'):
             continue
+        columns.append(f.column)
         fields.append((f.name, f.get_internal_type() == 'DateField'))
+    return columns, fields
 
-    def project(row):
-        out = {}
-        for name, is_date in fields:
-            v = row.get(name)
-            if is_date:
-                v = date.fromisoformat(v) if isinstance(v, str) and v else None
-            out[name] = v
-        return out
 
-    return project
+def _copy_escape(v):
+    """Escape one value for the COPY TEXT format.
+
+    TEXT (not CSV) so ``None`` → ``\\N`` (SQL NULL) stays distinct from an empty
+    string → empty field; backslash / tab / newline / CR are escaped.
+    """
+    if v is None:
+        return r'\N'
+    if v is True:
+        return 't'
+    if v is False:
+        return 'f'
+    s = v if isinstance(v, str) else str(v)
+    return (s.replace('\\', '\\\\').replace('\t', '\\t')
+            .replace('\n', '\\n').replace('\r', '\\r'))
+
+
+class _CopyStream(io.RawIOBase):
+    """Readable stream that pulls encoded COPY lines from a row iterator on demand,
+    so an ~18M-row snapshot streams into ``COPY … FROM STDIN`` without ever
+    materializing in memory (#256)."""
+
+    def __init__(self, line_iter):
+        self._iter = line_iter
+        self._buf = b''
+
+    def readable(self):
+        return True
+
+    def readinto(self, b):
+        while not self._buf:
+            try:
+                self._buf = next(self._iter)
+            except StopIteration:
+                return 0
+        n = min(len(b), len(self._buf))
+        b[:n] = self._buf[:n]
+        self._buf = self._buf[n:]
+        return n
 
 
 def _last_processed_etag():
@@ -143,43 +180,65 @@ def _prepare_cross_artifacts(release_id):
 
 
 def _load_table(client, release_id, table, expected_count):
-    """Stream + bulk-load one table into the (fresh) staging generation.
+    """Stream one table's snapshot into the (fresh) staging generation via
+    ``COPY … FROM STDIN`` (#256).
 
-    Returns the loaded row count. Raises ``VocabSyncError`` on a truncated
+    COPY replaces per-batch ORM ``bulk_create`` — for ``concept_relationship``
+    (~18M rows in prod RxNorm) it avoids materializing millions of model objects
+    and streams straight into Postgres, a large speedup on the periodic sync.
+    Indexes are deliberately kept live (dropping the shared release_id-leading
+    indexes around a load would degrade the concurrently-ACTIVE generation's
+    reads). Returns the loaded row count; raises ``VocabSyncError`` on a truncated
     stream (no sentinel) or a count that disagrees with the sentinel / manifest.
     """
     model = TABLE_MODELS[table]
-    project = _row_projector(model)
+    columns, fields = _copy_columns(model)
     model.objects.using(_DB).filter(release_id=release_id).delete()  # idempotent restage
 
-    count = 0
-    batch = []
-    sentinel = None
+    state = {'count': 0, 'sentinel': None, 'saw_done': False}
     gen = client.stream_snapshot(release_id, table)
-    try:
+    rid = _copy_escape(release_id)
+
+    def _lines():
         for row in gen:
             if row.get('__done'):
-                sentinel = row.get('rows')
-                break
-            batch.append(model(release_id=release_id, **project(row)))
-            if len(batch) >= _BATCH_SIZE:
-                model.objects.using(_DB).bulk_create(batch)
-                count += len(batch)
-                batch = []
-        else:
-            # Stream ended without the sentinel line -> truncated download.
-            raise VocabSyncError(f'{table}: stream ended without a __done sentinel (truncated)')
+                state['sentinel'] = row.get('rows')
+                state['saw_done'] = True
+                return  # stop before the sentinel; COPY sees EOF here
+            parts = [rid]
+            for name, is_date in fields:
+                v = row.get(name)
+                if is_date:
+                    v = date.fromisoformat(v) if isinstance(v, str) and v else None
+                parts.append(_copy_escape(v))
+            state['count'] += 1
+            yield ('\t'.join(parts) + '\n').encode('utf-8')
+
+    col_sql = ', '.join(f'"{c}"' for c in columns)
+    sql = f'COPY "{model._meta.db_table}" ({col_sql}) FROM STDIN'
+    conn = connections[_DB]
+    conn.ensure_connection()
+    try:
+        with conn.connection.cursor() as cur:
+            cur.copy_expert(sql, _CopyStream(_lines()))
+    except Exception as exc:
+        # A COPY parse/DB error (malformed row, constraint) — surface as the sync's
+        # own error type so _do_sync fails the release closed (rolls back its rows).
+        if isinstance(exc, VocabSyncError):
+            raise
+        raise VocabSyncError(f'{table}: COPY failed: {exc}') from exc
     finally:
         # Close the generator (and its underlying streamed response) even when we
-        # break early at the sentinel or raise mid-stream.
+        # stop early at the sentinel or raise mid-stream.
         close = getattr(gen, 'close', None)
         if close is not None:
             close()
 
-    if batch:
-        model.objects.using(_DB).bulk_create(batch)
-        count += len(batch)
+    if not state['saw_done']:
+        # Stream ended without the sentinel line -> truncated download.
+        raise VocabSyncError(f'{table}: stream ended without a __done sentinel (truncated)')
 
+    sentinel, count = state['sentinel'], state['count']
     # The sentinel is the always-present per-#334 completeness signal; require an
     # integer count (a `{"__done": true}` with no `rows` is malformed, not a pass).
     if not isinstance(sentinel, int) or isinstance(sentinel, bool):


### PR DESCRIPTION
Closes #256 (the COPY half; checksum half stays blocked cross-repo — see below). Part of epic #246. Prioritized as the top remaining pre-cutover item (confirmed by codex): prod-scale relationship ingestion was the clearest un-benchmarked risk.

## Problem
The sync loaded each table via batched ORM `bulk_create`. For `concept_relationship` (~18M rows in prod RxNorm) that materializes millions of model objects; the e2e only used 290k rows, so prod-scale load speed/memory was **unproven**.

## Fix
Stream each snapshot straight into `COPY … FROM STDIN`:
- `_CopyStream` (a `RawIOBase`) pulls encoded COPY lines from the row generator on demand — the load never materializes the table in memory.
- **TEXT format** (not CSV) so `None` → `\N` (SQL NULL) stays distinct from an empty string → empty field; backslash / tab / newline / CR escaped.
- Indexes stay **live** — dropping the shared release_id-leading indexes would degrade the concurrently-ACTIVE generation's reads.
- All completeness checks unchanged (`__done` sentinel, count vs sentinel vs manifest `row_counts`); a COPY parse/DB error surfaces as `VocabSyncError` so the sync fails the release closed and rolls back its rows.

## Benchmark (1M `concept_relationship` rows, local Postgres)
| loader | time | throughput |
|---|---|---|
| `bulk_create` | 19.03s | 53k rows/s |
| **COPY** | **4.77s** | **210k rows/s** |

**4.0× faster** — extrapolating to ~86s vs ~343s at 18M rows, plus no object materialization.

## Review (two-part, pre-push)
- **codex**: no actionable regressions.
- **fresh-context subagent**: correct, mergeable, no blocking issues — traced escaping completeness (incl. the `\N`-collision), sentinel/count/truncation parity, raw-connection/autocommit safety + fail-closed recovery, no leak, all 4 tables' field types round-trip. Applied its two P8 notes (stale `(#256)` checksum ref in models.py → re-scoped; psycopg2-only comment). Its optional COPY-error unit test was skipped (a real COPY error aborts a pytest transaction, diverging from prod autocommit — a fragile test).

## Checksum half — blocked cross-repo
promop's manifest `checksums` are `{count, min_ctid, max_ctid}`; ctids are meaningless to a consumer (EXACT's copy has different ctids), so only `count` is verifiable (and already is). Real byte-level verification needs promop to emit a **content hash** over a pinned per-table canonicalization — filed as a promop issue.

## Verification
New escaping test (tab/newline/backslash round-trip, empty-string stays `''` not NULL, NULL + NULL-date preserved). #256 tests: 15 pass.

⚠️ **Env note:** a full-suite run currently shows 9 failures in `tests/services/test_omop_therapy_types_matching.py` — these are **pre-existing environment contamination** (an editable `exact_matching` install in the test venv points at a separate `healthkey/exact` checkout that a parallel session advanced to `#294`, shadowing `trials`). They fail identically on clean 2omop **without** this change. Excluding that one file, the suite is **1106 passed, 5 skipped**; `makemigrations --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)