### PR TITLE
ci: gate deploy-staging to manual dispatch only (replaces #143)

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -17,8 +17,6 @@ name: deploy-staging
 #   GCP_SERVICE_ACCOUNT          exact-staging-gh@<project>.iam.gserviceaccount.com
 
 on:
-  push:
-    branches: [main]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Replaces the stale #143 (its branch was 264 commits behind `main`), freshened off current `main`.

## What
Remove the `push: branches: [main]` trigger from `.github/workflows/deploy-staging.yml`, leaving only `workflow_dispatch`.

## Why
EXACT staging is deployed **manually** (build image → `terraform apply` in ht-phr → Secret Manager values → `exact-staging-migrate` job). The push trigger auto-deployed staging on every merge to `main`, which was unintended/unused. (Policy re-confirmed by the repo owner.)

## Safety checks
- `main` has **no branch protection** → `deploy-staging` is not a required status check, so removing its push run can't block merges.
- **No other workflow** chains off `deploy-staging` (no `workflow_run` reference).
- `workflow_dispatch` keeps it runnable from the Actions UI/API; `${{ github.sha }}` resolves under manual dispatch too.

Reviewed: codex + fresh-context subagent, both confirm safe.

Closes #143.