### PR TITLE
fix(frontend): 'Unknown' for unresolvable OMOP therapy concepts, not raw id

### DIFF
--- a/frontend/src/federation/TrialDetailPage.tsx
+++ b/frontend/src/federation/TrialDetailPage.tsx
@@ -78,10 +78,17 @@ function formatValue(value: unknown, options?: TrialDetailField["options"]): str
   return labelOf(value, options);
 }
 
+/** Shown in place of a therapy concept the vocab mirror could not resolve to a
+ *  name (e.g. a concept EXACT's projection references but promop's snapshot does
+ *  not ship yet — see promop#390). A raw concept_id is meaningless to a user, so
+ *  we render a hint instead. The criterion is still shown (never dropped). */
+export const UNRESOLVED_CONCEPT_LABEL = "Unknown";
+
 /** Resolve OMOP-mapped therapy `value` concept_ids to their mirror titles (drug
- *  names). Falls back to the raw id for any concept the server didn't resolve,
- *  so a partial mapping never hides a criterion. Used for the OMOP therapy
- *  regimen/component levels, whose `value` is concept_ids with no `options` map. */
+ *  names). For any concept the server did not resolve, render a placeholder hint
+ *  rather than the raw id — so the criterion is still visible but not shown as a
+ *  meaningless number. Used for the OMOP therapy regimen/component levels, whose
+ *  `value` is concept_ids with no `options` map. */
 export function formatOmopConcepts(
   value: unknown,
   concepts: NonNullable<TrialDetailField["omopConcepts"]>,
@@ -90,7 +97,7 @@ export function formatOmopConcepts(
   const ids = Array.isArray(value) ? value : value == null || value === "" ? [] : [value];
   const parts = ids
     .filter((v) => v != null && v !== "")
-    .map((v) => byCode.get(String(v)) ?? String(v));
+    .map((v) => byCode.get(String(v)) ?? UNRESOLVED_CONCEPT_LABEL);
   return parts.length ? parts.join(", ") : "—";
 }
 

--- a/frontend/src/federation/trialDetailOmop.test.ts
+++ b/frontend/src/federation/trialDetailOmop.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { formatOmopConcepts } from "./TrialDetailPage";
+import { formatOmopConcepts, UNRESOLVED_CONCEPT_LABEL } from "./TrialDetailPage";
 
 // The OMOP therapy regimen/component levels arrive as concept_ids in `value`
 // with no `options` map; the server attaches mirror-resolved `omopConcepts`
@@ -22,10 +22,17 @@ describe("formatOmopConcepts", () => {
     expect(formatOmopConcepts("19026972", concepts)).toBe("lenalidomide");
   });
 
-  it("falls back to the raw id for a concept the server did not resolve", () => {
-    // never hide a criterion just because one code is unmapped
+  it("renders a placeholder (not the raw id) for a concept the server did not resolve", () => {
+    // never hide a criterion just because one code is unmapped (promop#390), but
+    // a raw concept_id is meaningless to a user — show a hint instead
     expect(formatOmopConcepts(["19026972", "999999"], concepts)).toBe(
-      "lenalidomide, 999999",
+      `lenalidomide, ${UNRESOLVED_CONCEPT_LABEL}`,
+    );
+  });
+
+  it("renders the placeholder for an entirely-unresolved value", () => {
+    expect(formatOmopConcepts(["999999", "888888"], concepts)).toBe(
+      `${UNRESOLVED_CONCEPT_LABEL}, ${UNRESOLVED_CONCEPT_LABEL}`,
     );
   });
 


### PR DESCRIPTION
Follow-up to #332 (merged).

## Problem
When a therapy concept_id in a trial's projection isn't resolvable in the vocab mirror (a known coverage gap — e.g. a **SNOMED** concept EXACT references but promop's HemOnc-only snapshot doesn't ship yet, promop#390), the detail table showed the **raw concept_id** (`4144157`) next to real drug names (`RVD, 4144157, Dara-RVd`). A bare number is meaningless to a user.

## Fix
Render a placeholder (`UNRESOLVED_CONCEPT_LABEL = "Unknown"`) for any concept the mirror couldn't resolve, instead of the raw id. The criterion **stays visible** (never dropped) — just without a meaningless number: `RVD, Unknown, Dara-RVd`.

- "Unknown" over "N/A" — avoids reading as "not required" in the Required column (per codex).
- Named exported constant → the copy is a one-line change.
- Tests: resolved / partial-unresolved / fully-unresolved / empty. Full suite green, typecheck clean.

This is a presentation stopgap; the real fix is producer-side (promop#390 ships the referenced concepts; exact#315 required-roots contract). Frontend-only, no backend change.

Reviewed: codex + fresh-context subagent, both confirm correct. Relates promop#390.