### PR TITLE
fix(matcher): host-agnostic pre_existing get_value accessor (QR4d §3d/L7)

### DIFF
--- a/matcher_app/exact_matching/patient_info/patient_info_attributes.py
+++ b/matcher_app/exact_matching/patient_info/patient_info_attributes.py
@@ -151,8 +151,22 @@ class PatientInfoAttributes:
                 return ['none']
             elif hasattr(self.patient_info, '_pre_existing_condition_categories'):
                 return [c.code for c in self.patient_info._pre_existing_condition_categories]
-            else:
-                return []
+            # Host-agnostic seam (CB, QR4d PIA drain): CB's PatientInfo exposes a
+            # Django related manager, not a pre-populated `_pre_existing_condition_
+            # categories` list. Query the codes so a drained CB PatientInfoAttributes
+            # does not silently blank answered conditions via the `return []` fallback
+            # (docs/exact-queryset-reconciliation-qr4.md §3d / L7). Memoized on the
+            # shared patient_info, matching CB's get_value (Sentry
+            # CANCERBOT-BACKEND-N2); values_list bypasses prefetch identically for
+            # prefetched and unprefetched PatientInfo.
+            related = getattr(self.patient_info, 'pre_existing_condition_categories', None)
+            if related is not None and hasattr(related, 'values_list'):
+                codes = getattr(self.patient_info, '_pre_existing_condition_codes_cache', None)
+                if codes is None:
+                    codes = list(related.values_list('category__code', flat=True))
+                    self.patient_info._pre_existing_condition_codes_cache = codes
+                return list(codes)
+            return []
 
         user_attr_value = getattr(self.patient_info, attr_name)
 

--- a/tests/services/patient_info/test_pre_existing_get_value_seam.py
+++ b/tests/services/patient_info/test_pre_existing_get_value_seam.py
@@ -1,0 +1,64 @@
+"""QR4d §3d / L7 — host-agnostic get_value('pre_existing_condition_categories').
+
+The package must not silently blank answered pre-existing conditions when a
+drained CB PatientInfoAttributes wraps a CB PatientInfo, which exposes a Django
+related manager (values_list('category__code')) rather than the pre-populated
+`_pre_existing_condition_categories` list EXACT's API consumer sets. Cover all
+four shapes.
+"""
+import pytest
+
+from trials.services.patient_info.patient_info import PatientInfo
+from trials.services.patient_info.patient_info_attributes import PatientInfoAttributes
+
+pytestmark = pytest.mark.django_db
+
+
+class _Code:
+    def __init__(self, code):
+        self.code = code
+
+
+class _FakeRelatedManager:
+    """Mimics CB's PatientInfo.pre_existing_condition_categories related manager."""
+    def __init__(self, codes):
+        self._codes = codes
+
+    def values_list(self, field, flat=False):
+        assert field == 'category__code' and flat is True
+        return list(self._codes)
+
+
+def _get(pi):
+    return PatientInfoAttributes(pi).get_value('pre_existing_condition_categories')
+
+
+def test_no_pre_existing_conditions_returns_none_sentinel():
+    assert _get(PatientInfo(no_pre_existing_conditions=True)) == ['none']
+
+
+def test_exact_prepopulated_list_shape():
+    pi = PatientInfo(no_pre_existing_conditions=False)
+    pi._pre_existing_condition_categories = [_Code('diabetes'), _Code('hypertension')]
+    assert _get(pi) == ['diabetes', 'hypertension']
+
+
+def test_cb_related_manager_shape_is_not_silently_blanked():
+    # The §3d/L7 regression: a CB-shaped patient (related manager, no pre-populated
+    # list) must yield its codes, not [].
+    pi = PatientInfo(no_pre_existing_conditions=False)
+    pi.pre_existing_condition_categories = _FakeRelatedManager(['diabetes', 'copd'])
+    assert _get(pi) == ['diabetes', 'copd']
+
+
+def test_cb_related_manager_codes_are_memoized():
+    pi = PatientInfo(no_pre_existing_conditions=False)
+    pi.pre_existing_condition_categories = _FakeRelatedManager(['diabetes'])
+    assert _get(pi) == ['diabetes']
+    assert pi._pre_existing_condition_codes_cache == ['diabetes']
+
+
+def test_no_source_falls_back_to_empty():
+    pi = PatientInfo(no_pre_existing_conditions=False)
+    # No _pre_existing_condition_categories and no values_list-bearing related manager.
+    assert _get(pi) == []


### PR DESCRIPTION
## What (QR4d hard block-gate — §3d / L7)
`PatientInfoAttributes.get_value('pre_existing_condition_categories')` returned `['none']` (if `no_pre_existing_conditions`), else the pre-populated `_pre_existing_condition_categories` list (EXACT's API-consumer shape), else `[]`. CB's `PatientInfo` instead exposes a Django **related manager**, queried as `values_list('category__code')`.

When CB drains its `PatientInfoAttributes` onto the package (the QR4d PIA cutover), the package's `get_value` would hit the `[]` fallback for **every** CB patient → `is_attr_blank` True → **answered pre-existing conditions silently treated as blank and their filter skipped**. A result-set shadow can mask this (another filter may cover it) — it's the §3d/L7 landmine, gated explicitly.

## Fix
Add a host-agnostic branch before the `[]` fallback: when the patient exposes a `pre_existing_condition_categories` attr with `values_list` (duck-typed), query `category__code` and memoize on `_pre_existing_condition_codes_cache` — matching CB's own `get_value` exactly (Sentry CANCERBOT-BACKEND-N2). `values_list` bypasses prefetch identically for prefetched and unprefetched `PatientInfo`.

**Inert for EXACT:** the pre-populated-list branch runs first, and EXACT's plain-field `PatientInfo` has no `values_list`-bearing attr (no `__getattr__` magic) → falls through to `[]` as before. Suite: **619 passed**.

## Tests
Permanent regressions across all four shapes: none-sentinel; EXACT pre-populated; **CB related-manager not-silently-blanked** (the true regression — returns `[]` without the fix); memoization; empty fallback.

## Review
`codex review --base 2omop` (clean) + fresh-context Claude subagent (clean/ship — EXACT-inert confirmed, faithful CB mirror, duck-typing safe, `is None` memo guard correct).

🤖 Generated with [Claude Code](https://claude.com/claude-code)