### PR TITLE
fix(mcl): MIPI high cutoff 6.5 → 6.2 on 2omop (matcher_app) — QR4b

### DIFF
--- a/frontend/src/federation/tooltips.ts
+++ b/frontend/src/federation/tooltips.ts
@@ -309,8 +309,8 @@ Reference: Hoster et al., Blood 2008.`,
   "mipiRisk": `The MIPI (Mantle Cell Lymphoma International Prognostic Index) risk category, computed from age, ECOG performance status, LDH level, and WBC count.
 
 Low risk: MIPI score < 5.7
-Intermediate risk: 5.7 ≤ MIPI < 6.5
-High risk: MIPI ≥ 6.5
+Intermediate risk: 5.7 ≤ MIPI < 6.2
+High risk: MIPI ≥ 6.2
 
 Reference: Hoster et al., Blood 2008.`,
   "molecularMarkers": `t(11;14):

--- a/matcher_app/exact_matching/patient_info/patient_info_attributes.py
+++ b/matcher_app/exact_matching/patient_info/patient_info_attributes.py
@@ -746,7 +746,10 @@ class PatientInfoAttributes:
 
         if score < 5.7:
             return 'low'
-        elif score < 6.5:
+        # High cutoff is >= 6.2 per Hoster et al. 2008 (low <5.7 / intermediate
+        # 5.7-<6.2 / high >=6.2), matching the vocab label "High MIPI Score >=6.2"
+        # (CB migration 0370, SME-confirmed #4478).
+        elif score < 6.2:
             return 'intermediate'
         return 'high'
 

--- a/tests/services/patient_info/test_mcl_derivations.py
+++ b/tests/services/patient_info/test_mcl_derivations.py
@@ -29,7 +29,8 @@ def _mcl_patient(**kwargs):
 
 
 class TestMipiRiskBuckets:
-    """Hoster 2008 MIPI cutoffs: low < 5.7, intermediate < 6.5, high >= 6.5."""
+    """Hoster 2008 MIPI cutoffs: low < 5.7, intermediate 5.7-<6.2, high >= 6.2
+    (high cutoff is 6.2, not 6.5 — CB migration 0370, SME-confirmed #4478)."""
 
     def test_low_for_healthy_inputs(self):
         # WBC as cells/µL (Hoster 2008). score ≈ 4.41 — below 5.7
@@ -39,17 +40,26 @@ class TestMipiRiskBuckets:
         assert PatientInfoAttributes(pi).mipi_risk == 'low'
 
     def test_intermediate_for_moderate_disease(self):
-        # score ≈ 5.91 — in [5.7, 6.5)
+        # score ≈ 5.91 — in [5.7, 6.2)
         pi = _mcl_patient(patient_age=65, ecog_performance_status=0,
                           white_blood_cell_count=7000, white_blood_cell_count_units='CELLS/UL',
                           lactate_dehydrogenase_level=250)
         assert PatientInfoAttributes(pi).mipi_risk == 'intermediate'
 
     def test_high_for_aggressive_disease(self):
-        # score well above 6.5
+        # score well above 6.2
         pi = _mcl_patient(patient_age=75, ecog_performance_status=3,
                           white_blood_cell_count=100000, white_blood_cell_count_units='CELLS/UL',
                           lactate_dehydrogenase_level=3000)
+        assert PatientInfoAttributes(pi).mipi_risk == 'high'
+
+    def test_high_cutoff_is_6_2_not_6_5(self):
+        # Regression for the CB catch-up (#4478): the high band starts at 6.2, not
+        # 6.5. age 73 + wbc 10000/uL (ldh at ULN) -> score ~= 6.34, which is in the
+        # [6.2, 6.5) band that flips from 'intermediate' (old) to 'high' (now).
+        pi = _mcl_patient(patient_age=73, ecog_performance_status=0,
+                          white_blood_cell_count=10000, white_blood_cell_count_units='CELLS/UL',
+                          lactate_dehydrogenase_level=250)
         assert PatientInfoAttributes(pi).mipi_risk == 'high'
 
     def test_wbc_uses_per_microliter_magnitude_4421(self):


### PR DESCRIPTION
## MIPI high cutoff 6.5 → 6.2 — 2omop / matcher_app (QR4b)

The 2omop counterpart of dev **#296**. Applies CB #4478's MIPI high-risk cutoff to the **extracted package** (`matcher_app/exact_matching/patient_info/patient_info_attributes.py`), so CB's `mipi_risk` drain later lands on the corrected cutoff.

Bands: low `<5.7` / intermediate `5.7-<6.2` / high `≥6.2`, per Hoster 2008 + vocab "High MIPI Score ≥6.2" (CB migration 0370, SME #4478).

- `matcher_app` `mipi_risk` cutoff `6.5` → `6.2`.
- frontend `mipiRisk` tooltip aligned to 6.2.
- regression test (score in [6.2, 6.5) → `high`) + docstring/comment fixes.

### Why a separate PR (not a dev→2omop back-merge)
The E1 `git mv` means the old `trials/services` path is a shim on 2omop, so a back-merge would NOT auto-carry the fix into `matcher_app/` — **and** the full dev→2omop merge drags in an unrelated **9-hunk ADR conflict** (`docs/adr/0001`). So the cutoff is re-applied surgically here; the full dev↔2omop sync is a separate, dedicated task.

### Review
codex clean; fresh-context Claude SHIP (verified band ordering, regression score 6.338 ∈ [6.2,6.5), no other stale 6.5 refs, only 3 files). Identical logic to #296 (already merged to dev after a 3-round codex + fresh-Claude review); mipi_risk was validated 53-green in the EX312-linked clone before being re-landed here via an isolated worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)