### PR TITLE
docs(adr): 0003 — ratify Option D (attestation on trials DB, no HTTP channel)

### DIFF
--- a/docs/adr/0003-cb-exact-convergence-attestation-seam.md
+++ b/docs/adr/0003-cb-exact-convergence-attestation-seam.md
@@ -1,6 +1,6 @@
 # ADR 0003: CB↔EXACT convergence — the vocab-mirror / projection-attestation seam
 
-- **Status:** Proposed
+- **Status:** Accepted — **Option D ratified** (2026-08-07). Supersedes #307 (HTTP publish channel) and rejects B/E; retires the C interim posture. Enforce-flip trigger re-homed off Phase-T per [ADR 0004](0004-patient-expansion-tell-dont-ask.md) (see Decision).
 - **Date:** 2026-08-07
 - **Deciders:** cross-repo / platform decision (EXACT + CB owners; the shared-lib
   direction is a HealthKey-platform call, Adam Blum). ADR file lives in EXACT but
@@ -79,7 +79,7 @@ in-process. **Pros:** matches the end-state; one code path. **Cons:** couples CB
 EXACT's `default`-DB connection; larger than the matcher convergence has taken on;
 premature until the QR roadmap reaches the vocab/patient seam.
 
-### D. (Likely best) Attestation on the trials DB — no publish channel
+### D. (Chosen — ratified) Attestation on the trials DB — no publish channel
 CB writes the immutable, release-keyed attestation **into the CB-owned trials DB**
 (it already owns it, writes it in the same unit as sealing the projection); EXACT
 reads it via its **existing read-only trials connection** (`trials` DB alias,
@@ -112,56 +112,103 @@ Keep `publish_projection_attestation(...)` as the **one seam** (mgmt-command
 adapter exists today). **Do not build #307.** Hold until D is proven or refuted,
 then commit to D (or A/B). Not a final answer — an execution posture.
 
-## Decision (proposed)
+## Decision
 
-**Prefer D, subject to proof; adopt C as the interim posture; A/B only if D fails.**
+**Option D is chosen (ratified 2026-08-07): CB writes the immutable, release-keyed
+projection attestation into the CB-owned trials DB; EXACT reads it read-only via the
+existing `trials` alias at activation.** No publish channel: **#307 (HTTP) and B/E are
+closed won't-do**, and the **C interim posture is retired** — D is the committed
+topology.
 
-- **Freeze #307** (do not implement); relabel "blocked on this ADR".
-- **Validate D's (narrow) preconditions** before committing — note a lagging
-  replica is acceptable (fail-closed), so the checks are: (i) releases are
-  immutable, `release_id` never reused; (ii) attestations are insert-only (no
-  delete/update — enforce at DB grants); (iii) the row binds R to the projection
-  checksum the gate activates. If all hold, **D wins** and #307 + B/E are closed
-  won't-do. If any fails, choose **A or B explicitly** — before enforcement.
-- **De-risk with a spike — DONE (2026-08-07, read path proven).** In the local HT
-  stack a `ProjectionAttestation` table was created on the `trials` DB
-  (`exact_trials`) with a CB-side write for the active release; EXACT read it back
-  through the `trials` alias with the **same `ProjectionAttestation` model and zero
-  `default`-DB schema** — attested release → `True`, unattested → `False`
-  (fail-closed). Confirmed a genuine cross-DB read (`trials`=`exact_trials` vs
-  `default`=`exact`; no row on `default`), and that raw DDL on the trials DB works
-  under the router's `allow_migrate=False` (so CB owns the table, EXACT only reads).
-  The read path is **not** the risk; the remaining D preconditions are policy —
-  release-immutability + insert-only attestations — not code.
-- The **#265 enforce flip stays gated on BOTH** this topology decision *and*
-  Phase-T (#263); never flip enforce without a working publish/read path for the
-  chosen option (else every activation fail-closes permanently).
+Basis for ratification:
+- **The read path is proven (spike, 2026-08-07).** In the local HT stack a
+  `ProjectionAttestation` table was created on the `trials` DB (`exact_trials`) with a
+  CB-side write for the active release; EXACT read it back through the `trials` alias
+  with the **same model and zero `default`-DB schema** — attested → `True`, unattested
+  → `False` (fail-closed). Confirmed a genuine cross-DB read (`trials`=`exact_trials`
+  vs `default`=`exact`; no row on `default`), and that raw DDL on the trials DB works
+  under the router's `allow_migrate=False` (CB owns the table, EXACT only reads).
+- **The remaining preconditions are policy, not code, and are hereby accepted as
+  commitments** (item list below): (i) releases immutable, `release_id` never reused;
+  (ii) attestations insert-only (no delete/update — enforced at DB grants); (iii) the
+  row binds R to the projection checksum the gate activates. A lagging read replica is
+  acceptable — being monotonic, D can only *miss* an attestation (false-negative,
+  fail-closed), never fabricate one; mount strong-consistency is **not** required.
 
-## Any option MUST specify (decision content)
+Implementation delta from today (a follow-up, not a re-decision):
+- The `ProjectionAttestation` model + gate (#265 / PR #306) live on EXACT's **`default`**
+  DB today, written by the `publish_projection_attestation` management command. Under D
+  the table **relocates to the CB-owned `trials` DB**, written by CB in the same unit as
+  sealing the projection; EXACT keeps a **read-only** model routed to `trials`.
+- **Routing is not automatic** (relocation-issue detail): `TrialsDatabaseRouter` keys on
+  `app_label == 'trials'`, but `ProjectionAttestation` is a **`vocab_mirror`** model, so
+  ordinary ORM reads still hit `default`. The relocation must do one of: move the
+  read model into the `trials` app, add an explicit router exception for it, or read via
+  `.using('trials')`. It must be read-only from EXACT (`allow_migrate=False` — CB owns
+  the DDL). Miss this and the moved table reads as missing → the gate fail-closes every
+  activation.
 
-1. **Attestation identity/schema:** `release_id`, projection checksum (algorithm +
-   scope), schema/vocab version, source/run id, producer version, timestamp.
-2. **Lifecycle:** who seals a release and when the attestation is written; delete/
-   update prohibited (enforce at DB-permission level).
-3. **Conflict semantics:** unique key + immutable insert; a second *different*
-   attestation for R is an **incident**, never an overwrite (idempotent re-publish
-   of the *same* attestation is fine).
-4. **Read semantics (D):** required mount consistency + tolerated lag behaviour.
-5. **Trust boundary:** which principal may attest — restrict writes to the
-   release-finalization workflow, not arbitrary CB app credentials.
-6. **Failure policy:** fail closed + alert + retry/reconciliation + runbook.
-7. **Revocation/rollback:** can an attested release be disabled, and where does
-   that (mutable) revocation state live — distinct from the immutable attestation.
+Enforce-flip trigger (corrected for [ADR 0004](0004-patient-expansion-tell-dont-ask.md)):
+- #265's enforce flip (`_PROJECTION_GATE_ENFORCE`) was gated on BOTH this topology
+  decision **and Phase-T (#263)**. **Phase-T is redirected by ADR 0004** (EXACT no
+  longer expands regimens on the eligibility path), so the Phase-T half of the trigger
+  is void. Re-home it: flip enforce only when **(a)** the D read path is live in the
+  target environment; **(b)** the mirror is genuinely on the verdict path there — i.e.
+  while the `type_release_gate` (#286) is enabled (ADR 0004's transitional posture); and
+  **(c)** the gate actually **verifies the projection checksum**, not just row existence.
+  (c) is load-bearing: `projection_attested()` is an existence-only check today and
+  `checksum` is an optional/blank-default column, so enforcing on existence alone would
+  activate on a blank or mismatched attestation. Before the flip, the gate MUST bind +
+  verify `release_id` → `checksum` (and reject blank/mismatch), and attestations MUST be
+  insert-only + immutable (per Decision content). If/when `type_release_gate` retires
+  (ADR 0004 end-state) with no mirror-backed verdict dependency left, the projection-gate
+  enforce obligation falls away with it. Never flip enforce without a working, checksum-
+  verifying read path (else every activation fail-closes permanently, or worse, fail-opens
+  on a blank row).
+
+## Decision content (D, ratified)
+
+The commitments the chosen option must pin, resolved for D. Where the existing
+`ProjectionAttestation` model (#265 / PR #306) already answers, that is noted; open
+items are impl detail for the relocation issue, not re-decisions.
+
+1. **Attestation identity/schema:** `release_id` (unique), projection `checksum`,
+   `run_id`, `trial_count`, timestamp — the existing model's fields. The checksum
+   **algorithm + scope** and any `schema/vocab version` + `producer version` columns
+   are finalized in the relocation issue (add columns if the CB seal needs them);
+   `release_id` + `checksum` are the load-bearing pair the gate binds.
+2. **Lifecycle:** CB writes the attestation **in the same unit as sealing the
+   projection** for release R (after its release-wide backfill verifies every trial is
+   stamped for R). Delete/update prohibited — enforced at DB-permission level on the
+   CB-owned `trials` DB.
+3. **Conflict semantics:** unique `release_id` + insert-only. Idempotent re-publish of
+   the *same* attestation is fine; a second *different* attestation for R is an
+   **incident**, never an overwrite (the DB unique constraint makes the overwrite
+   impossible; the incident is the surfaced signal).
+4. **Read semantics (D):** EXACT reads through the `trials` alias at activation. A
+   **lagging replica is tolerated** (monotonic → fail-closed false-negatives only);
+   **mount strong-consistency is NOT required**. The gate reads the single row for the
+   activating `release_id`; absent/mismatched → do not activate (fail closed).
+5. **Trust boundary:** writes restricted to CB's **release-finalization workflow**, not
+   arbitrary CB app credentials — a DB grant on the `trials` DB scoped to that principal.
+6. **Failure policy:** fail closed + alert on missing/mismatched attestation; keep the
+   last consistent bundle; runbook for reconciliation. (Enforce stays observe-only until
+   its trigger — see Decision.)
+7. **Revocation/rollback:** an attested release is disabled via **mutable revocation
+   state kept separate** from the immutable attestation (e.g. the mirror
+   generation's own state / an EXACT-side revocation list), so revocation never mutates
+   the insert-only attestation row. Concrete location finalized in the relocation issue.
 
 ## Consequences
 
-- **Positive:** no speculative HTTP surface; D (if it holds) is the cheapest,
+- **Positive:** no speculative HTTP surface (#307 avoided); D is the cheapest,
   most-correct shape (co-located write, no new channel); the decision + invariant
   are captured, not implicit in #307.
-- **Negative / risk:** the enforce path stays parked until D is proven or A/B
-  chosen. **Hard trigger:** make the choice *before* the first production cutover
-  that turns enforcement on (or Phase-T landing) — whichever comes first — so this
-  never blocks a release under pressure.
+- **Remaining risk (now scoped, not open-ended):** the topology is decided, so the
+  parked work is concrete — **relocate the attestation to the `trials` DB** (the
+  follow-up issue) and, separately, **flip enforce** once its (re-homed) trigger holds.
+  The old "make the choice before the first production cutover" hard-trigger is
+  **discharged** (the choice is made). Phase-T is no longer a trigger input (ADR 0004).
 - **Follow-ups:** align with promop `healthkey-core` (#46/#54) on package
   ownership of the vocab/attestation seam; update CB
   `docs/exact-downstream-and-omop.md` with the chosen seam.
@@ -172,8 +219,12 @@ then commit to D (or A/B). Not a final answer — an execution posture.
    (2026-08-07):** the cross-DB read path is proven (see the spike note under
    Decision). What remains for D is a policy guarantee (release-immutability +
    insert-only), not a technical unknown.
-2. Does CB embedding `exact_matching` drag in an EXACT-`default`-DB connection, or
-   are the matcher seam and vocab seam independent (making B a separate later bite)?
-3. Governance: this ADR lives in EXACT for now, but the decision binds CB + promop
-   `healthkey-core` — confirm whether it should be ratified as a cross-repo/platform
-   ADR (coordinates with promop #254).
+2. ~~Does CB embedding `exact_matching` drag in an EXACT-`default`-DB connection…~~
+   **Moot for this decision:** D uses no embed and no `default`-DB write, so the
+   matcher-seam / vocab-seam independence no longer gates the topology choice. (Still a
+   real question for the `exact_matching` convergence work — tracked there, not here.)
+3. **Governance — decided:** ratified here as **EXACT's consumer-side decision**; the
+   attestation contract it depends on (CB writes the `trials`-DB row) is a **CB
+   commitment** to coordinate via CB `docs/exact-downstream-and-omop.md` + promop
+   `healthkey-core` (#46/#54, #254). A cross-repo/platform re-ratification is optional
+   follow-up, not a blocker — EXACT's read-side gate is fully specified by this ADR.


### PR DESCRIPTION
## What

Moves **ADR 0003** from *Proposed* to **Accepted**, ratifying **Option D**: CB writes the immutable, release-keyed projection attestation into the **CB-owned `trials` DB**; EXACT reads it **read-only** via the existing `trials` alias at mirror activation. No publish channel.

## Why now

ADR 0003 named this the **pre-cutover hard trigger** ("make the choice before the first production cutover"). With ADR 0004 merged (#338) and the D read-path spike proven, the topology can be committed so it never blocks a release under pressure.

## What the ratification settles

- **Option D chosen; #307 (HTTP publish) + options B/E closed won't-do; the C interim posture retired.**
- The 7 "decision content" items resolved concretely for D, grounded in the existing `ProjectionAttestation` model (#265 / PR #306).
- **Implementation delta** (follow-up, not a re-decision): relocate the attestation table from EXACT's `default` DB to the CB-owned `trials` DB → tracked in **#340** (supersedes #307's HTTP work).
- **Enforce-trigger corrected for ADR 0004:** Phase-T (#263) is redirected, so the enforce flip re-homes onto the mirror-on-verdict-path lifetime (the `type_release_gate`/#286), and gains an explicit **checksum-verification** prerequisite (existence-only gating would activate on a blank/mismatched row).

## Follow-ups
- **#340** — implement Option D (relocate attestation to `trials` DB, read-only cross-DB gate, checksum verification, stale-comment cleanup).
- **#307** — closed as superseded by this ADR.

## Review

Doc-only. Two-part self-review before push: **codex** (`--base origin/2omop`) + a **fresh-context Claude subagent**, reconciled:
- codex **P1** (checksum must be verified before enforce, not just row existence) + **P2** (routing: `TrialsDatabaseRouter` keys on `app_label=='trials'`, so the `vocab_mirror` model needs an explicit route) — both folded into the ADR + #340.
- Subagent verified all 5 code claims (attestation on `default` today; model fields; `allow_migrate=False`; `_PROJECTION_GATE_ENFORCE=False` at activation.py:161; ADR 0004 redirect) and caught that ADR 0004's links were dangling on my stale branch base — fixed by rebasing onto the post-#338 `origin/2omop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
