### PR TITLE
feat(mcl): disease_code + MCL-derivation gate strip whitespace on 2omop (matcher_app) — CB #4323

### DIFF
--- a/matcher_app/exact_matching/patient_info/patient_info_attributes.py
+++ b/matcher_app/exact_matching/patient_info/patient_info_attributes.py
@@ -263,7 +263,11 @@ class PatientInfoAttributes:
 
     @cached_property
     def disease_code(self):
-        disease = str(self.patient_info.disease).lower()
+        # Tolerate surrounding whitespace + None/empty (CB #4323): a bare
+        # str(None).lower() would be 'none'. Kept consistent with the MCL disease
+        # gate in normalize._normalize_mcl_derivations so a padded title can't
+        # resolve here to a code but skip derivation there.
+        disease = (self.patient_info.disease or '').strip().lower()
         if disease == 'multiple myeloma':
             return 'MM'
         elif disease == 'follicular lymphoma':

--- a/tests/services/patient_info/test_mcl_derivations.py
+++ b/tests/services/patient_info/test_mcl_derivations.py
@@ -247,10 +247,14 @@ class TestNormalizerWiring:
         'mantle cell lymphoma',
         'Mantle Cell Lymphoma',
         'MANTLE CELL LYMPHOMA',
+        '  Mantle Cell Lymphoma  ',  # #4323: surrounding whitespace tolerated
+        'mantle cell lymphoma ',
     ])
-    def test_disease_gate_is_case_insensitive(self, disease):
-        # str(pi.disease).lower() == 'mantle cell lymphoma' must accept any
-        # casing the API caller sends.
+    def test_disease_gate_is_case_and_whitespace_insensitive(self, disease):
+        # The disease gate must accept any casing AND surrounding whitespace the
+        # API caller sends, staying consistent with disease_code (#4323): a padded
+        # title resolves to MCL, so derivation must run (else MCL is matched on
+        # blank derived values).
         pi = _mcl_patient(disease=disease, largest_lesion_size=6)
         normalize_patient_info(pi)
         assert pi.bulky_disease_criteria == 'bulky_lesion_5cm'
@@ -434,3 +438,23 @@ class TestMclDiseaseScoping:
         from trials.services.patient_info.configs import USER_TO_TRIAL_ATTRS_MAPPING as M
         assert 'MCL' in M[attr]['disease'], (attr, M[attr]['disease'])
 
+
+
+class TestDiseaseCodeNormalization:
+    """disease_code (#4323): case + surrounding-whitespace tolerant, None-safe."""
+
+    @pytest.mark.parametrize('disease,expected', [
+        ('  Mantle Cell Lymphoma  ', 'MCL'),
+        ('mantle cell lymphoma', 'MCL'),
+        (' breast cancer ', 'BC'),
+        ('MULTIPLE MYELOMA', 'MM'),
+    ])
+    def test_strips_and_lowercases(self, disease, expected):
+        assert PatientInfoAttributes(_mcl_patient(disease=disease)).disease_code == expected
+
+    def test_none_disease_returns_none_not_crash(self):
+        # (disease or '').strip() avoids str(None).lower() == 'none'
+        assert PatientInfoAttributes(_mcl_patient(disease=None)).disease_code is None
+
+    def test_unknown_disease_returns_none(self):
+        assert PatientInfoAttributes(_mcl_patient(disease='glioblastoma')).disease_code is None

--- a/trials/services/patient_info/normalize.py
+++ b/trials/services/patient_info/normalize.py
@@ -235,7 +235,10 @@ def _normalize_mcl_derivations(pi) -> None:
     patient_info.py:215). Skips non-MCL patients so other diseases keep
     whatever defaults / inputs they had.
     """
-    if str(pi.disease).lower() != 'mantle cell lymphoma':
+    # Whitespace/None-tolerant, consistent with PatientInfoAttributes.disease_code
+    # (CB #4323): else a padded 'mantle cell lymphoma ' would resolve to disease_code
+    # 'MCL' (MCL attrs matched) yet skip derivation here (MCL matched on blank values).
+    if (pi.disease or '').strip().lower() != 'mantle cell lymphoma':
         return
 
     # Late import: PatientInfoAttributes imports normalize indirectly via


### PR DESCRIPTION
## disease_code + MCL-derivation gate: whitespace/None tolerant on 2omop — counterpart of #314

2omop counterpart of dev **#314** (CB #4323). Strips + None-guards the two matching-relevant disease gates so a padded `'mantle cell lymphoma '` resolves to `disease_code == 'MCL'` **and** runs `_normalize_mcl_derivations` (else MCL matched on blank derived values — codex P2 from the structural PR).

- `matcher_app/exact_matching/patient_info/patient_info_attributes.py` `disease_code` → `(disease or '').strip().lower()`.
- `trials/services/patient_info/normalize.py` (NOT extracted; host-side) `_normalize_mcl_derivations` gate → same.
- disease_code strip/None/unknown tests + whitespace-extended gate test.

Byte-identical logic to #314 (dev commit's hunks applied cleanly; patient_info_attributes remapped to matcher_app, normalize + test at their normal paths).

### codex P1 (disease filter) — reconciled to CB-parity (user-confirmed)
codex noted `_filter_disease` uses `disease__iexact=value.lower()` on the raw patient disease, so a padded title matches 0 trials (whitespace tolerance not end-to-end). **CancerBot does the identical thing** (`trials/querysets/trial.py:660`, raw `.lower()`, no strip — fresh-review verified). EXACT reads the same trials table as CB; stripping only EXACT's filter would make it more permissive than CB (a downstream-parity violation). So the filter is intentionally left raw. Full end-to-end tolerance, if wanted, is a **CB-first** change.

### Review
codex (P1 reconciled as CB-parity) + fresh-context Claude SHIP (parity claim independently verified: CB filter is raw; faithful to #314; 84 tests green).

## Tests
MCL + golden suites green (93, worktree matcher_app / `--create-db`).