### PR TITLE
feat(mcl): remove metastatic_status as a matching attr (catch up to CB #4121)

### DIFF
--- a/tests/management/test_normalize_ctomop_row.py
+++ b/tests/management/test_normalize_ctomop_row.py
@@ -212,6 +212,13 @@ class TestMetastaticStatus:
         result = _normalize_ctomop_row(_row(metastasis_status='Unknown'))
         assert 'metastatic_status' not in result
 
+    def test_not_a_matching_attr(self):
+        # #4121 catch-up: metastatic_status is still a normalized PatientInfo field
+        # (above), but it was removed as a trial-matching attr (redundant with
+        # stage / distant_metastasis_stage) — it must not be in the mapping.
+        from trials.services.patient_info.configs import USER_TO_TRIAL_ATTRS_MAPPING
+        assert 'metastatic_status' not in USER_TO_TRIAL_ATTRS_MAPPING
+
 
 # ---------------------------------------------------------------------------
 # Staging modality — "c → Clinical" → "c"

--- a/trials/services/patient_info/configs.py
+++ b/trials/services/patient_info/configs.py
@@ -615,12 +615,7 @@ USER_TO_TRIAL_ATTRS_MAPPING = {
         "disease": "BC",
         "attr": "menopausal_status",
     },
-    "metastatic_status": {
-        "type": "bool_restriction",
-        "searchable": True,
-        "disease": "BC",
-        "attr": "metastatic_required",
-    },
+    # metastatic_status removed (#4121) — redundant with stage / distant_metastasis_stage.
     "bone_only_metastasis_status": {
         "type": "bool_restriction",
         "searchable": True,

--- a/trials/services/trial_details/configs.py
+++ b/trials/services/trial_details/configs.py
@@ -36,7 +36,6 @@ ATTR_FALSE_VALUE_IS_BLANK = [
     'pulmonaryFunctionTestResultRequired',
     'boneImagingResultRequired',
     'noGeographicExposureRiskRequired',
-    'metastaticRequired',
     'boneOnlyMetastasisRequired',
     'measurableDiseaseByRecistRequired',
     'measurableDiseaseImwgRequired',
@@ -116,7 +115,6 @@ ATTR_DEPS_MAPPING = {
 
     # Computed in pre_save signal
     'flipiScore': ['flipiScoreOptions'],
-    'metastaticStatus': ['disease', 'stage'],
     'measurableDiseaseImwg': ['monoclonalProteinSerum', 'monoclonalProteinUrine', 'kappaFLC', 'lambdaFLC'],
     'lastTreatment': ['laterDate', 'secondLineDate', 'firstLineDate'],
     'geoPoint': ['country', 'postalCode', 'longitude', 'latitude'],
@@ -266,7 +264,6 @@ SUBFORM_ATTRS_MAPPING = {
     'meets_slim': ['clonal_plasma_cells', 'kappa_flc', 'lambda_flc', 'bone_lesions'],
     'hr_statuses_required': ['estrogen_receptor_status', 'progesterone_receptor_status'],
     'tnbc_status': ['estrogen_receptor_status', 'progesterone_receptor_status', 'her2_status'],
-    'metastatic_status': ['stage'],
     'measurable_disease_imwg': ['monoclonal_protein_serum', 'monoclonal_protein_urine', 'kappa_flc', 'lambda_flc'],
 }
 
@@ -400,7 +397,6 @@ ATTR_GROUP_MAPPING = {
     'tumorGradeMax': 'disease',
 
     'menopausalStatus': 'disease',
-    'metastaticRequired': 'disease',
     'toxicityGradeMax': 'disease',
 
     'histologicTypesRequired': 'disease',


### PR DESCRIPTION
## Remove `metastatic_status` from trial matching (CB #4121, D5)

CB removed `metastatic_status` as a matching attribute (redundant with `stage` / `distant_metastasis_stage`, SME-confirmed #4121) while keeping the data field. Port to EXACT (git-history: EXACT only inherited it, never intentionally kept it).

- `patient_info/configs.py`: drop the `metastatic_status` `USER_TO_TRIAL_ATTRS_MAPPING` entry (BC `bool_restriction` on `metastatic_required`), leaving CB's removal comment.
- `trial_details/configs.py`: drop the 4 mirror refs (one-for-one with CB's #4121 diff).
- **Kept:** the `metastatic_required` Trial column + the CTOMOP normalization that populates `PatientInfo.metastatic_status` (still a data field, just not matched on). Regression test asserts it's out of the mapping.

Also clears a QR4d blocker (the pkg-only `metastatic_status` mapping key breaking CB↔pkg mapping-key equality).

## Review (codex P1 reconciled)
codex flagged a P1 (removing the matcher loosens BC trials that set `metastatic_required=True`). Reconciled + user-confirmed to proceed:
- **Faithful port** of CB's SME-confirmed #4121 (CB also kept the column, no migration).
- The loosening is **substantially redundant**: patient `metastatic_status` was never authored independently — it was *derived* as `disease==BreastCancer AND stage=='IV'` (pre_save signal deleted in #4121), so `stage` already carries it. Residual gap = only BC trials with `metastatic_required=True` AND empty `stages` — identical in CB.
- **Decisive:** EXACT and CB read the same trials table; NOT porting would make EXACT *stricter* than CB — the exact divergence the downstream-parity contract prevents.
- Optional low-pri **CB-side** audit (BC trials with `metastatic_required=True AND stages=[]`) — does not gate this port.

fresh-context Claude: SHIP.

## Tests
Golden + MCL suites green (85, `--create-db`); disease-aware/value (26) + CTOMOP normalize (110) green. No golden-test churn (metastatic_status was BC-scoped; MM/FL/CLL/MCL sets unaffected).

Then 2omop counterpart via worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)