### PR TITLE
fix(matcher): host-agnostic computed_value_type seam for bulky_disease_criteria

### DIFF
--- a/matcher_app/exact_matching/patient_info/configs.py
+++ b/matcher_app/exact_matching/patient_info/configs.py
@@ -569,6 +569,14 @@ USER_TO_TRIAL_ATTRS_MAPPING = {
     "bulky_disease_criteria": {
         "type": ATTR_MAPPING_TYPE_COMPUTED,
         "custom_search": True,
+        # Host-agnostic seam (matches CB): CB exposes bulky_disease_criteria as a
+        # computed @property (no model field), so is_attr_blank's fallback
+        # get_field() would raise there. computed_value_type short-circuits that
+        # lookup with the value's type. Inert for EXACT, where it is a TextField —
+        # both resolve to the same str/'' blank check. is_computed_value is inert
+        # metadata (not read by the package) kept for parity.
+        "is_computed_value": True,
+        "computed_value_type": "str",
         "disease": "MCL",
         "attr": ["bulky_disease_criteria_required"],
         "uvalue_function": {


### PR DESCRIPTION
## What (QR4d contract-diff — item a)
The QR4d config contract-diff (CB `USER_TO_TRIAL_ATTRS_MAPPING` vs the package's) surfaced one real shape delta on a shared key: CB's `bulky_disease_criteria` carries `computed_value_type='str'` (+ inert `is_computed_value`); the package's did not. This adds them to the package config.

## Why
`bulky_disease_criteria` is a computed **@property** on CB's `PatientInfo` (no model field), so `is_attr_blank`'s fallback `type(PatientInfo._meta.get_field('bulky_disease_criteria'))` raises `FieldDoesNotExist`. In EXACT it's a real `TextField`, so the fallback works and the key was omitted. When CB drains onto this shared config (QR4d), it would lose `computed_value_type` and crash on the property.

Adding it makes the shared mapping **host-agnostic**: `computed_value_type='str'` short-circuits the field lookup with the value's type.

## Behaviour-inert for EXACT
`'str'` and EXACT's `TextField` both resolve to the same `str`/`''` branch in `is_attr_blank` (and the orchestrator's `user_attr_type` block only value-gates int/float, so both fall through equally). `is_computed_value` is inert (never read by package code). Full queryset+services suite: **614 passed**.

## Result
Brings the QR4d config contract-diff down to only the intentionally-held deltas: 2b/#94 attr shapes (`largest_lesion_size`/`p53_ihc`); `white_blood_cell_count` sane_range (the WBC cells/µL-vs-cells/L host-data contract). Key sets are otherwise equal (D5/metastatic already reconciled).

## Review
`codex review --base 2omop` (clean) + fresh-context Claude subagent (clean/ship — verified behaviour-inert across is_attr_blank + orchestrator, is_computed_value unused).

🤖 Generated with [Claude Code](https://claude.com/claude-code)