### PR TITLE
docs(adr-0002): record Gate 1 release-consistency for OMOP type matching (#286)

### DIFF
--- a/docs/adr/0002-vocab-mirror-consumer-consistency.md
+++ b/docs/adr/0002-vocab-mirror-consumer-consistency.md
@@ -109,6 +109,83 @@ only by the **singleton sync writer** and the **brief pointer-flip** transaction
     stall the mirror; v1 uses the release-match **gate** instead and defers full versioning
     until Phase-T actually consumes the mirror.
 
+### Gate 1 — release-consistency for OMOP drug-class *type* matching (#286)
+
+Mechanism #4 gates **trial↔mirror** at activation. OMOP *type* matching (promop ADR 0002)
+adds a **patient** side: the patient carries pre-expanded HemOnc class `concept_id`s and one
+aggregate `therapy_release_id` (promop VocabularyRelease pk as a decimal string; unanimous of
+contributing therapy lines else null — promop [#394](https://github.com/healthkey-ai/promop/pull/394)).
+This is EXACT issue [#286](https://github.com/healthkey-ai/exact/issues/286) "Gate 1", distinct
+from Gate 2 (per-concept validity of the patient's own ids in the mirror). Codex-adjudicated.
+
+**Architecture: extend mechanism #4's *role* (gate activation on a projection attestation) —
+do NOT read per-trial release tags.** #4's attestation **transport and mutability are still being
+decided in [ADR 0003](0003-cb-exact-convergence-attestation-seam.md)** (Option D — immutable /
+insert-only attestation on the CB-owned trials DB, read cross-DB — is *proposed subject to proof*;
+the **interim posture keeps** today's `publish_projection_attestation(...)` as the single seam and
+**freezes #307**). Gate 1 does not pick that topology; it only *requires* that whatever seam ADR
+0003 lands provide an **immutable, insert-only** attestation binding R to the projection checksum —
+today's mutable upsert into EXACT's `default` DB does not yet meet that, and hardening it is a
+**precondition to enforcement** (gap #2 below), not a reason to remove the working interim seam now.
+If activating mirror release R requires the trial projection to be *verified complete
+for R*, and the patient release == R, then patient and trial share generation R transitively —
+a direct per-trial `patient == trial` compare adds nothing, and a per-trial `omop_therapy_digest`
+mirrored onto EXACT is dead weight at match time (EXACT holds neither a patient digest nor an
+independent expected digest). CB's per-trial `omop_therapy_release_id`+`omop_therapy_digest`
+(cancerbot-org/cancerbot#4667) are **inputs** to CB's release-wide backfill + projection
+attestation, not an EXACT match-time dependency.
+
+**Match-time check (new — the only patient-side gate):** accept `patient.therapy_release_id`
+**only** when it is a `str` of ASCII digits of bounded length, then compare the **canonical
+decimal strings**: `patient.therapy_release_id == str(active_pinned_release())`. Comparing
+strings (not `int(...)`) side-steps two `int()` coercion hazards — `int(True) == 1` /
+`int(1.9) == 1` — that a bare `int(patient.therapy_release_id)` would accept whenever release 1 is
+active. The comparison is **same-namespace by construction**: EXACT's mirror `release_id` *is* the
+promop `VocabularyRelease` pk (`vocab_mirror.models`), the same identifier promop stamps into
+`therapy_release_id`. **Fail-closed** on null / non-string / non-digit / over-length / mismatch, and
+when `active_pinned_release()` is `None` (no active release); the string compare itself never
+raises, so the length bound is defense-in-depth (it also caps the rejected-`int()` path's ~4300-digit
+`ValueError`). Memoized once per request; applied at the same
+three `resolve_type_validation` sites Gate 2 uses — queryset prefilter + the matcher's verdict
+and status-render (display) paths — so a stale patient can't be *shown* matching. Gate 1 is
+**not** redundant
+with Gate 2: only a release check catches a changed drug→class `Is a` expansion that keeps
+every concept valid but shifts the patient's aggregate class set — and thus the overlap.
+
+**Two fail-OPEN gaps in mechanism #4 as prototyped — close BEFORE enforcing:**
+1. **Existence-only attestation is fail-open.** `projection_attested(R)` proves only that a row
+   was inserted, not that EXACT's trial rows are the complete CB projection for R. Activation
+   must **verify** the attestation `checksum`+`trial_count` against a hash EXACT **recomputes
+   from its own trial projection snapshot** (sorted trial identity + `omop_therapy_types_*`
+   values + complete universe) — needs no CB crosswalk, though the canonical hash
+   domain/algorithm is a CB↔EXACT contract (ADR 0003 §"Any option MUST specify"). (Record-then-
+   alarm-on-drift is monitoring, not the gate.)
+2. **Post-attestation trial mutation is fail-open.** Prefer **immutable/versioned** projections
+   (a mutation is a new version ⇒ a new release; the active R stays self-consistent). Invalidating
+   the attestation **alone is insufficient for an already-active R**: the activation gate is not
+   re-run, so `active_release` stays R and Gate 1 keeps accepting R-stamped patients against the
+   changed projection. So the non-versioned alternative must **atomically revoke/block the active
+   release** (fail-closed → 503, accounting for in-flight pinned reads), not merely invalidate the
+   attestation. Do not flip `_PROJECTION_GATE_ENFORCE` without one of these.
+
+The attestation **write/read seam** (how the projection attestation reaches the gate) is **not
+decided here** — it is [ADR 0003](0003-cb-exact-convergence-attestation-seam.md) (leading:
+**Option D** — CB writes the immutable, release-keyed attestation into the CB-owned trials DB and
+EXACT reads it via its existing read-only `trials` connection; **#307's HTTP endpoint is frozen**).
+ADR 0003's monotonic invariant ("activation permitted only when a durable, immutable attestation
+binds R to the projection checksum the gate is activating") is exactly what gap #1's checksum
+verification enforces.
+
+**v1 sequencing (all flag-off):** (1) **carry `therapy_release_id` through EXACT's patient input
+contract first** — register it on the `PatientInfo` field registry + the promop/inline adapters so
+`_build_in_memory` (which filters input against `PatientInfo._meta.get_fields()`) does not drop it,
+and add a `get_user_therapy_release_id()` getter; **without this every patient reads null and
+fail-closes even when the value was supplied.** Then the canonical patient-release parse + all-seams
+decision behind an observe-only enforce toggle (mirrors `_PROJECTION_GATE_ENFORCE`); (2) the attestation seam per
+ADR 0003; (3) activation-time recompute/verify vs the local projection, log-only; (4) projection
+immutability / invalidate-on-mutation; (5) after Phase-T (#263) + the chosen attestation seam
+live: enforce activation verification, then enable `patient == active-release`.
+
 ### Placement
 
 The mirror tables and all mutable sync state live in a **new `default`-DB-owned Django app**


### PR DESCRIPTION
Records the **Gate 1** architecture decision as a section in ADR 0002 (the home of mechanism #4, projection attestation), per #286. Docs-only, no code.

## Decision (codex-adjudicated)

Extend mechanism #4's **role** (gate activation on a projection attestation) — do **not** mirror per-trial `omop_therapy_release_id`/digest onto EXACT and compare per trial (architecture A). Under B, "active mirror R ⇒ trial projection verified-complete for R" + "patient release == R" gives patient↔trial consistency transitively; a per-trial digest is dead weight at match time (EXACT holds neither a patient digest nor an independent expected one). CB #4667's per-trial columns are **inputs** to CB's projection attestation, not an EXACT match dependency.

## What the section adds

- **The patient-side match-time check** (new — the prototype only gates trial↔mirror at activation): `patient.therapy_release_id == str(active_pinned_release())`, string-compared (no `int()` coercion), fail-closed on null/non-digit/over-length/mismatch/active-None; all three `resolve_type_validation` seams; per-request memo. Patient aggregate release = promop #394.
- **Two fail-OPEN gaps to close before enforcing:** (1) existence-only attestation → verify `checksum`+`trial_count` against a hash EXACT recomputes from its own trial projection; (2) post-attestation mutation → immutable/versioned projection, or atomically **revoke the active release** (invalidating the attestation alone doesn't protect an already-active R).
- **Transport deferred to ADR 0003** (Option D proposed subject to proof; interim keeps `publish_projection_attestation` as the single seam; #307 frozen) — the section does not re-decide it.
- **v1 sequencing** incl. the prerequisite to carry `therapy_release_id` through the `PatientInfo` input contract (else `_build_in_memory` filters it out → every patient reads null).
- **Gate 1 ≠ Gate 2:** only a release check catches a changed drug→class `Is a` expansion that keeps concepts valid but shifts the overlap.

## Self-review (two-part, reconciled)

- **codex** `--base 2omop` × 7 rounds: found + fixed `int(True)` coercion [P2], an ADR-0003 #307 contradiction [P2], oversized-int `ValueError` [P2], an over-strong supersession [P2], a patient-input-contract gap [P1], and an active-release-revocation gap [P1]; final pass clean.
- **fresh-context subagent** (final): clean, no P1/P2; two P3 clarity notes folded in (same-namespace `release_id`; length-check as defense-in-depth).