### PR TITLE
fix(frontend): render OMOP therapy titles in trial detail, not concept_ids (#331)

### DIFF
--- a/frontend/src/federation/TrialDetailPage.tsx
+++ b/frontend/src/federation/TrialDetailPage.tsx
@@ -78,10 +78,28 @@ function formatValue(value: unknown, options?: TrialDetailField["options"]): str
   return labelOf(value, options);
 }
 
+/** Resolve OMOP-mapped therapy `value` concept_ids to their mirror titles (drug
+ *  names). Falls back to the raw id for any concept the server didn't resolve,
+ *  so a partial mapping never hides a criterion. Used for the OMOP therapy
+ *  regimen/component levels, whose `value` is concept_ids with no `options` map. */
+export function formatOmopConcepts(
+  value: unknown,
+  concepts: NonNullable<TrialDetailField["omopConcepts"]>,
+): string {
+  const byCode = new Map(concepts.map((c) => [String(c.code), c.title]));
+  const ids = Array.isArray(value) ? value : value == null || value === "" ? [] : [value];
+  const parts = ids
+    .filter((v) => v != null && v !== "")
+    .map((v) => byCode.get(String(v)) ?? String(v));
+  return parts.length ? parts.join(", ") : "—";
+}
+
 function EligibilityRow({ field }: { field: TrialDetailField }) {
   const matched = field.matchingType === "matched";
   const notMatched = field.matchingType === "not_matched";
-  const required = formatValue(field.value, field.options);
+  const required = field.omopConcepts?.length
+    ? formatOmopConcepts(field.value, field.omopConcepts)
+    : formatValue(field.value, field.options);
   const yours = formatValue(field.uvalue, field.uoptions ?? field.options);
   const tooltip = FIELD_TOOLTIPS[field.ufield as string] ?? FIELD_TOOLTIPS[field.name];
 

--- a/frontend/src/federation/trialDetailOmop.test.ts
+++ b/frontend/src/federation/trialDetailOmop.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+
+import { formatOmopConcepts } from "./TrialDetailPage";
+
+// The OMOP therapy regimen/component levels arrive as concept_ids in `value`
+// with no `options` map; the server attaches mirror-resolved `omopConcepts`
+// (drug names). The detail row must render those names, not raw concept_ids.
+describe("formatOmopConcepts", () => {
+  const concepts = [
+    { code: 19026972, title: "lenalidomide", vocab: "RxNorm" },
+    { code: 43014237, title: "pomalidomide", vocab: "RxNorm" },
+  ];
+
+  it("resolves concept_id array values to their titles", () => {
+    // value arrives as strings over the wire; codes are numbers — compare stringified
+    expect(formatOmopConcepts(["19026972", "43014237"], concepts)).toBe(
+      "lenalidomide, pomalidomide",
+    );
+  });
+
+  it("resolves a single (non-array) concept_id", () => {
+    expect(formatOmopConcepts("19026972", concepts)).toBe("lenalidomide");
+  });
+
+  it("falls back to the raw id for a concept the server did not resolve", () => {
+    // never hide a criterion just because one code is unmapped
+    expect(formatOmopConcepts(["19026972", "999999"], concepts)).toBe(
+      "lenalidomide, 999999",
+    );
+  });
+
+  it("renders an em dash for empty / missing values", () => {
+    expect(formatOmopConcepts([], concepts)).toBe("—");
+    expect(formatOmopConcepts(null, concepts)).toBe("—");
+    expect(formatOmopConcepts("", concepts)).toBe("—");
+  });
+});

--- a/frontend/src/federation/types.ts
+++ b/frontend/src/federation/types.ts
@@ -101,6 +101,11 @@ export interface TrialDetailField {
   units?: string;
   /** Unit for the patient's `uvalue` — may differ from `units`. */
   uunits?: string;
+  /** OMOP-mirror-resolved titles for the trial's `value` concept_ids on the
+   *  OMOP-mapped therapy levels (regimen/component). The server resolves these
+   *  from the pinned vocab release so the UI shows drug names, not raw ids.
+   *  Source: `matcher.therapy_related_things_match_status` / `_resolve_omop_concepts`. */
+  omopConcepts?: { code: number | string; title: string; vocab?: string }[];
   [key: string]: unknown;
 }
 


### PR DESCRIPTION
## Problem
The federated trial-detail eligibility table rendered the OMOP-mapped therapy rows **"Therapy Components"** / **"Therapy Components Excluded"** as raw concept_ids (`19026972`) instead of drug names (`lenalidomide`). "Therapy Types" nearby rendered fine — only the concept-id-valued levels were affected. Surfaced in the #310 federated-UI QA.

## Root cause
The backend already resolves titles from the pinned vocab mirror and attaches `field.omopConcepts = [{code, title, vocab}]` (matcher.py:398 / `_resolve_omop_concepts`), but the frontend `EligibilityRow` rendered `formatValue(field.value, field.options)` and **ignored `omopConcepts`** — and these levels have no `options` value→label map, so the raw id printed. The vocab mirror's concept_id→title resolution wasn't applied on the presentation side.

## Fix (frontend-only)
- `formatOmopConcepts(value, omopConcepts)` maps each concept_id in `value` to its title, **falling back to the raw id** for any the server didn't resolve (a partial mapping never hides a criterion).
- `EligibilityRow`: `field.omopConcepts?.length ? formatOmopConcepts(...) : formatValue(...)` — non-OMOP fields keep the existing path (no regression).
- Type added to `TrialDetailField`; unit tests (`trialDetailOmop.test.ts`) cover array/single/partial-unresolved/empty. Full frontend suite **30 green**, typecheck clean.

The "Your Value" (patient) column is intentionally left on `formatValue` — `omopConcepts` resolves the *trial's* criterion value, not the patient's.

## Review
codex + fresh-context subagent, both confirm correct/complete.

Closes #331.