### PR TITLE
ci: pin pip < 24.1 in the Django install step (fix get_runnable_pip ImportError)

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -37,7 +37,14 @@ jobs:
           libgeos-dev \
           postgresql-client
     - name: Install Python dependencies
-      run: pip install -r requirements.txt
+      # Pin pip < 24.1: the runner's default pip removed
+      # pip._internal.utils.misc.get_runnable_pip, which a build-isolation path
+      # in `pip install -r requirements.txt` still imports -> ImportError on
+      # install (tests never run). Deterministic fix until the offending build
+      # backend is upgraded.
+      run: |
+        python -m pip install "pip<24.1"
+        pip install -r requirements.txt
 
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Fix backend CI install failure (`get_runnable_pip` ImportError)

The backend workflow's `pip install -r requirements.txt` started failing at the **install** step (tests never run) with:
```
ImportError: cannot import name 'get_runnable_pip' from pip._internal.utils.misc
```
That symbol was **removed in pip 24.1**, but a build-isolation path still imports it, so the runner's newer default pip breaks the install.

**Fix:** pin `pip < 24.1` before installing, in the `build` job's install step. The `test` job restores the build job's env via the `pythonLocation` cache (no second install), so one pin covers the whole workflow.

**Not a code change** — this only unblocks CI. It's why PR #314 (dev) went red while its 2omop counterpart #316 stayed green (the latter's build cache-hit an older pip).

Follow-up: identify + upgrade the build backend that imports `get_runnable_pip`, then drop the pin. The same `django.yml` on 2omop should get this pin too (its CI currently passes only on a stale pip cache).

## Review
codex clean; fresh-context Claude SHIP (correct downgrade-then-install, only one install step + cache flow verified, no pip>=24.1 requirement, no injection surface, YAML valid).

This PR's own CI run validates the fix.