### PR TITLE
feat(omop): Gate 1 v1 step 1 — patient therapy_release_id + observe-only release skew (#286)

### DIFF
--- a/matcher_app/exact_matching/patient_info/patient_info_attributes.py
+++ b/matcher_app/exact_matching/patient_info/patient_info_attributes.py
@@ -275,6 +275,28 @@ class PatientInfoAttributes:
             return None
         return [str(v) for v in val if v is not None and str(v).strip().isdigit()]
 
+    def get_user_therapy_release_id(self):
+        """Return the aggregate therapy-vocab release the patient's class ids were
+        derived against (PROMOP-supplied, promop#394; #286 Gate 1) as a canonical
+        decimal string, or None.
+
+        None when the field is absent OR malformed — anything that is not a
+        non-empty, bounded-length ASCII-digit string (never coerce bool/float/None
+        or an over-length value to a release). The patient-release gate compares
+        this string to ``str(active_pinned_release())``; a None/malformed release
+        is treated as unknown → fail-closed once the gate is enforced. Inert until
+        then.
+        """
+        val = self.get_value('therapy_release_id')
+        # Accept only a real ASCII-decimal string; bool is not str, float is not str,
+        # so both are rejected here (unlike int(...), which would coerce them).
+        # isascii() excludes non-ASCII digits (str.isdigit() accepts superscripts /
+        # Arabic-Indic) — intent is a promop pk. Bound the length so a pathological
+        # digit string can't reach any int() elsewhere.
+        if isinstance(val, str) and val.isascii() and val.isdigit() and 0 < len(val) <= 32:
+            return val
+        return None
+
     @cached_property
     def disease_code(self):
         # Tolerate surrounding whitespace + None/empty (CB #4323): a bare

--- a/matcher_app/exact_matching/querysets/trial.py
+++ b/matcher_app/exact_matching/querysets/trial.py
@@ -126,12 +126,18 @@ def _filter_prior_therapy(scope, value, ctx):
     # Apply the therapy-related-things filter ONLY ONCE per
     # filter_by_patient_info call; ctx tracks the flag.
     if ctx['has_no_prior_therapy'] and not ctx['is_therapies_filter_applied']:
+        # #286 Gate 1 (observe-only, measure once per search): release-gate the class ids.
+        # Gate on the TYPES flag (not the master omop flag): class ids are consumed by
+        # derive/eligible_for_omop_therapy_types only under omop_therapy_types_enabled
+        # (types-off ignores them), so this is behaviour-preserving AND keeps the skew
+        # metric out of the legacy path.
+        from trials.services.omop.patient_release_gate import release_gated_class_ids
         scope = scope.eligible_for_therapy_related_things_from_lines(
             ctx['user_therapies'], ctx['has_no_prior_therapy'],
             patient_component_ids=(ctx['patient_info_attr'].get_user_therapy_component_ids()
                                    if ctx.get('omop_therapy') else None),
-            patient_class_ids=(ctx['patient_info_attr'].get_user_therapy_type_ids()
-                               if ctx.get('omop_therapy') else None),
+            patient_class_ids=release_gated_class_ids(
+                ctx['patient_info_attr'], omop_therapy_types_enabled(), measure=True),
         )
         ctx['is_therapies_filter_applied'] = True
     return scope
@@ -154,12 +160,15 @@ def _filter_therapy_lines_once(scope, _value, ctx):
     # later_therapy, later_therapies) — the actual filter is applied once at
     # most across all of them.
     if not ctx['is_therapies_filter_applied']:
+        # #286 Gate 1 (observe-only, measure once per search): release-gate the class ids.
+        # Gate on the TYPES flag (see _filter_prior_therapy) — behaviour-preserving.
+        from trials.services.omop.patient_release_gate import release_gated_class_ids
         scope = scope.eligible_for_therapy_related_things_from_lines(
             ctx['user_therapies'], ctx['has_no_prior_therapy'],
             patient_component_ids=(ctx['patient_info_attr'].get_user_therapy_component_ids()
                                    if ctx.get('omop_therapy') else None),
-            patient_class_ids=(ctx['patient_info_attr'].get_user_therapy_type_ids()
-                               if ctx.get('omop_therapy') else None),
+            patient_class_ids=release_gated_class_ids(
+                ctx['patient_info_attr'], omop_therapy_types_enabled(), measure=True),
         )
         ctx['is_therapies_filter_applied'] = True
     return scope
@@ -1679,9 +1688,12 @@ class TrialQuerySet(models.QuerySet):
         # are blank and skipped), so the component/type prefilter would be missed. Apply it
         # once here. Legacy is unaffected (flag off → skipped).
         if omop_therapy_enabled() and not is_therapies_filter_applied and not has_no_prior_therapy:
+            # #286 Gate 1 (observe-only): measure the release skew once per search; the
+            # class ids are returned unchanged (no verdict change until enforcement).
+            from trials.services.omop.patient_release_gate import release_gated_class_ids
             component_ids = patient_info_attr.get_user_therapy_component_ids()
-            class_ids = (patient_info_attr.get_user_therapy_type_ids()
-                         if omop_therapy_types_enabled() else None)
+            class_ids = release_gated_class_ids(
+                patient_info_attr, omop_therapy_types_enabled(), measure=True)
             if component_ids or class_ids:
                 # Pass [] for the regimen codes, not user_therapies: this is the
                 # component/class-only path (no regimen lines), and user_therapies also

--- a/tests/services/patient_info/test_therapy_release_id_attr.py
+++ b/tests/services/patient_info/test_therapy_release_id_attr.py
@@ -1,0 +1,72 @@
+"""Unit tests for get_user_therapy_release_id() (promop#394, #286 Gate 1).
+
+The getter is the strict, fail-closed normalizer for the patient's aggregate
+therapy-vocab release: only a non-empty, bounded-length ASCII-digit string is a
+real release; everything else (absent / None / bool / float / non-digit /
+over-length) → None (unknown → the patient-release gate fails closed once
+enforced). It must NEVER int()-coerce (bool/float would slip through).
+"""
+import pytest
+
+from trials.services.patient_info.patient_info import PatientInfo
+from trials.services.patient_info.patient_info_attributes import PatientInfoAttributes
+
+pytestmark = pytest.mark.django_db
+
+
+def _attr(**kw):
+    return PatientInfoAttributes(PatientInfo(**kw))
+
+
+def test_absent_returns_none():
+    assert _attr().get_user_therapy_release_id() is None
+
+
+def test_none_value_returns_none():
+    assert _attr(therapy_release_id=None).get_user_therapy_release_id() is None
+
+
+def test_valid_decimal_string_returned_verbatim():
+    assert _attr(therapy_release_id='7').get_user_therapy_release_id() == '7'
+
+
+def test_multi_digit_release_preserved():
+    assert _attr(therapy_release_id='12345').get_user_therapy_release_id() == '12345'
+
+
+def test_empty_string_returns_none():
+    assert _attr(therapy_release_id='').get_user_therapy_release_id() is None
+
+
+def test_non_digit_string_returns_none():
+    assert _attr(therapy_release_id='7a').get_user_therapy_release_id() is None
+    assert _attr(therapy_release_id='rel-7').get_user_therapy_release_id() is None
+
+
+def test_bool_returns_none():
+    # int(True) == 1 would be a fail-open; the getter rejects a non-str.
+    assert _attr(therapy_release_id=True).get_user_therapy_release_id() is None
+
+
+def test_int_returns_none():
+    # Only a canonical decimal STRING is accepted; a bare int is not the wire shape.
+    assert _attr(therapy_release_id=7).get_user_therapy_release_id() is None
+
+
+def test_float_returns_none():
+    # int(7.0)==7 would be a fail-open; a float is not a str → rejected.
+    assert _attr(therapy_release_id=7.0).get_user_therapy_release_id() is None
+
+
+def test_whitespace_padded_returns_none():
+    assert _attr(therapy_release_id=' 7').get_user_therapy_release_id() is None
+    assert _attr(therapy_release_id='7 ').get_user_therapy_release_id() is None
+
+
+def test_non_ascii_digit_returns_none():
+    # str.isdigit() accepts superscript/Arabic-Indic digits; isascii() rejects them.
+    assert _attr(therapy_release_id='²').get_user_therapy_release_id() is None  # ²
+
+
+def test_over_length_returns_none():
+    assert _attr(therapy_release_id='1' * 33).get_user_therapy_release_id() is None

--- a/tests/services/test_omop_therapy_types_matching.py
+++ b/tests/services/test_omop_therapy_types_matching.py
@@ -49,7 +49,9 @@ def _reset_type_metrics():
     assertion can never inherit accumulated state from an earlier measure=True
     queryset test (the counters are process-global)."""
     from trials.services.omop import type_release_metrics as m
+    from trials.services.omop import patient_release_metrics as prm
     m.reset()
+    prm.reset()
 
 
 @pytest.fixture(autouse=True)
@@ -222,6 +224,46 @@ def test_display_type_excluded_hit_not_matched():
     trial = TrialFactory(disease='multiple myeloma', omop_therapy_types_excluded=[PI_CLASS])
     out = UserToTrialAttrMatcher(trial, pi).therapy_related_things_match_status()
     assert out['therapyTypesExcluded']['status'] == 'not_matched'
+
+
+# ── #286 Gate 1 (patient-release consistency) — OBSERVE-ONLY (no verdict change) ──
+# active mirror release is _RID (the autouse _active_mirror fixture). This slice only
+# measures release skew; enforcement (fail-closing on a mismatch) is a later slice.
+
+@override_settings(**OMOP_TYPES)
+def test_display_release_mismatch_observe_only_unchanged():
+    # A stale patient release must NOT change the verdict/display in this slice.
+    pi = PatientInfo(disease='multiple myeloma', first_line_therapy=REG, prior_therapy='One line',
+                     therapy_component_ids=[int(BORT_CID)], therapy_type_ids=[int(PI_CLASS)],
+                     therapy_release_id=str(_RID + 1))
+    trial = TrialFactory(disease='multiple myeloma', omop_therapy_types_required=[PI_CLASS])
+    out = UserToTrialAttrMatcher(trial, pi).therapy_related_things_match_status()
+    assert out['therapyTypesRequired']['status'] == 'matched'  # unchanged (observe-only)
+
+
+@override_settings(**OMOP_TYPES)
+def test_queryset_release_mismatch_observe_only_records_skew():
+    # A stale-release patient is still matched (observe-only), but the search records
+    # one release-skew shadow event.
+    from trials.services.omop import patient_release_metrics as prm
+    prm.reset()
+    needs = TrialFactory(disease='multiple myeloma', omop_therapy_types_required=[PI_CLASS])
+    pi = PatientInfo(disease='multiple myeloma', prior_therapy='One line',
+                     therapy_type_ids=[int(PI_CLASS)], therapy_release_id=str(_RID + 1))
+    scope, _ = Trial.objects.filter_by_patient_info(pi)
+    assert needs.id in set(scope.values_list('id', flat=True))  # unchanged (observe-only)
+    assert prm.skew_search_count() == 1                         # skew observed
+
+
+@override_settings(**OMOP_TYPES)
+def test_queryset_release_match_no_skew():
+    from trials.services.omop import patient_release_metrics as prm
+    prm.reset()
+    TrialFactory(disease='multiple myeloma', omop_therapy_types_required=[PI_CLASS])
+    pi = PatientInfo(disease='multiple myeloma', prior_therapy='One line',
+                     therapy_type_ids=[int(PI_CLASS)], therapy_release_id=str(_RID))
+    Trial.objects.filter_by_patient_info(pi)
+    assert prm.skew_search_count() == 0
 
 
 @override_settings(**OMOP_TYPES)

--- a/tests/services/test_patient_release_gate.py
+++ b/tests/services/test_patient_release_gate.py
@@ -1,0 +1,178 @@
+"""Unit tests for the #286 Gate 1 patient-release gate (ADR 0002 §Gate 1).
+
+Covers the strict fail-closed resolver, the observe-only release_gated_class_ids
+(returns the class ids unchanged — this slice only measures skew), the per-request
+memo, and the shadow metric. Enforcement (fail-closing on a mismatch) is a later slice.
+"""
+import pytest
+
+from trials.services.patient_info.patient_info import PatientInfo
+from trials.services.patient_info.patient_info_attributes import PatientInfoAttributes
+from trials.services.omop import patient_release_gate as prg
+from trials.services.omop import patient_release_metrics as prm
+
+pytestmark = pytest.mark.django_db
+
+
+def _pin(monkeypatch, active):
+    """Force active_pinned_release() to return `active` (int or None)."""
+    monkeypatch.setattr(prg, 'active_pinned_release', lambda: active)
+
+
+def _attr(**kw):
+    return PatientInfoAttributes(PatientInfo(**kw))
+
+
+# ── resolve_patient_release_ok — strict, fail-closed ────────────────────────────
+
+def test_match_is_ok(monkeypatch):
+    _pin(monkeypatch, 7)
+    assert prg.resolve_patient_release_ok('7') is True
+
+
+def test_mismatch_fails_closed(monkeypatch):
+    _pin(monkeypatch, 7)
+    assert prg.resolve_patient_release_ok('8') is False
+
+
+def test_no_active_release_fails_closed(monkeypatch):
+    _pin(monkeypatch, None)
+    assert prg.resolve_patient_release_ok('7') is False
+
+
+def test_none_patient_release_fails_closed(monkeypatch):
+    _pin(monkeypatch, 7)
+    assert prg.resolve_patient_release_ok(None) is False
+
+
+def test_non_string_patient_release_fails_closed(monkeypatch):
+    _pin(monkeypatch, 1)
+    # int(True)==1 would fail open; the string compare rejects a bool/int/float.
+    assert prg.resolve_patient_release_ok(True) is False
+    assert prg.resolve_patient_release_ok(1) is False
+    assert prg.resolve_patient_release_ok(1.0) is False
+
+
+def test_non_digit_patient_release_fails_closed(monkeypatch):
+    _pin(monkeypatch, 7)
+    assert prg.resolve_patient_release_ok('7a') is False
+
+
+def test_over_length_patient_release_fails_closed(monkeypatch):
+    _pin(monkeypatch, 7)
+    assert prg.resolve_patient_release_ok('1' * 33) is False
+
+
+# ── release_gated_class_ids — observe-only vs enforced ──────────────────────────
+
+def test_disabled_returns_none(monkeypatch):
+    _pin(monkeypatch, 7)
+    a = _attr(therapy_type_ids=[35807295], therapy_release_id='7')
+    assert prg.release_gated_class_ids(a, enabled=False) is None
+
+
+def test_absent_class_ids_returns_none(monkeypatch):
+    _pin(monkeypatch, 7)
+    a = _attr(therapy_release_id='7')  # no therapy_type_ids
+    assert prg.release_gated_class_ids(a, enabled=True) is None
+
+
+def test_empty_class_ids_returns_none_and_records_no_skew(monkeypatch):
+    # Known-empty ([]) is verdict-neutral (== None downstream) AND must NOT record a
+    # skew measurement — an empty patient set is not release-relevant (parity with the
+    # type_release_gate empty early-return).
+    _pin(monkeypatch, 7)
+    prm.reset()
+    a = _attr(therapy_type_ids=[], therapy_release_id='8')  # stale release, but empty set
+    assert prg.release_gated_class_ids(a, enabled=True, measure=True) is None
+    assert prm.total_search_count() == 0  # no measurement recorded
+
+
+def test_consistent_release_returns_class_ids(monkeypatch):
+    _pin(monkeypatch, 7)
+    a = _attr(therapy_type_ids=[35807295, 35807403], therapy_release_id='7')
+    assert prg.release_gated_class_ids(a, enabled=True) == ['35807295', '35807403']
+
+
+def test_mismatch_returns_class_ids_unchanged(monkeypatch):
+    # OBSERVE-ONLY: a stale patient release NEVER changes the class ids (this slice
+    # only measures skew; enforcement is a later slice).
+    _pin(monkeypatch, 7)
+    a = _attr(therapy_type_ids=[35807295], therapy_release_id='8')
+    assert prg.release_gated_class_ids(a, enabled=True) == ['35807295']
+
+
+def test_null_release_returns_class_ids_unchanged(monkeypatch):
+    # OBSERVE-ONLY: patient with types but no release still gets its class ids.
+    _pin(monkeypatch, 7)
+    a = _attr(therapy_type_ids=[35807295])  # no therapy_release_id
+    assert prg.release_gated_class_ids(a, enabled=True) == ['35807295']
+
+
+# ── per-request memo ────────────────────────────────────────────────────────────
+
+def test_memo_dedups_within_request(monkeypatch):
+    _pin(monkeypatch, 7)
+    calls = {'n': 0}
+    real_compute = prg._compute
+
+    def _counting(patient_release_id, active_release_id):
+        calls['n'] += 1
+        return real_compute(patient_release_id, active_release_id)
+    monkeypatch.setattr(prg, '_compute', _counting)
+    with prg.patient_release_check_request_cache():
+        assert prg.resolve_patient_release_ok('7') is True
+        assert prg.resolve_patient_release_ok('7') is True
+    # The memoized work (_compute) runs once for the repeated (release, patient) key.
+    assert calls['n'] == 1
+
+
+def test_no_memo_outside_request_recomputes(monkeypatch):
+    _pin(monkeypatch, 7)
+    calls = {'n': 0}
+    real_compute = prg._compute
+
+    def _counting(patient_release_id, active_release_id):
+        calls['n'] += 1
+        return real_compute(patient_release_id, active_release_id)
+    monkeypatch.setattr(prg, '_compute', _counting)
+    # No request-cache context → no memo → each call recomputes.
+    prg.resolve_patient_release_ok('7')
+    prg.resolve_patient_release_ok('7')
+    assert calls['n'] == 2
+
+
+# ── shadow metric ───────────────────────────────────────────────────────────────
+
+def test_measure_records_skew_on_mismatch(monkeypatch):
+    _pin(monkeypatch, 7)
+    prm.reset()
+    a = _attr(therapy_type_ids=[35807295], therapy_release_id='8')
+    prg.release_gated_class_ids(a, enabled=True, measure=True)
+    assert prm.skew_search_count() == 1
+    assert prm.total_search_count() == 1
+
+
+def test_measure_no_skew_on_match(monkeypatch):
+    _pin(monkeypatch, 7)
+    prm.reset()
+    a = _attr(therapy_type_ids=[35807295], therapy_release_id='7')
+    prg.release_gated_class_ids(a, enabled=True, measure=True)
+    assert prm.skew_search_count() == 0
+    assert prm.total_search_count() == 1
+
+
+def test_no_measure_records_nothing(monkeypatch):
+    _pin(monkeypatch, 7)
+    prm.reset()
+    a = _attr(therapy_type_ids=[35807295], therapy_release_id='8')
+    prg.release_gated_class_ids(a, enabled=True, measure=False)
+    assert prm.total_search_count() == 0
+
+
+# ── input contract: the field survives _build_in_memory ────────────────────────
+
+def test_therapy_release_id_survives_build_in_memory():
+    from trials.services.patient_info.resolve import _build_in_memory
+    pi = _build_in_memory({'therapy_release_id': '7'})
+    assert pi.therapy_release_id == '7'  # not filtered out, not coerced to Decimal

--- a/trials/api/trials_views.py
+++ b/trials/api/trials_views.py
@@ -69,12 +69,16 @@ class TrialsViewSet(viewsets.ReadOnlyModelViewSet):
         from vocab_mirror.release_context import MatchingReleaseContext
         from trials.services.omop.component_category_lookup import component_lookup_request_cache
         from trials.services.omop.type_release_gate import type_validation_request_cache
+        from trials.services.omop.patient_release_gate import patient_release_check_request_cache
         # component_lookup_request_cache: dedup the per-trial component→type lookups
         # within this request without a process-global cache that could go stale in
         # web workers after a sync-job rebuild (ADR 0002 guard #8, #266).
         # type_validation_request_cache: same, for the #286 per-concept class-id
         # release validation (one mirror query per class-id set per request).
-        with MatchingReleaseContext() as ctx, component_lookup_request_cache(), type_validation_request_cache():
+        # patient_release_check_request_cache: same, for the #286 Gate 1 aggregate
+        # patient-release check (one decision per request; observe-only until enforced).
+        with MatchingReleaseContext() as ctx, component_lookup_request_cache(), \
+                type_validation_request_cache(), patient_release_check_request_cache():
             self._release_ctx = ctx
             return super().dispatch(request, *args, **kwargs)
 

--- a/trials/services/omop/patient_release_gate.py
+++ b/trials/services/omop/patient_release_gate.py
@@ -1,0 +1,138 @@
+"""#286 Gate 1 — patient↔mirror release-consistency for OMOP drug-class TYPE matching.
+
+Gate 2 (:mod:`type_release_gate`) validates each of the patient's class concept_ids
+against the pinned vocab-mirror release. Gate 1 is coarser and orthogonal: the
+patient's WHOLE aggregate class set (``therapy_type_ids``) must have been derived
+against the SAME vocabulary generation the mirror is pinned to — else a stale
+generation can silently change the concept_id OVERLAP even when every concept is
+individually valid (a changed drug→class ``Is a`` expansion). See EXACT ADR 0002
+§"Gate 1" (the decided architecture) + issue #286.
+
+The patient carries ONE aggregate release token ``therapy_release_id`` (promop
+VocabularyRelease pk as a decimal string; promop#394, unanimous-of-lines else null).
+The check is a strict string compare against ``str(active_pinned_release())`` — never
+``int(...)`` (which would coerce ``True``→1 / ``1.9``→1 and can raise on an over-long
+digit string). Anything that is not a canonical decimal string equal to the active
+release is **not release-consistent**.
+
+This slice is **OBSERVE-ONLY**: it records the release-skew shadow metric + logs but
+NEVER changes a verdict — :func:`release_gated_class_ids` returns the patient's class
+ids unchanged. ENFORCEMENT (fail-closing type matching on a release mismatch) is a
+deliberately separate later slice: it must be wired holistically across every seam's
+fail-closed chokepoints (the detail-display type map, and the component-only
+``eligible_for_therapy_related_things_from_lines`` short-circuit that returns ``self``
+when both component and class ids are empty) so the queryset and matcher agree — and it
+requires the trial-side attestation gaps closed first (ADR 0002 §Gate 1 gaps 1-2). Not
+bolted on here.
+
+Release resolution + memo mirror :mod:`type_release_gate`: the pinned release comes from
+:func:`active_pinned_release` and the OK decision is memoized per-request via
+:class:`patient_release_check_request_cache` (one decision per (release, patient-release)
+per request; nothing process-global that could straddle a mirror rebuild).
+"""
+import contextvars
+import logging
+
+from vocab_mirror.release_context import active_pinned_release
+
+logger = logging.getLogger(__name__)
+
+# Defensive bound: the patient release is a small VocabularyRelease pk. A string
+# longer than this is malformed → fail-closed (and never reaches any int()).
+_MAX_RELEASE_LEN = 32
+
+# Request-scoped memo (see module docstring). None outside a request → no caching.
+_request_memo: contextvars.ContextVar = contextvars.ContextVar(
+    'patient_release_check_memo', default=None)
+
+
+def _compute(patient_release_id, active_release_id):
+    """The uncached OK decision + observe-only log. True only when the patient's
+    release is a canonical decimal string equal to the active mirror release."""
+    if active_release_id is None:
+        logger.warning(
+            'OMOP-types patient-release check with no active vocab-mirror release; '
+            'not release-consistent (fail-closed when enforced).')
+        return False
+    ok = (
+        isinstance(patient_release_id, str)
+        and patient_release_id.isascii()  # exclude non-ASCII digits (a promop pk is ASCII)
+        and patient_release_id.isdigit()
+        and 0 < len(patient_release_id) <= _MAX_RELEASE_LEN
+        and patient_release_id == str(active_release_id)
+    )
+    if not ok:
+        logger.warning(
+            'OMOP-types patient-release mismatch: patient therapy_release_id=%r vs '
+            'active mirror release=%r; overlap not release-consistent (fail-closed '
+            'when enforced).', patient_release_id, active_release_id)
+    return ok
+
+
+def resolve_patient_release_ok(patient_release_id, measure=False):
+    """True when the patient's aggregate ``therapy_release_id`` is release-consistent
+    with the pinned mirror (strict decimal-string equality), else False (fail-closed).
+
+    ``measure=True`` records the shadow release-skew metric — once per search (the
+    queryset passes it; the per-trial matcher / detail display leave it False so the
+    signal is emitted once per search, not once per trial). Observation only.
+    """
+    release_id = active_pinned_release()
+    memo = _request_memo.get()
+    if memo is None:
+        ok = _compute(patient_release_id, release_id)
+    else:
+        cache_key = (release_id, patient_release_id)
+        if cache_key not in memo:
+            memo[cache_key] = _compute(patient_release_id, release_id)
+        ok = memo[cache_key]
+    if measure:
+        from trials.services.omop.patient_release_metrics import record_patient_release_skew
+        record_patient_release_skew(ok)
+    return ok
+
+
+def release_gated_class_ids(patient_info_attr, enabled, measure=False):
+    """The patient's class ids for type matching, with the #286 Gate 1 release skew
+    OBSERVED (this slice never changes them — enforcement is a later slice).
+
+    Drop-in for ``get_user_therapy_type_ids() if enabled else None`` at every seam
+    that consumes the patient's class ids (queryset prefilter, matcher verdict,
+    detail display):
+
+    - ``enabled`` False → ``None`` (legacy path untouched; byte-identical).
+    - class ids absent (``None``) OR known-empty (``[]``) → ``None`` (nothing to
+      observe; ``[]`` and ``None`` are treated identically by the downstream type
+      filter, so this is verdict-neutral — and it keeps an empty patient set out of
+      the skew metric, mirroring the ``type_release_gate`` empty early-return).
+    - a non-empty set → the class ids **unchanged**, after recording (``measure=True``,
+      the once-per-search queryset call) whether the patient's aggregate release is
+      consistent with the pinned mirror. The return value is identical whether or not
+      the release matches — no verdict change (see module docstring on enforcement).
+    """
+    if not enabled:
+        return None
+    class_ids = patient_info_attr.get_user_therapy_type_ids()
+    if not class_ids:  # None (absent) or [] (known-empty) — nothing to observe
+        return None
+    resolve_patient_release_ok(
+        patient_info_attr.get_user_therapy_release_id(), measure=measure)
+    return class_ids
+
+
+class patient_release_check_request_cache:
+    """Enable the request-scoped patient-release-check memo for a ``with`` block.
+
+    Enter once per request (the trials view does, alongside
+    ``type_validation_request_cache``) so the three seams share one decision; the
+    memo resets on exit, so nothing persists across requests/workers or straddles a
+    mirror rebuild.
+    """
+
+    def __enter__(self):
+        self._token = _request_memo.set({})
+        return self
+
+    def __exit__(self, *exc):
+        _request_memo.reset(self._token)
+        return False

--- a/trials/services/omop/patient_release_metrics.py
+++ b/trials/services/omop/patient_release_metrics.py
@@ -1,0 +1,65 @@
+"""Gate 1 (#286) shadow observation — patient aggregate-release skew.
+
+Pure observation for the OMOP-types cutover (mirrors ``type_release_metrics`` /
+``phase_t_metrics``, #263): **no behaviour change**. Records, once per search,
+whether the patient's aggregate ``therapy_release_id`` (promop#394) is NOT
+release-consistent with the pinned vocab-mirror release — i.e. whether Gate 1
+*would* fail-close the patient's type matching once enforcement lands (a later
+slice). Measures the release-skew rate before then.
+
+Convention (there is no metrics library in this codebase — see
+``type_release_metrics``): the durable signal is the structured, greppable **log
+event**; the process-local counters are for tests / introspection only.
+
+Granularity: recorded **once per search** — the search queryset calls the gate with
+``measure=True``; the per-trial matcher and the detail display leave it off, so one
+release-skewed search emits one log line, not one per trial scored. This mirrors
+``type_release_metrics`` exactly: single-trial ``retrieve`` / detail requests that
+bypass the search queryset are NOT counted in either shadow metric (they are not
+"searches"). Extending both metrics to record once per such request — via a
+request-scoped measured-once guard — is a shared follow-up, out of scope for this
+observe-only slice.
+"""
+import logging
+
+logger = logging.getLogger('omop.patient_release')
+
+# Process-local; tests/introspection only. The durable signal is the log event.
+_skew_search_count = 0    # searches whose patient release was NOT consistent
+_total_search_count = 0   # searches measured (consistent or not)
+
+
+def record_patient_release_skew(release_consistent):
+    """Record one measured search's Gate-1 outcome.
+
+    ``release_consistent``: True when the patient's ``therapy_release_id`` equals the
+    active mirror release (Gate 1 would pass). A False records release skew — the
+    patient's class overlap is not release-consistent and Gate 1 would fail-close it
+    once enforced. Only the False case logs, so the log stays quiet until skew occurs.
+    """
+    global _skew_search_count, _total_search_count
+    _total_search_count += 1
+    if release_consistent:
+        return
+    _skew_search_count += 1
+    logger.info(
+        'patient_release_skew: patient therapy_release_id not consistent with the '
+        'active vocab-mirror release (#286 Gate 1 shadow; would fail-close type '
+        'matching when enforced).')
+
+
+def skew_search_count():
+    """Release-skewed searches recorded since the last reset (tests)."""
+    return _skew_search_count
+
+
+def total_search_count():
+    """Total measured searches since the last reset (tests)."""
+    return _total_search_count
+
+
+def reset():
+    """Reset the process-local counters (tests only)."""
+    global _skew_search_count, _total_search_count
+    _skew_search_count = 0
+    _total_search_count = 0

--- a/trials/services/patient_info/patient_info.py
+++ b/trials/services/patient_info/patient_info.py
@@ -97,6 +97,13 @@ _FIELDS = [
     # None when the consumer has not sent them; consumed as the patient's type
     # match-values once EXACT_OMOP_THERAPY_TYPES is on (#285). Inert until then.
     _f(JSONField, 'therapy_type_ids', default=None),
+    # Aggregate therapy-vocab release the patient's therapy_type_ids were derived
+    # against (promop VocabularyRelease pk as a decimal string; promop#394). One
+    # value for the whole class set (unanimous-of-lines else null). #286 Gate 1
+    # compares it == active_pinned_release(); inert until the patient-release gate
+    # is enforced (ADR 0002 §Gate 1). TextField (not Decimal) to keep the exact
+    # decimal string — resolve._coerce_numerics would coerce a DecimalField.
+    _f(TextField, 'therapy_release_id', default=None),
     _f(DateField, 'later_date'),
     _f(TextField, 'later_outcome'),
     _f(TextField, 'old_supportive_therapies'),


### PR DESCRIPTION
Implements the first, **observe-only** slice of EXACT ADR 0002 §"Gate 1" (issue #286): carry the patient's aggregate therapy-vocab release into the matcher and **observe** its consistency with the pinned vocab-mirror release. **No verdict change** — this slice only measures.

## What

- **PatientInfo**: register `therapy_release_id` (a decimal-string, promop VocabularyRelease pk; promop #394) as a `TextField` so it survives `_build_in_memory`'s field filter (a `DecimalField` would be coerced to `Decimal` by `resolve._coerce_numerics`).
- **`get_user_therapy_release_id()`**: strict, fail-closed normalizer — only a non-empty, bounded-length **ASCII**-decimal string; rejects bool/float/int/non-digit/over-length/non-ASCII-digit (never `int()`-coerces).
- **`patient_release_gate.py`** (new): `resolve_patient_release_ok()` compares the patient release to `str(active_pinned_release())` **as strings** (no `int()` → no bool/float coercion, no oversized-digit `ValueError`), fail-closed; per-request memo mirroring `type_release_gate`. `release_gated_class_ids()` **observes** skew and returns the class ids **unchanged**. The strict resolver is ready for the enforcement slice to consume.
- **`patient_release_metrics.py`** (new): once-per-search shadow skew metric (parity with `type_release_metrics`).
- **`trials_views.py`**: enter `patient_release_check_request_cache` in dispatch.
- **One queryset seam** (component/type once-per-search) records the skew via `measure=True`. `matcher.py` is intentionally **unchanged** (verdict/display untouched).

## Why observe-only (scope)

Enforcement (fail-closing type matching on a release mismatch) is a **deliberately separate later slice**. Review surfaced that a naive enforce path leaks through several fail-closed chokepoints — the detail-display type map and the component-only `eligible_for_therapy_related_things_from_lines` short-circuit that `return self` when both component and class ids are empty — so it must be wired **holistically** across all seams (or the queryset and matcher disagree). It also needs the trial-side attestation gaps closed first (ADR 0002 §Gate 1 gaps 1-2). This slice de-risks the cutover by measuring the release-skew rate first.

## Known limitation

The skew metric fires **once per search** (queryset), exactly like `type_release_metrics`. Single-trial `retrieve`/detail requests that bypass the search queryset are not counted in **either** shadow metric — a shared follow-up, out of scope here.

## Tests

Resolver fail-closed branches, observe-only returns-unchanged, empty-set no-measure, per-request memo (in/out of request), shadow metric, `_build_in_memory` survival, getter normalization, and queryset/display observe-only no-op (+ skew recorded). Full suite **1198 passed**.

## Self-review (two-part, reconciled)

- **codex** `--base 2omop` × 4 rounds: found a display enforce-path fail-open, a metric-scope contamination, and a component-only short-circuit leak [all P2] — which drove the rescope to observe-only (enforce path removed, not patched); final pass clean.
- **fresh-context subagent**: confirmed the observe-only no-op (zero P1, verdict-neutral, resolver fail-closed); prompted the Unicode-digit tightening, the empty-set no-measure fix, and memo/getter test hardening.