### PR TITLE
feat(omop): handle promop latest-only snapshots — 409 re-resolve + X-Vocab-Release-Id (#301)

### DIFF
--- a/tests/vocab_mirror/test_promop_vocab_client.py
+++ b/tests/vocab_mirror/test_promop_vocab_client.py
@@ -8,22 +8,28 @@ renderer). Found by the local vocab-mirror e2e.
 """
 import json
 
+import pytest
+
 from vocab_mirror import promop_vocab_client as pvc
 from vocab_mirror.promop_vocab_client import PromopVocabClient
 
 
 class _FakeStreamResp:
-    def __init__(self, lines, status_code=200):
+    def __init__(self, lines, status_code=200, headers=None):
         self._lines = lines
         self.status_code = status_code
         self.ok = 200 <= status_code < 300
-        self.reason = 'OK'
+        self.reason = 'OK' if self.ok else 'Conflict'
+        self.headers = headers or {}
 
     def __enter__(self):
         return self
 
     def __exit__(self, *exc):
         return False
+
+    def close(self):
+        pass
 
     def iter_lines(self, decode_unicode=False):
         yield from self._lines
@@ -60,3 +66,35 @@ def test_stream_snapshot_accept_offers_ndjson_and_wildcard(monkeypatch):
     assert accept.startswith('application/x-ndjson')
     assert '*/*' in accept
     assert captured['headers']['Authorization'] == 'Bearer t'
+
+
+def _run(monkeypatch, resp):
+    monkeypatch.setattr(pvc.requests, 'get', lambda *a, **k: resp)
+    return list(_client().stream_snapshot(2, 'concept'))
+
+
+def test_stream_snapshot_409_raises_release_superseded(monkeypatch):
+    # promop snapshots are latest-only (#373): a 409 means our release is stale →
+    # a re-resolve signal, NOT a hard failure.
+    resp = _FakeStreamResp([], status_code=409)
+    with pytest.raises(pvc.VocabReleaseSuperseded):
+        _run(monkeypatch, resp)
+
+
+def test_stream_snapshot_verifies_release_id_header(monkeypatch):
+    # A matching X-Vocab-Release-Id passes; a mismatch fails closed.
+    ok = _FakeStreamResp(
+        [json.dumps({'concept_id': 1}), json.dumps({'__done': True, 'rows': 1})],
+        headers={'X-Vocab-Release-Id': '2'})
+    assert _run(monkeypatch, ok) == [{'concept_id': 1}, {'__done': True, 'rows': 1}]
+
+    wrong = _FakeStreamResp([json.dumps({'concept_id': 1})],
+                            headers={'X-Vocab-Release-Id': '99'})
+    with pytest.raises(pvc.VocabSyncError):
+        _run(monkeypatch, wrong)
+
+
+def test_stream_snapshot_tolerates_absent_release_id_header(monkeypatch):
+    # An older promop without the header still works (verify only when present).
+    resp = _FakeStreamResp([json.dumps({'__done': True, 'rows': 0})], headers={})
+    assert _run(monkeypatch, resp) == [{'__done': True, 'rows': 0}]

--- a/tests/vocab_mirror/test_sync.py
+++ b/tests/vocab_mirror/test_sync.py
@@ -16,7 +16,11 @@ from vocab_mirror.models import (
     MirrorRelease,
     MirrorVocabulary,
 )
-from vocab_mirror.promop_vocab_client import LatestRelease, VocabSyncError
+from vocab_mirror.promop_vocab_client import (
+    LatestRelease,
+    VocabReleaseSuperseded,
+    VocabSyncError,
+)
 from vocab_mirror.sync import sync_vocab_mirror
 
 pytestmark = pytest.mark.django_db
@@ -257,3 +261,53 @@ class TestCopyLoad:
         assert c.standard_concept is None        # NULL preserved
         assert c.valid_start_date == date(1970, 1, 1)
         assert c.valid_end_date is None          # NULL date preserved
+
+
+class TestSupersededMidSync:
+    """promop snapshots are latest-only (#373/#301): a mid-sync 409 must re-resolve
+    /latest and restart, never mark the release FAILED."""
+
+    def test_supersede_reresolves_latest_and_activates_new_release(self):
+        class _Client:
+            def __init__(self):
+                self.polls = 0
+
+            def get_latest_release(self, if_none_match=None):
+                self.polls += 1
+                rid = 10 if self.polls == 1 else 11
+                return LatestRelease(not_modified=False,
+                                     manifest=_manifest(release_id=rid), etag=f'e{rid}')
+
+            def stream_snapshot(self, release_id, table):
+                # Eager (like the real client): raise at call time, not inside the
+                # generator, so a supersede never reaches the COPY.
+                if release_id == 10:            # stale mid-sync
+                    raise VocabReleaseSuperseded('release 10 superseded')
+                return self._rows(table)         # release 11 streams normally
+
+            @staticmethod
+            def _rows(table):
+                rows = _SNAPSHOTS[table]
+                yield from rows
+                yield {'__done': True, 'rows': len(rows)}
+
+        outcome = sync_vocab_mirror(client=_Client())
+
+        assert outcome.status == 'synced'
+        assert outcome.release_id == 11
+        assert active_release_id() == 11
+        assert not MirrorRelease.objects.filter(release_id=10).exists()  # discarded, not FAILED
+
+    def test_relentless_supersede_gives_up_gracefully(self):
+        class _Client:
+            def get_latest_release(self, if_none_match=None):
+                return LatestRelease(not_modified=False,
+                                     manifest=_manifest(release_id=20), etag='e20')
+
+            def stream_snapshot(self, release_id, table):
+                raise VocabReleaseSuperseded('always superseded')
+
+        outcome = sync_vocab_mirror(client=_Client())
+
+        assert outcome.status == 'superseded'
+        assert not MirrorRelease.objects.exists()  # every stale staging discarded

--- a/tests/vocab_mirror/test_sync.py
+++ b/tests/vocab_mirror/test_sync.py
@@ -299,15 +299,23 @@ class TestSupersededMidSync:
         assert not MirrorRelease.objects.filter(release_id=10).exists()  # discarded, not FAILED
 
     def test_relentless_supersede_gives_up_gracefully(self):
+        from vocab_mirror.sync import _SUPERSEDE_MAX_RETRIES
+
         class _Client:
+            def __init__(self):
+                self.polls = 0
+
             def get_latest_release(self, if_none_match=None):
+                self.polls += 1
                 return LatestRelease(not_modified=False,
                                      manifest=_manifest(release_id=20), etag='e20')
 
             def stream_snapshot(self, release_id, table):
                 raise VocabReleaseSuperseded('always superseded')
 
-        outcome = sync_vocab_mirror(client=_Client())
+        client = _Client()
+        outcome = sync_vocab_mirror(client=client)
 
         assert outcome.status == 'superseded'
-        assert not MirrorRelease.objects.exists()  # every stale staging discarded
+        assert client.polls == _SUPERSEDE_MAX_RETRIES  # re-resolved exactly the bound
+        assert not MirrorRelease.objects.exists()      # every stale staging discarded

--- a/vocab_mirror/promop_vocab_client.py
+++ b/vocab_mirror/promop_vocab_client.py
@@ -150,7 +150,12 @@ class PromopVocabClient:
         # verify it is the one we asked for, else promop served a different
         # release's rows under our label — fail closed.
         served = resp.headers.get('X-Vocab-Release-Id')
-        if served is not None and str(served).strip() != str(int(release_id)):
+        if served is None:
+            # Tolerated for backward-compat with a pre-#373 promop, but logged so a
+            # server that regresses and stops stamping loses the guard visibly.
+            logger.debug('snapshot %s: no X-Vocab-Release-Id header (unverified release)',
+                         table)
+        elif str(served).strip() != str(int(release_id)):
             resp.close()
             raise VocabSyncError(
                 f'snapshot {table}: X-Vocab-Release-Id {served!r} != requested '

--- a/vocab_mirror/promop_vocab_client.py
+++ b/vocab_mirror/promop_vocab_client.py
@@ -34,6 +34,14 @@ class VocabSyncError(Exception):
     """Any hard failure talking to the vocab-releases API (fail-closed)."""
 
 
+class VocabReleaseSuperseded(Exception):
+    """The requested release is no longer the latest — promop's snapshot endpoint
+    is latest-only and returned 409 (promop#371/#373). NOT a failure: the caller
+    should re-resolve ``/latest`` and restart the sync on the new release. Kept
+    distinct from ``VocabSyncError`` so the sync flow never marks the release
+    FAILED for this."""
+
+
 @dataclass
 class LatestRelease:
     not_modified: bool
@@ -102,7 +110,14 @@ class PromopVocabClient:
         return LatestRelease(not_modified=False, manifest=manifest, etag=resp.headers.get('ETag'))
 
     def stream_snapshot(self, release_id, table):
-        """Yield parsed NDJSON objects for one table snapshot (incl. the sentinel)."""
+        """Return an iterator of parsed NDJSON objects for one table snapshot
+        (incl. the sentinel).
+
+        The request and its **status + header checks are eager** (done here, before
+        the iterator is returned), NOT inside the generator: a supersede (409) or a
+        bad response is raised at call time, so it can never abort a mid-flight COPY
+        on the consumer side. Only the row iteration is lazy.
+        """
         if not self.base_url:
             raise VocabSyncError('PROMOP_VOCAB_BASE / PROMOP_API_BASE is not configured')
         url = f'{self.base_url}/api/v1/vocab-releases/{int(release_id)}/snapshot/{table}/'
@@ -119,12 +134,35 @@ class PromopVocabClient:
             )
         except requests.RequestException as exc:
             raise VocabSyncError(f'snapshot {table} request failed: {exc}') from exc
+
+        if resp.status_code == 409:
+            # Latest-only snapshots (promop#371/#373): a newer release published
+            # since we resolved /latest. Re-resolve + restart, never fail closed.
+            resp.close()
+            raise VocabReleaseSuperseded(
+                f'snapshot {table}: release {int(release_id)} is no longer the '
+                f'latest published release (409)')
+        if not resp.ok:
+            code, reason = resp.status_code, resp.reason
+            resp.close()
+            raise VocabSyncError(f'snapshot {table} -> {code} {reason}')
+        # Every snapshot response stamps the release it reflects (promop#373);
+        # verify it is the one we asked for, else promop served a different
+        # release's rows under our label — fail closed.
+        served = resp.headers.get('X-Vocab-Release-Id')
+        if served is not None and str(served).strip() != str(int(release_id)):
+            resp.close()
+            raise VocabSyncError(
+                f'snapshot {table}: X-Vocab-Release-Id {served!r} != requested '
+                f'release {int(release_id)}')
+        return self._iter_snapshot(resp, table)
+
+    @staticmethod
+    def _iter_snapshot(resp, table):
         # `with resp` closes the connection when the generator finishes OR is
-        # closed early (the loader breaks at the sentinel), so a streamed
-        # response is never left checked out.
+        # closed early (the loader breaks at the sentinel), so a streamed response
+        # is never left checked out.
         with resp:
-            if not resp.ok:
-                raise VocabSyncError(f'snapshot {table} -> {resp.status_code} {resp.reason}')
             try:
                 for line in resp.iter_lines(decode_unicode=True):
                     if not line:

--- a/vocab_mirror/sync.py
+++ b/vocab_mirror/sync.py
@@ -49,13 +49,20 @@ from vocab_mirror.models import (
     MirrorRelease,
     MirrorVocabulary,
 )
-from vocab_mirror.promop_vocab_client import PromopVocabClient, VocabSyncError
+from vocab_mirror.promop_vocab_client import (
+    PromopVocabClient,
+    VocabReleaseSuperseded,
+    VocabSyncError,
+)
 
 logger = logging.getLogger(__name__)
 
 _DB = 'default'  # the mirror lives on `default` (db_router / ADR §Placement)
 # Fixed 64-bit key for the sync singleton advisory lock.
 _SYNC_ADVISORY_LOCK_KEY = 8234502250
+# How many times one run re-resolves /latest after a mid-sync supersede (409)
+# before deferring to the next scheduled run (promop#371/#373).
+_SUPERSEDE_MAX_RETRIES = 3
 
 # promop#334 table slug -> mirror model. EXACT syncs exactly the tables it needs.
 TABLE_MODELS = {
@@ -73,6 +80,7 @@ class SyncOutcome:
     # 'synced' (loaded + activated) | 'activated' (recovered a stranded READY) |
     # 'partial' (subset load, left STAGING, not activated) |
     # 'loaded_not_activated' (READY but the release-match gate rejected it) |
+    # 'superseded' (releases kept publishing mid-sync; deferred to the next run) |
     # 'locked' (another sync holds the advisory lock)
     status: str
     release_id: int | None = None
@@ -271,6 +279,27 @@ def _reap_best_effort():
 
 
 def _do_sync(client, tables, activate):
+    """Run one sync, restarting if the release is superseded mid-stream.
+
+    promop's snapshots are latest-only (promop#371/#373): a newer release
+    published between our ``/latest`` poll and a snapshot stream surfaces as a 409
+    (``VocabReleaseSuperseded``). That is a re-resolve signal, not a failure — poll
+    ``/latest`` again and load the new release, bounded so rapid publishing can't
+    spin forever (the next scheduled run picks up where we left off).
+    """
+    for attempt in range(_SUPERSEDE_MAX_RETRIES):
+        try:
+            return _do_sync_once(client, tables, activate)
+        except VocabReleaseSuperseded as exc:
+            logger.info('vocab sync: %s; re-resolving /latest (attempt %d/%d)',
+                        exc, attempt + 1, _SUPERSEDE_MAX_RETRIES)
+    logger.warning(
+        'vocab sync: releases kept superseding after %d attempts; leaving it for '
+        'the next run', _SUPERSEDE_MAX_RETRIES)
+    return SyncOutcome(status='superseded')
+
+
+def _do_sync_once(client, tables, activate):
     # Only a full-table load may be activated — activating a subset would put an
     # incomplete generation live (empty relationship/ancestor tables → traversal
     # silently returns nothing). Subset loads (e.g. `--tables concept`) stage but
@@ -331,6 +360,15 @@ def _do_sync(client, tables, activate):
     try:
         for table in tables:
             counts[table] = _load_table(client, release_id, table, row_counts.get(table))
+    except VocabReleaseSuperseded as exc:
+        # A newer release published mid-sync (promop snapshots are latest-only).
+        # This release is stale, not corrupt — discard its staging (rows + the
+        # MirrorRelease row) and let the caller re-resolve /latest and restart.
+        _delete_release_rows(release_id)
+        rel.delete(using=_DB)
+        logger.info('vocab sync: release %s superseded mid-sync, discarded: %s',
+                    release_id, exc)
+        raise
     except Exception as exc:
         rel.state = MirrorRelease.FAILED
         rel.save(using=_DB, update_fields=['state', 'updated_at'])


### PR DESCRIPTION
Closes #301. Adapts EXACT's vocab-mirror sync to the now-merged **promop #373** (promop#371): bulk snapshots are latest-only.

## Problem
promop #373 made a non-latest release's snapshot return **409**, and stamps every snapshot response with **`X-Vocab-Release-Id`**. Since `concept_relationship` streams for minutes, a newer release publishing mid-sync is a real race — the old client treated the 409 as a hard error and marked the release **FAILED** (self-heals next run, but wastes a run + a cosmetic FAILED).

## Fix
- **Eager `stream_snapshot`:** the HTTP request + status/header checks now run at call time (before the row iterator is returned), so a supersede/error can never abort a mid-flight `COPY` on the consumer side. A 409 raises the new **`VocabReleaseSuperseded`** (distinct from `VocabSyncError`); a mismatched `X-Vocab-Release-Id` fails closed; an absent header is tolerated (pre-#373 backward-compat) + logged.
- **Bounded re-resolve:** `_do_sync` wraps `_do_sync_once` in a loop (`_SUPERSEDE_MAX_RETRIES=3`): on supersede, `_do_sync_once` discards the stale staging (rows + `MirrorRelease` row, **not** FAILED) and re-raises; the loop re-polls `/latest` and retries; after 3, returns a non-fatal `superseded` outcome for the next scheduled run.

## Review (two-part, pre-push)
- **codex**: correct — classifies 409 as retryable supersede, discards stale staging, bounded re-resolve.
- **fresh-context subagent**: ship-ready, no blockers; verified the eager restructure fixes the mid-COPY abort, resource safety, retry-loop correctness, no reaper/cross-artifact confusion. Applied its two notes: pin the give-up bound in the test; log absent header.

## Verification
Client (409 → `VocabReleaseSuperseded`; header match/mismatch/absent) + sync (mid-sync supersede re-resolves `/latest` and activates the new release, stale staging discarded not FAILED; relentless supersede gives up after exactly 3 polls). **87 vocab_mirror tests pass**; full suite (excluding a pre-existing checkout-drift file, `test_omop_therapy_types_matching`) **1118 passed**; `makemigrations --check` clean.

Live e2e against a promop-with-#373 deferred — unit coverage is complete; the header path exercises on the next real sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)