### PR TITLE
fix(build): COPY matcher_app before pip so `-e ./matcher_app` resolves (#313)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,13 @@ USER app
 WORKDIR /app
 ENV PATH="$PATH:/app/.local/bin"
 
+# requirements.txt installs the converged matcher as an editable local package
+# (`-e ./matcher_app`), so that directory must exist at pip time. Copy it in
+# before the install (cwd is WORKDIR /app, so `./matcher_app` resolves); the
+# later `COPY . /app` still brings the full tree. Without this the build fails
+# with "./matcher_app is not a valid editable requirement" (#313).
+COPY --chown=app:app matcher_app /app/matcher_app
+
 RUN python3 -m pip install --upgrade pip \
     && pip install --no-cache-dir -r /tmp/requirements.txt
 


### PR DESCRIPTION
## Problem
The exact Docker image no longer builds — `pip install -r requirements.txt` (which has `-e ./matcher_app`) runs **before** `COPY . /app`, so at pip time `./matcher_app` doesn't exist:
```
ERROR: ./matcher_app is not a valid editable requirement...
```
Blocks the local federated stack (surfaced bringing it up for the #310 OMOP e2e) and any Docker build of the converged image.

## Fix
Add `COPY --chown=app:app matcher_app /app/matcher_app` before the pip install. At pip time cwd is `WORKDIR /app`, so the editable requirement `-e ./matcher_app` resolves. The later `COPY . /app` still brings the full tree and refreshes the source in place (the editable install links a stable path, so this is safe).

Minimal + correct; the one tradeoff is that editing matcher_app now busts the pip layer cache (unavoidable for an in-repo editable dep).

## Verification
- Full image build succeeds end-to-end (editable `exact-matching` wheel builds, collectstatic runs, image tags) — validated in the local stack.
- Two-part self-review: `codex` + a fresh-context subagent review, both confirm correct/minimal; reconciled.

Closes #313.