### PR TITLE
feat(omop): Gate 1 v1 step 2 — patient-release enforcement (flag-off) (#286)

### DIFF
--- a/matcher_app/exact_matching/matcher.py
+++ b/matcher_app/exact_matching/matcher.py
@@ -368,8 +368,12 @@ class UserToTrialAttrMatcher:
             type_mismatch_status = 'not_matched'
             raw_class_ids = self.patient_info_attr.get_user_therapy_type_ids()
             if raw_class_ids is not None:
+                # Gate 1 release passed explicitly (this seam holds the attr), parity
+                # with the verdict; Gate 2 per-concept validation as before.
                 from trials.services.omop.type_release_gate import resolve_type_validation
-                validated, has_unvalidated = resolve_type_validation(raw_class_ids)
+                validated, has_unvalidated = resolve_type_validation(
+                    raw_class_ids,
+                    patient_release_id=self.patient_info_attr.get_user_therapy_release_id())
                 types_map = {k: v for k, v in therapy_types_to_therapy.items() if k in validated}
                 types_excluded_conservative = has_unvalidated
 
@@ -484,9 +488,11 @@ class UserToTrialAttrMatcher:
             if not has_no_prior_therapy:
                 return 'unknown'
             return 'matched'
-        # Concrete patient class ids ([] or a list) → #286 per-concept validation.
+        # Concrete patient class ids ([] or a list) → #286 per-concept validation, plus
+        # Gate 1 release-consistency (release passed explicitly — this seam holds the attr).
         from trials.services.omop.type_release_gate import resolve_type_validation
-        validated, has_unvalidated = resolve_type_validation(type_values)
+        validated, has_unvalidated = resolve_type_validation(
+            type_values, patient_release_id=self.patient_info_attr.get_user_therapy_release_id())
         # excluded: never drop an unvalidated id → conservatively reject.
         if excluded_list and has_unvalidated:
             return 'not_matched'

--- a/matcher_app/exact_matching/querysets/trial.py
+++ b/matcher_app/exact_matching/querysets/trial.py
@@ -1545,6 +1545,20 @@ class TrialQuerySet(models.QuerySet):
         return self.filter(researchers_emails__has_any_keys=[email.lower()])
 
     def filter_by_patient_info(self, patient_info, add_traces=False):
+        # #286 Gate 1: bind the patient's aggregate release for the whole eligibility
+        # build so the OMOP-type prefilter (resolve_type_validation) enforces
+        # release-consistency for EVERY caller of this method — the HTTP view (via
+        # filtered_trials), the embedded ExactMatcher backend, mgmt commands, and direct
+        # callers. Reset on exit (no cross-call leak). The matcher verdict / detail-display
+        # seams pass the release explicitly instead (they hold the patient_info_attr).
+        from exact_matching.patient_info.patient_info_attributes import PatientInfoAttributes
+        from trials.services.omop.patient_release_gate import patient_release_scope
+        release = (PatientInfoAttributes(patient_info).get_user_therapy_release_id()
+                   if patient_info is not None else None)
+        with patient_release_scope(release):
+            return self._filter_by_patient_info(patient_info, add_traces=add_traces)
+
+    def _filter_by_patient_info(self, patient_info, add_traces=False):
         from exact_matching.patient_info.patient_info_attributes import PatientInfoAttributes
 
         traces = []

--- a/tests/services/test_omop_therapy_types_matching.py
+++ b/tests/services/test_omop_therapy_types_matching.py
@@ -7,6 +7,8 @@ promop#370). With EXACT_OMOP_THERAPY + EXACT_OMOP_THERAPY_TYPES on:
 - derive returns the consumer's class concept_ids as type_values (no category lookup);
 - matching is class-concept_id overlap, FAIL-CLOSED on unknown/empty patient classes.
 """
+from contextlib import contextmanager
+
 import pytest
 from django.test import override_settings
 
@@ -264,6 +266,197 @@ def test_queryset_release_match_no_skew():
                      therapy_type_ids=[int(PI_CLASS)], therapy_release_id=str(_RID))
     Trial.objects.filter_by_patient_info(pi)
     assert prm.skew_search_count() == 0
+
+
+# ── #286 Gate 1 ENFORCED (toggle on) — fail-closed at every seam, parity ────────
+# The patient carries its release on therapy_release_id; the matcher verdict/detail
+# seams read it via the attr (explicit), the queryset reads it from the scope
+# filter_by_patient_info binds. active mirror release = _RID. `+1` = a stale release.
+
+@contextmanager
+def _enforce_gate1(monkeypatch):
+    from trials.services.omop import patient_release_gate as prg
+    monkeypatch.setattr(prg, '_PATIENT_RELEASE_GATE_ENFORCE', True)
+    yield
+
+
+def _pi(release, **kw):
+    return PatientInfo(disease='multiple myeloma', therapy_component_ids=[int(BORT_CID)],
+                       therapy_type_ids=[int(PI_CLASS)], therapy_release_id=release, **kw)
+
+
+@override_settings(**OMOP_TYPES)
+def test_enforce_verdict_required_stale_not_matched(monkeypatch):
+    with _enforce_gate1(monkeypatch):
+        trial = TrialFactory(disease='multiple myeloma', omop_therapy_types_required=[PI_CLASS])
+        assert _match(trial, _pi(str(_RID + 1))) == 'not_matched'  # raw overlaps, release stale
+
+
+@override_settings(**OMOP_TYPES)
+def test_enforce_verdict_excluded_stale_not_matched(monkeypatch):
+    with _enforce_gate1(monkeypatch):
+        trial = TrialFactory(disease='multiple myeloma', omop_therapy_types_excluded=[PI_CLASS])
+        assert _match(trial, _pi(str(_RID + 1))) == 'not_matched'  # conservative excluded
+
+
+@override_settings(**OMOP_TYPES)
+def test_enforce_consistent_release_matches(monkeypatch):
+    # Patient release == active mirror release → Gate 1 passes; Gate 2 alone governs.
+    with _enforce_gate1(monkeypatch):
+        trial = TrialFactory(disease='multiple myeloma', omop_therapy_types_required=[PI_CLASS])
+        assert _match(trial, _pi(str(_RID))) == 'matched'
+
+
+@override_settings(**OMOP_TYPES)
+def test_enforce_display_stale_not_matched(monkeypatch):
+    with _enforce_gate1(monkeypatch):
+        trial = TrialFactory(disease='multiple myeloma', omop_therapy_types_required=[PI_CLASS])
+        out = UserToTrialAttrMatcher(trial, _pi(str(_RID + 1))).therapy_related_things_match_status()
+        assert out['therapyTypesRequired']['status'] == 'not_matched'
+
+
+@override_settings(**OMOP_TYPES)
+def test_enforce_queryset_stale_drops_required_type(monkeypatch):
+    # The queryset reads the release from the scope filter_by_patient_info binds.
+    with _enforce_gate1(monkeypatch):
+        needs = TrialFactory(disease='multiple myeloma', omop_therapy_types_required=[PI_CLASS])
+        open_ = TrialFactory(disease='multiple myeloma', omop_therapy_types_required=[])
+        pi = _pi(str(_RID + 1), prior_therapy='One line')
+        scope, _ = (Trial.objects.filter(id__in=[needs.id, open_.id])
+                    .filter_by_patient_info(pi))
+        assert set(scope.values_list('id', flat=True)) == {open_.id}  # required dropped
+
+
+@override_settings(**OMOP_TYPES)
+def test_enforce_queryset_matcher_parity_stale(monkeypatch):
+    # The prefilter and the verdict must AGREE under enforcement (no admit-then-reject).
+    with _enforce_gate1(monkeypatch):
+        match = TrialFactory(disease='multiple myeloma', omop_therapy_types_required=[PI_CLASS])
+        pi = _pi(str(_RID + 1), prior_therapy='One line')
+        scope, _ = Trial.objects.filter(id=match.id).filter_by_patient_info(pi)
+        assert set(scope.values_list('id', flat=True)) == set()  # queryset drops it
+        assert _match(match, pi) == 'not_matched'                 # matcher agrees
+
+
+@override_settings(**OMOP_TYPES)
+def test_enforce_component_only_stale_fail_closed(monkeypatch):
+    # Component-less stale patient (only type_ids): the compose approach keeps the raw
+    # class ids flowing, so the eligible_for_therapy_related_things_from_lines short-
+    # circuit is NOT hit and the type prefilter fails closed (the step-1 bug that the
+    # class-id-gating approach caused). Parity with the matcher.
+    with _enforce_gate1(monkeypatch):
+        needs = TrialFactory(disease='multiple myeloma', omop_therapy_types_required=[PI_CLASS])
+        pi = PatientInfo(disease='multiple myeloma', prior_therapy='One line',
+                         therapy_type_ids=[int(PI_CLASS)], therapy_release_id=str(_RID + 1))
+        scope, _ = Trial.objects.filter_by_patient_info(pi)
+        assert needs.id not in set(scope.values_list('id', flat=True))
+        assert _match(needs, pi) == 'not_matched'
+
+
+@override_settings(**OMOP_TYPES)
+def test_enforce_empty_class_set_is_noop(monkeypatch):
+    # Empty patient class set → resolve_type_validation's empty guard returns BEFORE
+    # Gate 1, so enforcement is a no-op; a no-required-type trial stays visible.
+    with _enforce_gate1(monkeypatch):
+        open_ = TrialFactory(disease='multiple myeloma', omop_therapy_types_required=[])
+        pi = PatientInfo(disease='multiple myeloma', prior_therapy='One line',
+                         therapy_type_ids=[], therapy_release_id=str(_RID + 1))
+        scope, _ = Trial.objects.filter(id=open_.id).filter_by_patient_info(pi)
+        assert set(scope.values_list('id', flat=True)) == {open_.id}
+
+
+@override_settings(**OMOP_TYPES)
+def test_enforce_embedded_backend_search_stale_drops_required_type(monkeypatch):
+    # The EMBEDDED ExactMatcher backend (CancerBot runs it in-process) must enforce Gate 1
+    # too. Its search() funnels through filter_by_patient_info (for a patient-scoped
+    # search_type — 'all' is the admin/browse path that skips the patient prefilter), so
+    # the scope covers it. Explicitly guards the regression where a view-only set-point
+    # fail-opened for this path.
+    from exact_matching.backend import ExactMatcher
+    from trials.services.study_preferences import StudyPreferences
+    with _enforce_gate1(monkeypatch):
+        needs = TrialFactory(disease='multiple myeloma', omop_therapy_types_required=[PI_CLASS])
+        open_ = TrialFactory(disease='multiple myeloma', omop_therapy_types_required=[])
+        pi = _pi(str(_RID + 1), prior_therapy='One line')  # stale release
+
+        class _P:
+            geo_point = None
+
+            def as_patient_info(self):
+                return pi
+
+        class _Prefs:
+            query_params = {}
+            study_info = StudyPreferences()
+            search_type = 'standard'  # patient-scoped path → filter_by_patient_info
+            recruitment_status = None
+
+        qs = ExactMatcher().search(
+            Trial.objects.filter(id__in=[needs.id, open_.id]), _P(), _Prefs())
+        ids = set(qs.values_list('id', flat=True))
+        assert needs.id not in ids   # embedded backend enforces → stale required-type dropped
+        assert open_.id in ids
+
+
+@override_settings(**OMOP_TYPES)
+def test_enforce_embedded_backend_verdict_stale_not_matched(monkeypatch):
+    # For 'all' (admin/browse) searches the queryset skips the patient prefilter, so the
+    # embedded backend enforces per-trial via the verdict (match_status → matching_type),
+    # which reads the release explicitly. A stale-release patient → not_matched.
+    from exact_matching.backend import ExactMatcher
+    with _enforce_gate1(monkeypatch):
+        needs = TrialFactory(disease='multiple myeloma', omop_therapy_types_required=[PI_CLASS])
+        pi = _pi(str(_RID + 1))  # stale release
+
+        class _P:
+            def as_patient_info(self):
+                return pi
+
+        # matching_type's vocabulary is 'not_eligible' (vs the internal matcher's
+        # 'not_matched') — Gate 1 fired and the trial is not eligible for the stale patient.
+        assert ExactMatcher().match_status(needs, _P()) == 'not_eligible'
+
+
+def _authed_client():
+    from rest_framework.authtoken.models import Token
+    from rest_framework.test import APIClient
+    from accounts.models import Identity
+    user, _ = Identity.objects.get_or_create(issuer='urn:local', sub='gate1-view')
+    token, _ = Token.objects.get_or_create(user=user)
+    client = APIClient()
+    client.credentials(HTTP_AUTHORIZATION=f'Token {token.key}')
+    return client
+
+
+def _match_post(client, therapy_release_id):
+    return client.post('/trials/match/', {'patient_info': {
+        'disease': 'multiple myeloma',
+        'therapy_component_ids': [int(BORT_CID)],
+        'therapy_type_ids': [int(PI_CLASS)],
+        'therapy_release_id': therapy_release_id,
+    }}, format='json')
+
+
+@override_settings(**OMOP_TYPES)
+def test_enforce_view_end_to_end_stale_drops_required_type(monkeypatch):
+    # Full HTTP chain: the view's _resolve_patient_info publishes the patient release
+    # into the request contextvar, so enforcement fail-closes with NO manual set.
+    from trials.services.omop import patient_release_gate as prg
+    monkeypatch.setattr(prg, '_PATIENT_RELEASE_GATE_ENFORCE', True)
+    needs = TrialFactory(disease='multiple myeloma', omop_therapy_types_required=[PI_CLASS])
+    resp = _match_post(_authed_client(), str(_RID + 1))  # stale release
+    assert resp.status_code == 200
+    assert needs.id not in {t['trialId'] for t in resp.data['results']}
+
+
+@override_settings(**OMOP_TYPES)
+def test_enforce_view_end_to_end_match_keeps_required_type(monkeypatch):
+    from trials.services.omop import patient_release_gate as prg
+    monkeypatch.setattr(prg, '_PATIENT_RELEASE_GATE_ENFORCE', True)
+    needs = TrialFactory(disease='multiple myeloma', omop_therapy_types_required=[PI_CLASS])
+    resp = _match_post(_authed_client(), str(_RID))  # release == active mirror
+    assert resp.status_code == 200
+    assert needs.id in {t['trialId'] for t in resp.data['results']}
 
 
 @override_settings(**OMOP_TYPES)

--- a/tests/services/test_patient_release_gate.py
+++ b/tests/services/test_patient_release_gate.py
@@ -1,8 +1,9 @@
 """Unit tests for the #286 Gate 1 patient-release gate (ADR 0002 §Gate 1).
 
 Covers the strict fail-closed resolver, the observe-only release_gated_class_ids
-(returns the class ids unchanged — this slice only measures skew), the per-request
-memo, and the shadow metric. Enforcement (fail-closing on a mismatch) is a later slice.
+(returns the class ids unchanged — measures skew), the per-request memo, the shadow
+metric, and the enforcement decision gate1_fail_closed (composed into
+resolve_type_validation; observe-only by default via _PATIENT_RELEASE_GATE_ENFORCE).
 """
 import pytest
 
@@ -168,6 +169,99 @@ def test_no_measure_records_nothing(monkeypatch):
     a = _attr(therapy_type_ids=[35807295], therapy_release_id='8')
     prg.release_gated_class_ids(a, enabled=True, measure=False)
     assert prm.total_search_count() == 0
+
+
+# ── gate1_fail_closed — the enforcement decision (composed into resolve_type_validation) ──
+
+def _enforce(monkeypatch, on=True):
+    monkeypatch.setattr(prg, '_PATIENT_RELEASE_GATE_ENFORCE', on)
+
+
+def test_gate1_toggle_off_never_fails_closed(monkeypatch):
+    # Observe-only default: even a mismatched release must not fail closed.
+    _pin(monkeypatch, 7)
+    _enforce(monkeypatch, False)
+    assert prg.gate1_fail_closed('8') is False           # explicit mismatch, toggle off
+    with prg.patient_release_scope('8'):
+        assert prg.gate1_fail_closed() is False           # contextvar mismatch, toggle off
+
+
+def test_gate1_no_context_not_applied(monkeypatch):
+    # No explicit release AND no scope → _UNSET → Gate 1 not applied (Gate-2-only callers).
+    _pin(monkeypatch, 7)
+    _enforce(monkeypatch, True)
+    assert prg.gate1_fail_closed() is False
+
+
+# --- explicit release (matcher verdict / detail-display seams) ---
+
+def test_gate1_explicit_consistent_passes(monkeypatch):
+    _pin(monkeypatch, 7)
+    _enforce(monkeypatch, True)
+    assert prg.gate1_fail_closed('7') is False
+
+
+def test_gate1_explicit_mismatch_fails_closed(monkeypatch):
+    _pin(monkeypatch, 7)
+    _enforce(monkeypatch, True)
+    assert prg.gate1_fail_closed('8') is True
+
+
+def test_gate1_explicit_null_release_fails_closed(monkeypatch):
+    # A patient carrying no release → unknown → fail-closed when enforced.
+    _pin(monkeypatch, 7)
+    _enforce(monkeypatch, True)
+    assert prg.gate1_fail_closed(None) is True
+
+
+# --- scope contextvar (queryset prefilter path) ---
+
+def test_gate1_scope_consistent_passes(monkeypatch):
+    _pin(monkeypatch, 7)
+    _enforce(monkeypatch, True)
+    with prg.patient_release_scope('7'):
+        assert prg.gate1_fail_closed() is False
+
+
+def test_gate1_scope_mismatch_fails_closed(monkeypatch):
+    _pin(monkeypatch, 7)
+    _enforce(monkeypatch, True)
+    with prg.patient_release_scope('8'):
+        assert prg.gate1_fail_closed() is True
+
+
+def test_gate1_explicit_overrides_scope(monkeypatch):
+    # An explicit release wins over the scope contextvar (the seams always pass theirs).
+    _pin(monkeypatch, 7)
+    _enforce(monkeypatch, True)
+    with prg.patient_release_scope('8'):                  # scope stale
+        assert prg.gate1_fail_closed('7') is False         # explicit consistent → passes
+
+
+def test_gate1_scope_resets_after_context(monkeypatch):
+    # The scope contextvar must not leak past its `with` (no cross-call leak on a worker).
+    _pin(monkeypatch, 7)
+    _enforce(monkeypatch, True)
+    with prg.patient_release_scope('8'):
+        assert prg.gate1_fail_closed() is True
+    assert prg.gate1_fail_closed() is False  # back to _UNSET → not applied
+
+
+def test_pin_once_gate1_and_gate2_share_one_release_read(monkeypatch):
+    # resolve_type_validation must read active_pinned_release ONCE and reuse it for both
+    # Gate 1 (release token) and Gate 2 (per-concept validity) — a concurrent activation
+    # between two reads could otherwise split the checks across generations.
+    from trials.services.omop import type_release_gate as trg
+    calls = {'n': 0}
+
+    def _counting():
+        calls['n'] += 1
+        return 1
+    monkeypatch.setattr(trg, 'active_pinned_release', _counting)
+    _enforce(monkeypatch, True)
+    with prg.patient_release_scope('1'):          # consistent release → Gate 1 passes, Gate 2 runs
+        trg.resolve_type_validation(['35807295'])
+    assert calls['n'] == 1
 
 
 # ── input contract: the field survives _build_in_memory ────────────────────────

--- a/trials/services/omop/patient_release_gate.py
+++ b/trials/services/omop/patient_release_gate.py
@@ -15,15 +15,29 @@ The check is a strict string compare against ``str(active_pinned_release())`` �
 digit string). Anything that is not a canonical decimal string equal to the active
 release is **not release-consistent**.
 
-This slice is **OBSERVE-ONLY**: it records the release-skew shadow metric + logs but
-NEVER changes a verdict — :func:`release_gated_class_ids` returns the patient's class
-ids unchanged. ENFORCEMENT (fail-closing type matching on a release mismatch) is a
-deliberately separate later slice: it must be wired holistically across every seam's
-fail-closed chokepoints (the detail-display type map, and the component-only
-``eligible_for_therapy_related_things_from_lines`` short-circuit that returns ``self``
-when both component and class ids are empty) so the queryset and matcher agree — and it
-requires the trial-side attestation gaps closed first (ADR 0002 §Gate 1 gaps 1-2). Not
-bolted on here.
+**Default OBSERVE-ONLY** (:data:`_PATIENT_RELEASE_GATE_ENFORCE` is False): the gate
+records the release-skew shadow metric + logs but NEVER changes a verdict —
+:func:`release_gated_class_ids` returns the patient's class ids unchanged.
+
+**Enforcement** is composed into :func:`type_release_gate.resolve_type_validation` (which
+all three seams — queryset prefilter, matcher verdict, detail display — already call): when
+enforced and the request's aggregate patient release is inconsistent with the pinned mirror,
+the WHOLE class set is treated as unvalidated (``(set(), True)``), so every seam fails closed
+CONSISTENTLY via the existing Gate-2 machinery. This composes rather than gating the class-id
+VALUE, so it does not disturb the two fail-closed chokepoints (the detail-display type map and
+the component-only ``eligible_for_therapy_related_things_from_lines`` ``return self``
+short-circuit) — the raw class ids keep flowing; only the (validated, unvalidated) result
+changes. Do NOT flip the toggle before the trial-side attestation is verified +
+immutable/revocable (ADR 0002 §Gate 1 gaps 1-2).
+
+The patient release reaches :func:`gate1_fail_closed` two ways so EVERY entry point is
+covered without a per-entry-point set-point: the **matcher verdict / detail-display**
+seams pass it EXPLICITLY (they hold the patient_info_attr); the **queryset prefilter**
+reads it from the :class:`patient_release_scope` contextvar that
+:meth:`filter_by_patient_info` binds for the eligibility build (that method is the one
+funnel for the HTTP view (via filtered_trials), the embedded ``ExactMatcher`` backend,
+and mgmt commands). Outside a seam (unit-test / non-seam callers) neither is set →
+``_UNSET`` → Gate 1 not applied, so Gate-2-only callers are unaffected.
 
 Release resolution + memo mirror :mod:`type_release_gate`: the pinned release comes from
 :func:`active_pinned_release` and the OK decision is memoized per-request via
@@ -44,6 +58,68 @@ _MAX_RELEASE_LEN = 32
 # Request-scoped memo (see module docstring). None outside a request → no caching.
 _request_memo: contextvars.ContextVar = contextvars.ContextVar(
     'patient_release_check_memo', default=None)
+
+# Enforcement toggle (mirrors vocab_mirror.activation._PROJECTION_GATE_ENFORCE). While
+# False the gate is OBSERVE-ONLY — release_gated_class_ids records skew but nothing
+# changes a verdict. Flip to True ONLY once the trial-side attestation is verified +
+# immutable/revocable (ADR 0002 §Gate 1 gaps 1-2). When True, a patient whose aggregate
+# release is inconsistent with the pinned mirror has its WHOLE class set rejected —
+# composed into resolve_type_validation as (set(), unvalidated) so all three seams
+# (queryset prefilter, matcher verdict, detail display) fail closed consistently.
+_PATIENT_RELEASE_GATE_ENFORCE = False
+
+# The queryset-path patient release, bound for the duration of a `filter_by_patient_info`
+# eligibility build (which EVERY search entry point funnels through — HTTP view via
+# filtered_trials, the embedded ExactMatcher backend, mgmt commands, and direct callers)
+# and reset on exit so it never leaks across calls on a reused worker.
+# The matcher verdict / detail-display seams do NOT use this — they hold the
+# patient_info_attr and pass the release EXPLICITLY to resolve_type_validation, so Gate 1
+# covers every path without a per-entry-point set-point. _UNSET distinguishes "no release
+# context" (unit-test / non-seam caller → Gate 1 not applied) from "release is None"
+# (patient carries none → fail-closed when enforced).
+_UNSET = object()
+_request_patient_release: contextvars.ContextVar = contextvars.ContextVar(
+    'request_patient_release', default=_UNSET)
+
+
+class patient_release_scope:
+    """Bind the patient's aggregate release for the enclosed queryset build (entered by
+    ``filter_by_patient_info``, the one chokepoint every search entry point funnels
+    through). Reset on exit, so a value never leaks to the next call on a reused
+    worker thread."""
+
+    def __init__(self, release_id):
+        self._release = release_id
+
+    def __enter__(self):
+        self._token = _request_patient_release.set(self._release)
+        return self
+
+    def __exit__(self, *exc):
+        _request_patient_release.reset(self._token)
+        return False
+
+
+def gate1_fail_closed(patient_release_id=_UNSET, active_release_id=_UNSET):
+    """True when Gate 1 must fail-close the patient's type matching: enforcement is on and
+    the patient's aggregate release is NOT consistent with the pinned mirror.
+
+    The release comes either EXPLICITLY (``patient_release_id`` — the matcher verdict /
+    detail-display seams pass it, holding the patient_info_attr) or, when not supplied,
+    from the :class:`patient_release_scope` contextvar (the queryset prefilter path).
+    ``_UNSET`` in both → no release context (unit-test / non-seam caller) → Gate 1 not
+    applied, so the observe-only path and every Gate-2-only caller are byte-identical. A
+    release of ``None`` (patient carries none) → fail-closed when enforced.
+
+    ``active_release_id`` is the pinned mirror release read ONCE by the caller
+    (resolve_type_validation) and reused for both gates so a concurrent activation can't
+    split the two checks across generations."""
+    if not _PATIENT_RELEASE_GATE_ENFORCE:
+        return False
+    rel = patient_release_id if patient_release_id is not _UNSET else _request_patient_release.get()
+    if rel is _UNSET:
+        return False
+    return not resolve_patient_release_ok(rel, active_release_id=active_release_id)
 
 
 def _compute(patient_release_id, active_release_id):
@@ -69,15 +145,21 @@ def _compute(patient_release_id, active_release_id):
     return ok
 
 
-def resolve_patient_release_ok(patient_release_id, measure=False):
+def resolve_patient_release_ok(patient_release_id, measure=False, active_release_id=_UNSET):
     """True when the patient's aggregate ``therapy_release_id`` is release-consistent
     with the pinned mirror (strict decimal-string equality), else False (fail-closed).
+
+    ``active_release_id`` lets the caller PIN the release read once and reuse it for both
+    Gate 1 and Gate 2 (resolve_type_validation does this) so a concurrent activation can't
+    validate the release token against one generation and the class ids against another.
+    When ``_UNSET`` it reads :func:`active_pinned_release` itself (the observe-only
+    ``release_gated_class_ids`` path).
 
     ``measure=True`` records the shadow release-skew metric — once per search (the
     queryset passes it; the per-trial matcher / detail display leave it False so the
     signal is emitted once per search, not once per trial). Observation only.
     """
-    release_id = active_pinned_release()
+    release_id = active_pinned_release() if active_release_id is _UNSET else active_release_id
     memo = _request_memo.get()
     if memo is None:
         ok = _compute(patient_release_id, release_id)

--- a/trials/services/omop/type_release_gate.py
+++ b/trials/services/omop/type_release_gate.py
@@ -33,6 +33,9 @@ import logging
 
 from vocab_mirror.release_context import active_pinned_release
 from vocab_mirror.validate import validate_concept_ids
+# Shared sentinel: "no patient release supplied" (Gate 1 not applied) vs a real value
+# (str or None). patient_release_gate does not import this module → no cycle.
+from trials.services.omop.patient_release_gate import _UNSET as _NO_RELEASE
 
 logger = logging.getLogger(__name__)
 
@@ -46,7 +49,7 @@ def _normalized(type_ids):
     return tuple(sorted((str(x).strip() for x in type_ids), key=str))
 
 
-def resolve_type_validation(type_ids, measure=False):
+def resolve_type_validation(type_ids, measure=False, patient_release_id=_NO_RELEASE):
     """Validate the patient's raw class ``type_ids`` at the pinned release.
 
     Returns ``(validated, has_unvalidated)`` where ``validated`` is the set (of
@@ -63,8 +66,26 @@ def resolve_type_validation(type_ids, measure=False):
     """
     if not type_ids:
         return set(), False
-    key = _normalized(type_ids)
+    # Pin the active mirror release ONCE and reuse it for BOTH Gate 1 (release-token
+    # equality) and Gate 2 (per-concept validity below): a non-request caller (mgmt
+    # command / direct) has no MatchingReleaseContext pin, so two separate
+    # active_pinned_release() reads could straddle a concurrent activation and validate
+    # the release token against one generation and the class ids against another.
     release_id = active_pinned_release()
+    # #286 Gate 1: when enforced and the patient's aggregate release is inconsistent with
+    # the pinned mirror, the WHOLE class set is untrusted → every id unvalidated, so all
+    # three seams fail closed via the same machinery as a per-concept stale set. The
+    # release is passed explicitly by the matcher/detail seams, else read from the
+    # queryset patient_release_scope contextvar. Observe-only (toggle off) or no release
+    # context → returns False, so the path below is byte-identical (incl. the `measure`
+    # shadow metric).
+    from trials.services.omop.patient_release_gate import gate1_fail_closed
+    if gate1_fail_closed(patient_release_id, active_release_id=release_id):
+        # Return before the per-concept `measure` block: when the WHOLE set is gated the
+        # per-concept staleness metric is moot; the release-skew is already recorded
+        # upstream (release_gated_class_ids, once per search).
+        return set(), True  # type_ids is truthy here → (set(), bool(type_ids))
+    key = _normalized(type_ids)
     memo = _request_memo.get()
     if memo is None:
         validated = _validate(key, release_id)


### PR DESCRIPTION
Builds on the observe-only slice (#337): ENFORCE patient-release consistency for OMOP drug-class **type** matching (EXACT ADR 0002 §"Gate 1"; #286), behind an observe-only toggle `_PATIENT_RELEASE_GATE_ENFORCE=False`. **Ships OFF → a no-op today.** Flip only after the trial-side attestation gaps close (ADR 0002 §Gate 1 gaps 1-2).

## What (when enforced)

When the patient's aggregate `therapy_release_id` is NOT consistent with the pinned vocab-mirror release, the patient's **whole** class set fails closed for type matching — **consistently** across the queryset prefilter, matcher verdict, and detail display.

## Design — compose into the single Gate-2 chokepoint

All three seams already funnel the patient's class ids through `resolve_type_validation` (Gate 2). Gate 1 is composed there: enforced + release mismatch → `(set(), True)` (every id unvalidated), reusing Gate 2's fail-closed machinery. This **avoids** the two chokepoints a class-id-gating approach leaks through (the detail-display type map; the component-only `eligible_for_therapy_related_things_from_lines` `return self` short-circuit) — the raw class ids keep flowing, only the `(validated, unvalidated)` result changes.

## Coverage — every entry point, no per-entry-point set-point

The patient release reaches the gate for the HTTP view, the **embedded `ExactMatcher` backend CancerBot runs in-process**, and mgmt commands:
- **matcher verdict + detail-display** seams pass the release **explicitly** (they hold the `patient_info_attr`);
- the **queryset prefilter** reads it from a `patient_release_scope` contextvar that `filter_by_patient_info` (the one chokepoint every search path funnels through) binds and resets on exit (no cross-call leak).

`gate1_fail_closed(patient_release_id=_UNSET, active_release_id=_UNSET)`: toggle-first; explicit release else the scope contextvar; `_UNSET` → not applied (test/non-seam callers → byte-identical); `None` release → fail-closed. The active mirror release is **pinned once** in `resolve_type_validation` and reused for both gates (no TOCTOU split across a concurrent activation for non-request callers).

## Tests

`gate1_fail_closed` (toggle / no-context / explicit consistent-mismatch-null / scope consistent-mismatch / explicit-overrides-scope / scope-reset / **pin-once**); enforced fail-closed at all three seams; queryset==matcher parity; component-only stale (guards the step-1 short-circuit); empty-set no-op; **embedded ExactMatcher backend** (search prefilter for a patient-scoped search + verdict `match_status` for 'all'); two HTTP end-to-end; observe-only unchanged. Full suite **1223 passed**.

## Self-review (two-part, reconciled)

- **codex** `--base 2omop` × 4 rounds: found + fixed a fail-OPEN for the embedded `ExactMatcher` backend [P1] (a view-only set-point missed it) and a Gate-1/Gate-2 release TOCTOU for non-request callers [P2]; final pass clean.
- **fresh-context subagent**: confirmed no fail-open on any live path and toggle-OFF byte-identical; folded in doc precision, an enforcement metric note, and the direct embedded-backend tests.