### PR TITLE
feat(mcl): remove metastatic_status as a matching attr on 2omop (matcher_app) — #4121

### DIFF
--- a/matcher_app/exact_matching/patient_info/configs.py
+++ b/matcher_app/exact_matching/patient_info/configs.py
@@ -615,12 +615,7 @@ USER_TO_TRIAL_ATTRS_MAPPING = {
         "disease": "BC",
         "attr": "menopausal_status",
     },
-    "metastatic_status": {
-        "type": "bool_restriction",
-        "searchable": True,
-        "disease": "BC",
-        "attr": "metastatic_required",
-    },
+    # metastatic_status removed (#4121) — redundant with stage / distant_metastasis_stage.
     "bone_only_metastasis_status": {
         "type": "bool_restriction",
         "searchable": True,

--- a/matcher_app/exact_matching/trial_details/configs.py
+++ b/matcher_app/exact_matching/trial_details/configs.py
@@ -36,7 +36,6 @@ ATTR_FALSE_VALUE_IS_BLANK = [
     'pulmonaryFunctionTestResultRequired',
     'boneImagingResultRequired',
     'noGeographicExposureRiskRequired',
-    'metastaticRequired',
     'boneOnlyMetastasisRequired',
     'measurableDiseaseByRecistRequired',
     'measurableDiseaseImwgRequired',
@@ -116,7 +115,6 @@ ATTR_DEPS_MAPPING = {
 
     # Computed in pre_save signal
     'flipiScore': ['flipiScoreOptions'],
-    'metastaticStatus': ['disease', 'stage'],
     'measurableDiseaseImwg': ['monoclonalProteinSerum', 'monoclonalProteinUrine', 'kappaFLC', 'lambdaFLC'],
     'lastTreatment': ['laterDate', 'secondLineDate', 'firstLineDate'],
     'geoPoint': ['country', 'postalCode', 'longitude', 'latitude'],
@@ -266,7 +264,6 @@ SUBFORM_ATTRS_MAPPING = {
     'meets_slim': ['clonal_plasma_cells', 'kappa_flc', 'lambda_flc', 'bone_lesions'],
     'hr_statuses_required': ['estrogen_receptor_status', 'progesterone_receptor_status'],
     'tnbc_status': ['estrogen_receptor_status', 'progesterone_receptor_status', 'her2_status'],
-    'metastatic_status': ['stage'],
     'measurable_disease_imwg': ['monoclonal_protein_serum', 'monoclonal_protein_urine', 'kappa_flc', 'lambda_flc'],
 }
 
@@ -400,7 +397,6 @@ ATTR_GROUP_MAPPING = {
     'tumorGradeMax': 'disease',
 
     'menopausalStatus': 'disease',
-    'metastaticRequired': 'disease',
     'toxicityGradeMax': 'disease',
 
     'histologicTypesRequired': 'disease',

--- a/tests/management/test_normalize_promop_row.py
+++ b/tests/management/test_normalize_promop_row.py
@@ -212,6 +212,13 @@ class TestMetastaticStatus:
         result = _normalize_promop_row(_row(metastasis_status='Unknown'))
         assert 'metastatic_status' not in result
 
+    def test_not_a_matching_attr(self):
+        # #4121 catch-up: metastatic_status is still a normalized PatientInfo field
+        # (above), but it was removed as a trial-matching attr (redundant with
+        # stage / distant_metastasis_stage) — it must not be in the mapping.
+        from trials.services.patient_info.configs import USER_TO_TRIAL_ATTRS_MAPPING
+        assert 'metastatic_status' not in USER_TO_TRIAL_ATTRS_MAPPING
+
 
 # ---------------------------------------------------------------------------
 # Staging modality — "c → Clinical" → "c"


### PR DESCRIPTION
## Remove `metastatic_status` from matching on 2omop / matcher_app — counterpart of #311

2omop counterpart of dev **#311**. Removes `metastatic_status` as a trial-matching attribute in the **extracted package** (CB #4121, D5).

- `matcher_app/exact_matching/patient_info/configs.py`: drop the `metastatic_status` `USER_TO_TRIAL_ATTRS_MAPPING` entry (BC `bool_restriction`), leaving CB's removal comment.
- `matcher_app/exact_matching/trial_details/configs.py`: drop the 4 mirror refs.
- **Kept:** the `metastatic_required` Trial column + promop normalization of the data field. Regression test in `test_normalize_promop_row` (2omop renamed ctomop→promop).

Byte-identical to #311 (dev commit's hunks applied cleanly, matcher_app path remapped).

## Review
codex clean; fresh-context Claude SHIP (faithful to #311/CB, fully gone from matching, data field retained, 13 tests). The codex P1 (loosening) was reconciled + user-approved on #311 (faithful port of SME-confirmed #4121; patient `metastatic_status` was derived as `disease==BC AND stage=='IV'` so `stage` carries it; not porting makes EXACT stricter than CB = parity violation) — not re-litigated.

## Tests
metastatic + golden + MCL suites green (89, worktree matcher_app / `--create-db`).