### PR TITLE
fix(matcher): master-gate the #286 release-gate import in the therapy dispatch

### DIFF
--- a/matcher_app/exact_matching/querysets/trial.py
+++ b/matcher_app/exact_matching/querysets/trial.py
@@ -121,23 +121,37 @@ def _filter_tumor_grade(scope, value, _ctx):
     return scope.eligible_for_tumor_grade(str(value).lower())
 
 
+def _omop_therapy_ids(ctx):
+    """The patient's OMOP therapy component + class ids for the regimen dispatch, or
+    ``(None, None)`` in legacy mode.
+
+    #286 Gate 1 (observe-only release-skew metric) is imported and run ONLY in OMOP mode
+    (``ctx['omop_therapy']`` — the master flag). ``release_gated_class_ids`` short-circuits
+    to ``None`` without measuring when the TYPES flag is off, so master-gating the whole
+    thing is behaviour-preserving (legacy already resolved to ``None``). It also keeps the
+    ``trials.services.omop.patient_release_gate`` import off the legacy path, so a host
+    without the OMOP release-gate infra (CB, at the QR4d orchestrator drain) can run this
+    dispatch instead of ImportError-ing on a module it doesn't ship.
+    """
+    if not ctx.get('omop_therapy'):
+        return None, None
+    from trials.services.omop.patient_release_gate import release_gated_class_ids
+    component_ids = ctx['patient_info_attr'].get_user_therapy_component_ids()
+    class_ids = release_gated_class_ids(
+        ctx['patient_info_attr'], omop_therapy_types_enabled(), measure=True)
+    return component_ids, class_ids
+
+
 def _filter_prior_therapy(scope, value, ctx):
     scope = scope.eligible_for_prior_therapy(value)
     # Apply the therapy-related-things filter ONLY ONCE per
     # filter_by_patient_info call; ctx tracks the flag.
     if ctx['has_no_prior_therapy'] and not ctx['is_therapies_filter_applied']:
-        # #286 Gate 1 (observe-only, measure once per search): release-gate the class ids.
-        # Gate on the TYPES flag (not the master omop flag): class ids are consumed by
-        # derive/eligible_for_omop_therapy_types only under omop_therapy_types_enabled
-        # (types-off ignores them), so this is behaviour-preserving AND keeps the skew
-        # metric out of the legacy path.
-        from trials.services.omop.patient_release_gate import release_gated_class_ids
+        component_ids, class_ids = _omop_therapy_ids(ctx)
         scope = scope.eligible_for_therapy_related_things_from_lines(
             ctx['user_therapies'], ctx['has_no_prior_therapy'],
-            patient_component_ids=(ctx['patient_info_attr'].get_user_therapy_component_ids()
-                                   if ctx.get('omop_therapy') else None),
-            patient_class_ids=release_gated_class_ids(
-                ctx['patient_info_attr'], omop_therapy_types_enabled(), measure=True),
+            patient_component_ids=component_ids,
+            patient_class_ids=class_ids,
         )
         ctx['is_therapies_filter_applied'] = True
     return scope
@@ -160,15 +174,11 @@ def _filter_therapy_lines_once(scope, _value, ctx):
     # later_therapy, later_therapies) — the actual filter is applied once at
     # most across all of them.
     if not ctx['is_therapies_filter_applied']:
-        # #286 Gate 1 (observe-only, measure once per search): release-gate the class ids.
-        # Gate on the TYPES flag (see _filter_prior_therapy) — behaviour-preserving.
-        from trials.services.omop.patient_release_gate import release_gated_class_ids
+        component_ids, class_ids = _omop_therapy_ids(ctx)
         scope = scope.eligible_for_therapy_related_things_from_lines(
             ctx['user_therapies'], ctx['has_no_prior_therapy'],
-            patient_component_ids=(ctx['patient_info_attr'].get_user_therapy_component_ids()
-                                   if ctx.get('omop_therapy') else None),
-            patient_class_ids=release_gated_class_ids(
-                ctx['patient_info_attr'], omop_therapy_types_enabled(), measure=True),
+            patient_component_ids=component_ids,
+            patient_class_ids=class_ids,
         )
         ctx['is_therapies_filter_applied'] = True
     return scope

--- a/tests/querysets/test_custom_search_dispatch.py
+++ b/tests/querysets/test_custom_search_dispatch.py
@@ -23,7 +23,19 @@ from trials.querysets.trial import (
     _csv,
     _csv_stripped,
     _filter_therapy_lines_once,
+    _omop_therapy_ids,
 )
+
+
+def test_omop_therapy_ids_legacy_returns_none_without_importing_release_gate(monkeypatch):
+    """QR4d host-agnostic gate: in legacy mode (omop master flag off) the therapy
+    dispatch must NOT import trials.services.omop.patient_release_gate — a host that
+    doesn't ship it (CB, at the orchestrator drain) would ImportError otherwise.
+    Simulate its absence and assert the legacy path still yields (None, None)."""
+    import sys
+    monkeypatch.setitem(sys.modules, 'trials.services.omop.patient_release_gate', None)
+    assert _omop_therapy_ids({'omop_therapy': False}) == (None, None)
+    assert _omop_therapy_ids({}) == (None, None)  # missing key == off
 
 
 # Stateful handlers that take ctx — they call multiple queryset methods or

--- a/trials/querysets/trial.py
+++ b/trials/querysets/trial.py
@@ -7,4 +7,5 @@ from exact_matching.querysets.trial import (  # noqa: F401
     _csv,
     _csv_stripped,
     _filter_therapy_lines_once,
+    _omop_therapy_ids,
 )


### PR DESCRIPTION
## What (QR4d orchestrator-drain unblocker)
The therapy-line dispatch functions `_filter_prior_therapy` and `_filter_therapy_lines_once` (module-level, in `_CUSTOM_SEARCH_DISPATCH`) imported `trials.services.omop.patient_release_gate` (`release_gated_class_ids`, #286 Gate-1 observe-only release-skew) **unconditionally** for every therapy patient. `release_gated_class_ids` short-circuits to `None` (no measure) when the TYPES flag is off — a no-op in legacy — but the top-of-block **import** still executes, `ImportError`-ing on a host that doesn't ship the OMOP release-gate infra.

Surfaced by the QR4d orchestrator-drain flag-on shadow (CB running the package dispatch): `ModuleNotFoundError: trials.services.omop.patient_release_gate`.

## Fix
Extract `_omop_therapy_ids(ctx)`: compute the component + class ids **only in OMOP mode** (`ctx['omop_therapy']`, the master flag), returning `(None, None)` in legacy — so the import never runs off the OMOP path. The `patient_component_ids` were already master-gated inline; this makes the class ids symmetric. The #224 component-only post-loop already imports inside `omop_therapy_enabled()`, so it needed no change.

## Behaviour-preserving (verified by codex + fresh-context review)
- **master-on:** helper returns the identical `(component_ids, release_gated_class_ids(..., omop_therapy_types_enabled(), measure=True))` — inner TYPES gate retained.
- **master-off:** `omop_therapy_types_enabled() = omop_therapy_enabled() AND …` is provably False, so the old `release_gated_class_ids(attr, False)` already short-circuited to `None` with no measurement, and component was already `None`. New `(None, None)` is **byte-identical** — no spurious skew measure — only the needless import is skipped.

## Tests
`_omop_therapy_ids` returns `(None, None)` in legacy **even with `patient_release_gate` absent from `sys.modules`** (host-agnostic guarantee). Suite: **696 passed** (incl OMOP-on tests).

> Note: this unblocks the **import**; the flag-on shadow's next blocker is a CB-side signature divergence (`eligible_for_therapy_related_things_from_lines` missing `patient_component_ids`/`patient_class_ids`), handled separately.

## Review
`codex review --base 2omop` (clean) + fresh-context Claude subagent (clean/ship — byte-identical both modes, inner types gate intact, sys.modules test proves no-import).

🤖 Generated with [Claude Code](https://claude.com/claude-code)