### PR TITLE
ci: pin pip < 24.1 in the Django install step on 2omop (get_runnable_pip)

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -37,7 +37,14 @@ jobs:
           libgeos-dev \
           postgresql-client
     - name: Install Python dependencies
-      run: pip install -r requirements.txt
+      # Pin pip < 24.1: the runner's default pip removed
+      # pip._internal.utils.misc.get_runnable_pip, which a build-isolation path
+      # in `pip install -r requirements.txt` still imports -> ImportError on
+      # install (tests never run). Deterministic fix until the offending build
+      # backend is upgraded.
+      run: |
+        python -m pip install "pip<24.1"
+        pip install -r requirements.txt
 
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
2omop counterpart of dev **#317**. Byte-identical `django.yml` fix: pin `pip < 24.1` before `pip install -r requirements.txt` so the install doesn't hit `ImportError: cannot import name 'get_runnable_pip' from pip._internal.utils.misc` (removed in pip 24.1, still imported by a build-isolation path).

2omop's CI currently passes only because its build cache-hit an older pip — this makes it deterministic (and matches dev #317).

Review: codex clean; the identical change got a full codex + fresh-context Claude SHIP on #317.