### PR TITLE
feat(mcl): disease_code + MCL-derivation gate strip whitespace (CB #4323)

### DIFF
--- a/tests/services/patient_info/test_mcl_derivations.py
+++ b/tests/services/patient_info/test_mcl_derivations.py
@@ -247,10 +247,14 @@ class TestNormalizerWiring:
         'mantle cell lymphoma',
         'Mantle Cell Lymphoma',
         'MANTLE CELL LYMPHOMA',
+        '  Mantle Cell Lymphoma  ',  # #4323: surrounding whitespace tolerated
+        'mantle cell lymphoma ',
     ])
-    def test_disease_gate_is_case_insensitive(self, disease):
-        # str(pi.disease).lower() == 'mantle cell lymphoma' must accept any
-        # casing the API caller sends.
+    def test_disease_gate_is_case_and_whitespace_insensitive(self, disease):
+        # The disease gate must accept any casing AND surrounding whitespace the
+        # API caller sends, staying consistent with disease_code (#4323): a padded
+        # title resolves to MCL, so derivation must run (else MCL is matched on
+        # blank derived values).
         pi = _mcl_patient(disease=disease, largest_lesion_size=6)
         normalize_patient_info(pi)
         assert pi.bulky_disease_criteria == 'bulky_lesion_5cm'
@@ -434,3 +438,23 @@ class TestMclDiseaseScoping:
         from trials.services.patient_info.configs import USER_TO_TRIAL_ATTRS_MAPPING as M
         assert 'MCL' in M[attr]['disease'], (attr, M[attr]['disease'])
 
+
+
+class TestDiseaseCodeNormalization:
+    """disease_code (#4323): case + surrounding-whitespace tolerant, None-safe."""
+
+    @pytest.mark.parametrize('disease,expected', [
+        ('  Mantle Cell Lymphoma  ', 'MCL'),
+        ('mantle cell lymphoma', 'MCL'),
+        (' breast cancer ', 'BC'),
+        ('MULTIPLE MYELOMA', 'MM'),
+    ])
+    def test_strips_and_lowercases(self, disease, expected):
+        assert PatientInfoAttributes(_mcl_patient(disease=disease)).disease_code == expected
+
+    def test_none_disease_returns_none_not_crash(self):
+        # (disease or '').strip() avoids str(None).lower() == 'none'
+        assert PatientInfoAttributes(_mcl_patient(disease=None)).disease_code is None
+
+    def test_unknown_disease_returns_none(self):
+        assert PatientInfoAttributes(_mcl_patient(disease='glioblastoma')).disease_code is None

--- a/trials/services/patient_info/normalize.py
+++ b/trials/services/patient_info/normalize.py
@@ -235,7 +235,10 @@ def _normalize_mcl_derivations(pi) -> None:
     patient_info.py:215). Skips non-MCL patients so other diseases keep
     whatever defaults / inputs they had.
     """
-    if str(pi.disease).lower() != 'mantle cell lymphoma':
+    # Whitespace/None-tolerant, consistent with PatientInfoAttributes.disease_code
+    # (CB #4323): else a padded 'mantle cell lymphoma ' would resolve to disease_code
+    # 'MCL' (MCL attrs matched) yet skip derivation here (MCL matched on blank values).
+    if (pi.disease or '').strip().lower() != 'mantle cell lymphoma':
         return
 
     # Late import: PatientInfoAttributes imports normalize indirectly via

--- a/trials/services/patient_info/patient_info_attributes.py
+++ b/trials/services/patient_info/patient_info_attributes.py
@@ -233,7 +233,11 @@ class PatientInfoAttributes:
 
     @cached_property
     def disease_code(self):
-        disease = str(self.patient_info.disease).lower()
+        # Tolerate surrounding whitespace + None/empty (CB #4323): a bare
+        # str(None).lower() would be 'none'. Kept consistent with the MCL disease
+        # gate in normalize._normalize_mcl_derivations so a padded title can't
+        # resolve here to a code but skip derivation there.
+        disease = (self.patient_info.disease or '').strip().lower()
         if disease == 'multiple myeloma':
             return 'MM'
         elif disease == 'follicular lymphoma':


### PR DESCRIPTION
## disease_code + MCL-derivation gate: whitespace + None tolerant (CB #4323)

CB routes disease detection through `disease_code_for` (`.strip().lower()`, consistently). EXACT inlined `str(pi.disease).lower()` in two **matching-relevant** spots without stripping — a divergence that causes a **match/derive split**: a padded `'mantle cell lymphoma '` resolves to `disease_code == 'MCL'` (MCL attrs matched) but `_normalize_mcl_derivations` skips (MCL then matched on **blank** derived values). This is the codex P2 flagged on the structural PR.

Fix both consistently (whitespace + None tolerant):
- `PatientInfoAttributes.disease_code` → `(disease or '').strip().lower()`
- `normalize._normalize_mcl_derivations` disease gate → same

### Scope
- **Not touched:** `_normalize_metastatic_status`'s BC gate — `metastatic_status` is no longer a matching attr (#4121/#311), so its gate can't cause a match/derive split; separate #4121-cleanup candidate.
- Pre-existing unstripped resolvers **outside** the patient matcher (`user_to_trial_attr_matcher.get_disease_code_from_trial` reads TRIAL data; `trial_details` display path) are out of #4323 scope — optional future cleanup (fresh-review confirmed).

### Tests
`TestDiseaseCodeNormalization` (padded/None/unknown) + the case-insensitive gate test extended to whitespace-padded titles (proves derivation runs for padded MCL). MCL + golden suites green (93, `--create-db`). No golden churn (disease_code is a derived property, not an enumerated matching attr).

### Review
codex clean; fresh-context Claude SHIP (correctness for None/''/whitespace both sites, consistency achieved, line-174 deferral sound; fixed a misleading comment nit).

Then 2omop counterpart via worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)