### PR TITLE
feat(omop-types): #286 shadow metric — patient class-id release staleness

### DIFF
--- a/matcher_app/exact_matching/querysets/trial.py
+++ b/matcher_app/exact_matching/querysets/trial.py
@@ -1204,7 +1204,9 @@ class TrialQuerySet(models.QuerySet):
         if not type_values:                                  # None (unknown) or [] (known-empty)
             return self.filter(**{f'{req}__exact': []})
         from trials.services.omop.type_release_gate import resolve_type_validation
-        validated, has_unvalidated = resolve_type_validation(type_values)
+        # measure=True: the queryset is the once-per-search call, so the #286 shadow
+        # staleness metric is recorded here, not per-trial in the matcher.
+        validated, has_unvalidated = resolve_type_validation(type_values, measure=True)
         values = sorted(validated)
         # required: overlap validated ids, or trials that require no types. All ids
         # stale (validated empty) → keep only no-required-type trials (fail-closed).

--- a/tests/services/test_omop_therapy_types_matching.py
+++ b/tests/services/test_omop_therapy_types_matching.py
@@ -44,6 +44,15 @@ def _mirror_concept(concept_id, invalid_reason=None):
 
 
 @pytest.fixture(autouse=True)
+def _reset_type_metrics():
+    """Zero the process-local #286 shadow counters before each test, so a metric
+    assertion can never inherit accumulated state from an earlier measure=True
+    queryset test (the counters are process-global)."""
+    from trials.services.omop import type_release_metrics as m
+    m.reset()
+
+
+@pytest.fixture(autouse=True)
 def _active_mirror(db):
     """Seed an ACTIVE vocab-mirror release with the test class ids present + valid,
     so #286 per-concept validation admits them (an absent/invalidated id is stale).
@@ -361,6 +370,40 @@ def test_queryset_no_active_release_fails_closed():
         .eligible_for_omop_therapy_types([PI_CLASS]).values_list('id', flat=True)
     )
     assert qs == {open_.id}
+
+
+@override_settings(**OMOP_TYPES)
+def test_shadow_metric_records_stale_ids_once_per_search():
+    # The queryset records the #286 shadow signal ONCE per search — not per trial —
+    # so a multi-trial candidate set still records a single stale-search event.
+    from trials.services.omop import type_release_metrics as m
+    a = TrialFactory(disease='multiple myeloma', omop_therapy_types_required=[PI_CLASS])
+    b = TrialFactory(disease='multiple myeloma', omop_therapy_types_required=[IMID_CLASS])
+    Trial.objects.filter(id__in=[a.id, b.id]).eligible_for_omop_therapy_types([PI_CLASS, STALE_CLASS])
+    assert m.stale_search_count() == 1         # once per search, not once per trial
+    assert m.dropped_ids_total() == 1          # STALE_CLASS dropped; PI_CLASS valid
+
+
+@override_settings(**OMOP_TYPES)
+def test_shadow_metric_quiet_when_all_valid():
+    from trials.services.omop import type_release_metrics as m
+    m.reset()
+    needs = TrialFactory(disease='multiple myeloma', omop_therapy_types_required=[PI_CLASS])
+    Trial.objects.filter(id=needs.id).eligible_for_omop_therapy_types([PI_CLASS])
+    assert m.stale_search_count() == 0         # no stale id → no log/record
+    assert m.dropped_ids_total() == 0
+
+
+@override_settings(**OMOP_TYPES)
+def test_shadow_metric_not_recorded_per_trial_in_matcher():
+    # The per-trial matcher leaves measure off → no per-trial flooding.
+    from trials.services.omop import type_release_metrics as m
+    m.reset()
+    pi = PatientInfo(disease='multiple myeloma', therapy_component_ids=[int(BORT_CID)],
+                     therapy_type_ids=[int(PI_CLASS), int(STALE_CLASS)])
+    trial = TrialFactory(disease='multiple myeloma', omop_therapy_types_required=[PI_CLASS])
+    _match(trial, pi)
+    assert m.stale_search_count() == 0
 
 
 @override_settings(**OMOP_TYPES)

--- a/trials/services/omop/type_release_gate.py
+++ b/trials/services/omop/type_release_gate.py
@@ -46,7 +46,7 @@ def _normalized(type_ids):
     return tuple(sorted((str(x).strip() for x in type_ids), key=str))
 
 
-def resolve_type_validation(type_ids):
+def resolve_type_validation(type_ids, measure=False):
     """Validate the patient's raw class ``type_ids`` at the pinned release.
 
     Returns ``(validated, has_unvalidated)`` where ``validated`` is the set (of
@@ -55,6 +55,11 @@ def resolve_type_validation(type_ids):
 
     ``type_ids`` None/``[]`` → ``(set(), False)``: nothing to validate here; the
     existing #285 unknown/empty fail-closed handles those patient sets upstream.
+
+    ``measure=True`` records the #286 shadow staleness metric — once per search (the
+    queryset passes it; the per-trial matcher / detail display leave it False so the
+    signal is emitted once per search, not once per trial). Observation only: the
+    return value is identical either way.
     """
     if not type_ids:
         return set(), False
@@ -69,6 +74,12 @@ def resolve_type_validation(type_ids):
             memo[cache_key] = _validate(key, release_id)
         validated = memo[cache_key]
     has_unvalidated = any(cid not in validated for cid in key)
+    if measure:
+        from trials.services.omop.type_release_metrics import record_type_staleness
+        # Set-diff (not a per-element sum) so a duplicated wire id isn't over-counted —
+        # consistent with the set semantics used for matching.
+        dropped = len(set(key) - validated)
+        record_type_staleness(dropped, has_unvalidated)
     return validated, has_unvalidated
 
 

--- a/trials/services/omop/type_release_metrics.py
+++ b/trials/services/omop/type_release_metrics.py
@@ -1,0 +1,70 @@
+"""Gate 2 (#286) shadow observation — patient class-id release staleness.
+
+Pure observation for the OMOP-types cutover (mirrors ``phase_t_metrics``, #263):
+**no behaviour change**. Records, once per search, how often a patient arrives
+carrying drug-class concept_ids that are stale — absent or invalidated in the
+pinned vocab-mirror release — capturing the two #286 shadow signals:
+
+- **dropped-stale ids**: how many of the patient's class ids were dropped from
+  required matching (fail-closed for those ids);
+- **exclusion-block active**: whether the conservative excluded-type block is in
+  effect for the search (any unvalidated id → every excluded-type trial is
+  conservatively ``not_matched``; see ``type_release_gate`` / L2 blast-radius).
+
+Convention (there is no metrics library in this codebase — see
+``phase_t_metrics``): the durable signal is the structured, greppable **log
+event**; the process-local counters are for tests / introspection only.
+
+Granularity: recorded **once per search** — the search queryset calls the
+validator with ``measure=True``; the per-trial matcher and the detail display
+leave it off, so one stale-patient search emits one log line, not one per trial
+scored (which would flood logs precisely when the signal matters most).
+"""
+import logging
+
+logger = logging.getLogger('omop.type_release')
+
+# Process-local; tests/introspection only. The durable signal is the log event.
+_stale_search_count = 0    # searches whose patient carried >=1 stale class id
+_dropped_ids_total = 0     # total stale class ids dropped across those searches
+
+
+def record_type_staleness(dropped_count, exclusion_block_active):
+    """Record one search whose patient carried stale class ids.
+
+    ``dropped_count``: how many of the patient's class concept_ids were absent /
+    invalid in the pinned release (dropped from required matching). A value ``<= 0``
+    is a no-op — a healthy search (mirror covers every id) records nothing, so the
+    log stays quiet until staleness actually occurs.
+
+    ``exclusion_block_active``: True if the search also has the conservative
+    excluded-type block in effect (the patient carries an unvalidated id), so every
+    excluded-type trial in the search is conservatively ``not_matched``.
+    """
+    global _stale_search_count, _dropped_ids_total
+    if dropped_count <= 0:
+        return
+    _stale_search_count += 1
+    _dropped_ids_total += dropped_count
+    logger.info(
+        'type_release_staleness: patient carried %d stale class id(s) dropped from '
+        'required matching (#286 shadow); exclusion_block_active=%s',
+        dropped_count, bool(exclusion_block_active),
+    )
+
+
+def stale_search_count():
+    """Searches with >=1 stale patient class id recorded since the last reset (tests)."""
+    return _stale_search_count
+
+
+def dropped_ids_total():
+    """Total stale class ids dropped across recorded searches since reset (tests)."""
+    return _dropped_ids_total
+
+
+def reset():
+    """Reset the process-local counters (tests only)."""
+    global _stale_search_count, _dropped_ids_total
+    _stale_search_count = 0
+    _dropped_ids_total = 0


### PR DESCRIPTION
#286 near-term slice #5 (shadow metrics). Ships **DISABLED** (`EXACT_OMOP_THERAPY_TYPES` OFF); **pure observation, no behaviour change**.

## What
`trials/services/omop/type_release_metrics.py` — mirrors `phase_t_metrics` (#263): a **once-per-search** signal recording how often a patient arrives carrying drug-class concept_ids that are **stale** (absent/invalidated in the pinned vocab-mirror release). Captures the two #286 shadow signals:
- **dropped-stale-id count** — ids dropped from required matching (fail-closed for those ids);
- **exclusion-block active** — whether the conservative excluded-type block is in effect (any unvalidated id → every excluded-type trial conservatively `not_matched`; the L2 blast-radius).

## How
No metrics library in this codebase (team convention — see `phase_t_metrics`): the durable signal is a structured greppable log event (`omop.type_release`); process-local counters are tests-only. `resolve_type_validation` gains `measure=False`; only the queryset (`eligible_for_omop_therapy_types`, once per search) passes `measure=True` — the per-trial matcher and detail display leave it off, so one stale-patient search emits one log line, not one per trial scored. Quiet in the healthy case (`dropped==0` → no-op).

## Review
- **codex** (`--base 2omop`): clean — "preserves matching behavior; records only stale class-ID observations at the queryset seam."
- **Fresh cold Claude review** (separate subagent): observation-only proven (return values computed before the `measure` block, no raise path), granularity/counts/consistency correct — no Critical/High. Low findings addressed: set-diff dropped count (dedup), an autouse counter-reset fixture, and a multi-trial once-per-search test.

## Tests
Records once per stale search (multi-trial candidate set), quiet when all valid, not recorded per-trial in the matcher. Full suite **1106 passed, 5 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)