### PR TITLE
test(omop): pin end-to-end forwarding of patient therapy_release_id (#286 Gate 1)

### DIFF
--- a/tests/services/patient_info/test_promop_adapter_omop.py
+++ b/tests/services/patient_info/test_promop_adapter_omop.py
@@ -79,3 +79,37 @@ def test_flag_off_leaves_later_therapies_list_untouched():
     lst = [{'therapy': 'pomalidomide'}]
     r = normalize_promop_row(_row(later_therapies=list(lst)))
     assert r['later_therapies'] == lst  # legacy: not concept-remapped
+
+
+# ── #286 Gate 1: the aggregate patient release forwards through the ingest boundary ──
+# ht-phr forwards the whole PROMOP row to EXACT's /normalize-ctomop-row/ untyped, so a
+# new PROMOP field (promop#394 therapy_release_id) reaches the matcher only if it is
+# (1) preserved by normalize_promop_row and (2) a registered PatientInfo field. These
+# pin that end-to-end chain so a future normalize/allowlist change can't silently break
+# Gate 1's patient-release plumbing.
+
+@override_settings(EXACT_OMOP_THERAPY=True)
+def test_therapy_release_id_preserved_by_normalize():
+    r = normalize_promop_row(_row(therapy_type_ids=[35807295], therapy_release_id='7'))
+    assert r['therapy_release_id'] == '7'      # pass-through (not rewritten, not dropped)
+    assert r['therapy_type_ids'] == [35807295]
+
+
+@override_settings(EXACT_OMOP_THERAPY=False)
+def test_therapy_release_id_preserved_by_normalize_flag_off():
+    r = normalize_promop_row(_row(therapy_release_id='7'))
+    assert r['therapy_release_id'] == '7'      # untouched regardless of the OMOP flag
+
+
+@override_settings(EXACT_OMOP_THERAPY=True, EXACT_OMOP_THERAPY_TYPES=True)
+def test_therapy_release_id_reaches_getter_end_to_end():
+    # Full forwarding chain: PROMOP row -> normalize -> build PatientInfo -> getter.
+    # (The flags are prod-realistic context; neither normalize nor the getter reads
+    # them for this field — the getter is flag-independent by design.) Only
+    # therapy_release_id is under test here, so nothing else is put on the row.
+    from trials.services.patient_info.promop_adapter import build_patient_info_from_promop_row
+    from trials.services.patient_info.patient_info_attributes import PatientInfoAttributes
+    norm = normalize_promop_row(_row(therapy_release_id='7'))
+    pi = build_patient_info_from_promop_row(dict(norm))
+    assert pi.therapy_release_id == '7'                                   # survived SKIP_COLUMNS + field filter
+    assert PatientInfoAttributes(pi).get_user_therapy_release_id() == '7'  # readable by Gate 1


### PR DESCRIPTION
## Context

promop #394 emits a new patient field `therapy_release_id` (aggregate therapy-vocab release, a decimal-string). Gate 1 (#337, merged) reads it via `get_user_therapy_release_id()`. This PR closes the **forwarding** question: does the field actually reach the EXACT matcher from PROMOP through ht-phr?

## Finding: no ht-phr change needed — and no EXACT production change either

ht-phr forwards the **whole** PROMOP patient row to EXACT's `/normalize-ctomop-row/` **untyped** (`Record<string, unknown>`, no allowlist/DTO — `FindTrialsPage.tsx`). So `therapy_release_id` flows automatically, via the same whole-row pass-through that already carries `therapy_type_ids`.

It survives the EXACT side because:
1. `normalize_promop_row` rewrites only specific keys and **leaves unknown keys untouched**;
2. `#337` registered `therapy_release_id` as a `PatientInfo` field (a `TextField`, not `DecimalField` — a numeric field would be coerced by `_coerce_numerics`), so `_build_in_memory`'s field filter keeps it, and it is **not** in `SKIP_COLUMNS`.

Verified empirically end-to-end (PROMOP row → normalize → build PatientInfo → getter returns the value).

## What this PR adds

**Test-only.** Regression tests in `test_promop_adapter_omop.py` that pin the end-to-end chain, so a future `normalize` / `SKIP_COLUMNS` / field-registry / field-type change **cannot silently drop the field and break Gate 1's patient-release plumbing**:

- `normalize_promop_row` preserves `therapy_release_id` (OMOP flag on and off);
- PROMOP row → `normalize_promop_row` → `build_patient_info_from_promop_row` → `get_user_therapy_release_id()` round-trips `'7'`.

These are genuine preservation guards (they run the real, drop-capable transforms; they fail if the field is dropped, unregistered, added to `SKIP_COLUMNS`, or switched to a numeric type) — not tautologies.

## Verification

Full suite **1201 passed** (5 existing adapter tests + 3 new).

## Self-review (two-part, reconciled)

- **codex** `--base 2omop`: clean, no actionable defects (test-only, no production change).
- **fresh-context subagent**: confirmed the tests are sound (not tautological, nothing mocked away; faithful to the real ingest path via `build_patient_info_from_promop_row` / `_build_in_memory`); two P3 nits folded in (isolated the end-to-end row to just the field under test; clarified the flags are prod-realistic context).