### PR TITLE
fix(mcl): MIPI high cutoff 6.5 → 6.2 (catch up to CB #4478)

### DIFF
--- a/frontend/src/federation/tooltips.ts
+++ b/frontend/src/federation/tooltips.ts
@@ -309,8 +309,8 @@ Reference: Hoster et al., Blood 2008.`,
   "mipiRisk": `The MIPI (Mantle Cell Lymphoma International Prognostic Index) risk category, computed from age, ECOG performance status, LDH level, and WBC count.
 
 Low risk: MIPI score < 5.7
-Intermediate risk: 5.7 ≤ MIPI < 6.5
-High risk: MIPI ≥ 6.5
+Intermediate risk: 5.7 ≤ MIPI < 6.2
+High risk: MIPI ≥ 6.2
 
 Reference: Hoster et al., Blood 2008.`,
   "molecularMarkers": `t(11;14):

--- a/tests/services/patient_info/test_mcl_derivations.py
+++ b/tests/services/patient_info/test_mcl_derivations.py
@@ -29,7 +29,8 @@ def _mcl_patient(**kwargs):
 
 
 class TestMipiRiskBuckets:
-    """Hoster 2008 MIPI cutoffs: low < 5.7, intermediate < 6.5, high >= 6.5."""
+    """Hoster 2008 MIPI cutoffs: low < 5.7, intermediate 5.7-<6.2, high >= 6.2
+    (high cutoff is 6.2, not 6.5 — CB migration 0370, SME-confirmed #4478)."""
 
     def test_low_for_healthy_inputs(self):
         # WBC as cells/µL (Hoster 2008). score ≈ 4.41 — below 5.7
@@ -39,14 +40,14 @@ class TestMipiRiskBuckets:
         assert PatientInfoAttributes(pi).mipi_risk == 'low'
 
     def test_intermediate_for_moderate_disease(self):
-        # score ≈ 5.91 — in [5.7, 6.5)
+        # score ≈ 5.91 — in [5.7, 6.2)
         pi = _mcl_patient(patient_age=65, ecog_performance_status=0,
                           white_blood_cell_count=7000, white_blood_cell_count_units='CELLS/UL',
                           lactate_dehydrogenase_level=250)
         assert PatientInfoAttributes(pi).mipi_risk == 'intermediate'
 
     def test_high_for_aggressive_disease(self):
-        # score well above 6.5
+        # score well above 6.2
         pi = _mcl_patient(patient_age=75, ecog_performance_status=3,
                           white_blood_cell_count=100000, white_blood_cell_count_units='CELLS/UL',
                           lactate_dehydrogenase_level=3000)
@@ -60,6 +61,15 @@ class TestMipiRiskBuckets:
                           white_blood_cell_count=7000, white_blood_cell_count_units='CELLS/UL',
                           lactate_dehydrogenase_level=250)
         assert PatientInfoAttributes(pi).mipi_risk == 'intermediate'
+
+    def test_high_cutoff_is_6_2_not_6_5(self):
+        # Regression for the CB catch-up (#4478): the high band starts at 6.2, not
+        # 6.5. age 73 + wbc 10000/uL (ldh at ULN) -> score ~= 6.34, which is in the
+        # [6.2, 6.5) band that flips from 'intermediate' (old) to 'high' (now).
+        pi = _mcl_patient(patient_age=73, ecog_performance_status=0,
+                          white_blood_cell_count=10000, white_blood_cell_count_units='CELLS/UL',
+                          lactate_dehydrogenase_level=250)
+        assert PatientInfoAttributes(pi).mipi_risk == 'high'
 
     def test_ecog_zero_does_not_add_penalty(self):
         # ECOG 0 and 1 both contribute 0 (predicate is ecog >= 2)

--- a/trials/services/patient_info/patient_info_attributes.py
+++ b/trials/services/patient_info/patient_info_attributes.py
@@ -716,7 +716,10 @@ class PatientInfoAttributes:
 
         if score < 5.7:
             return 'low'
-        elif score < 6.5:
+        # High cutoff is >= 6.2 per Hoster et al. 2008 (low <5.7 / intermediate
+        # 5.7-<6.2 / high >=6.2), matching the vocab label "High MIPI Score >=6.2"
+        # (CB migration 0370, SME-confirmed #4478).
+        elif score < 6.2:
             return 'intermediate'
         return 'high'
 


### PR DESCRIPTION
## MIPI high-risk cutoff: 6.5 → 6.2

EXACT was extracted from CB, then CB corrected the MIPI high-risk cutoff. This ports it so EXACT's live matcher matches CB (follows the #187/#189 MCL catch-up pattern).

High band starts at **6.2**, not 6.5: low `<5.7` / intermediate `5.7-<6.2` / high `≥6.2`, per Hoster 2008 and the vocab label "High MIPI Score ≥6.2" (CB migration 0370, SME-confirmed #4478). Pure threshold, no data-contract dependency.

- **backend**: `mipi_risk` cutoff `6.5` → `6.2`.
- **frontend**: the `mipiRisk` tooltip documented the old 6.5 band (already inconsistent with the `highRiskMclCriteria` tooltip's ≥6.2 and the vocab label) — aligned to 6.2.

## Test
Regression test `test_high_cutoff_is_6_2_not_6_5`: a score in [6.2, 6.5) now returns `high` (was `intermediate`). Existing bucket tests still pass (their scores don't fall in that band). `test_mcl_derivations.py` green (53).

## Scoped to the cutoff only
Two other CB MIPI divergences were **deliberately excluded** (surfaced in review):
- **WBC blank-unit fallback** stays `CELLS/L` — EXACT declares CELLS/L as its WBC unit default (data is per-L); CB's canonical per-µL default (#4559) is a host data-contract difference that converges when CB's data drains, not by hardcoding a unit in shared code.
- **per-lab LDH ULN** needs a `lactate_dehydrogenase_level_uln` field EXACT's `PatientInfo` lacks (unreachable via real input paths, `_build_in_memory` drops unknown keys) — a follow-up (schema add, or CB-side at drain).

Then back-merged into `2omop` (with the same hunk re-applied to the extracted `matcher_app/` package, since the E1 git-mv means dev↔2omop don't auto-carry).

## Review
codex clean (caught 3 issues across rounds: WBC data-contract P1, LDH unreachable P2, stale tooltip P2 — all addressed); fresh-context Claude SHIP (verified band ordering, regression score in [6.2,6.5), no other stale 6.5 refs, 53 tests pass).

_Note: pre-existing failures in `tests/querysets/test_mcl_filter_by_patient_info.py` on dev (queryset seed) are unrelated to this change._

🤖 Generated with [Claude Code](https://claude.com/claude-code)