### PR TITLE
feat(omop): verify projection-attestation checksum at activation (ADR 0002 §Gate 1 gap #1)

### DIFF
--- a/tests/services/test_projection_checksum.py
+++ b/tests/services/test_projection_checksum.py
@@ -1,0 +1,79 @@
+"""Canonical trial-projection checksum (ADR 0002 §Gate 1 gap #1 / ADR 0003 Option D).
+
+The frozen CB↔EXACT contract EXACT recomputes at activation to verify CB's published
+attestation checksum. Must be deterministic and order/duplicate-independent (the matcher
+treats the type lists as sets), and change when a projected value changes.
+"""
+import pytest
+
+from trials.models import Trial
+from trials.services.omop.projection_checksum import (
+    _normalize,
+    compute_trial_projection_checksum,
+)
+from tests.factories import TrialFactory
+
+pytestmark = pytest.mark.django_db
+
+
+def _trial(code, required=None, excluded=None):
+    return TrialFactory(code=code, omop_therapy_types_required=required or [],
+                        omop_therapy_types_excluded=excluded or [])
+
+
+def test_normalize_sorts_dedups_stringifies():
+    assert _normalize([3, 1, 2, 2]) == ['1', '2', '3']
+    assert _normalize(None) == []
+    assert _normalize([]) == []
+    assert _normalize(['35807403', 35807295]) == ['35807295', '35807403']
+
+
+def test_empty_universe_is_stable_and_zero_count():
+    d1, n1 = compute_trial_projection_checksum()
+    d2, n2 = compute_trial_projection_checksum()
+    assert d1 == d2 and n1 == n2 == 0
+
+
+def test_count_and_determinism():
+    _trial('T1', [1])
+    _trial('T2', [2, 3], [9])
+    d1, n = compute_trial_projection_checksum()
+    d2, _ = compute_trial_projection_checksum()
+    assert n == 2 and d1 == d2 and len(d1) == 64  # sha256 hex
+
+
+def test_order_and_duplicate_independent():
+    t = _trial('T1', [3, 1, 2])
+    d_a, _ = compute_trial_projection_checksum()
+    Trial.objects.filter(pk=t.pk).update(omop_therapy_types_required=[2, 2, 1, 3])  # reorder + dup
+    d_b, _ = compute_trial_projection_checksum()
+    assert d_a == d_b  # set semantics → same checksum
+
+
+def test_value_change_changes_checksum():
+    t = _trial('T1', [1])
+    d_a, _ = compute_trial_projection_checksum()
+    Trial.objects.filter(pk=t.pk).update(omop_therapy_types_required=[1, 99])
+    d_b, _ = compute_trial_projection_checksum()
+    assert d_a != d_b
+
+
+def test_excluded_participates():
+    t = _trial('T1', [1], [])
+    d_a, _ = compute_trial_projection_checksum()
+    Trial.objects.filter(pk=t.pk).update(omop_therapy_types_excluded=[7])
+    d_b, _ = compute_trial_projection_checksum()
+    assert d_a != d_b
+
+
+def test_identity_is_code_not_pk():
+    # Two universes with the same (code, values) content but created in a different order
+    # (→ different pks) must hash identically — identity is the CB-portable `code`.
+    _trial('B', [2])
+    _trial('A', [1])
+    d1, _ = compute_trial_projection_checksum()
+    Trial.objects.all().delete()
+    _trial('A', [1])
+    _trial('B', [2])
+    d2, _ = compute_trial_projection_checksum()
+    assert d1 == d2

--- a/tests/vocab_mirror/test_projection_attestation.py
+++ b/tests/vocab_mirror/test_projection_attestation.py
@@ -19,8 +19,22 @@ from vocab_mirror.models import (
     MirrorVocabulary,
     ProjectionAttestation,
 )
+from tests.factories import TrialFactory
 
 pytestmark = pytest.mark.django_db
+
+
+def _trial(code, required):
+    TrialFactory(code=code, omop_therapy_types_required=required,
+                 omop_therapy_types_excluded=[])
+
+
+def _publish_matching_checksum(release_id):
+    """Publish an attestation whose checksum matches EXACT's current trial projection."""
+    from trials.services.omop.projection_checksum import compute_trial_projection_checksum
+    digest, count = compute_trial_projection_checksum()
+    publish_projection_attestation(release_id, checksum=digest, trial_count=count)
+    return digest, count
 
 
 def _ready_release(rid):
@@ -78,12 +92,109 @@ def test_enforcing_blocks_activation_without_attestation(monkeypatch):
     assert active_release_id() is None            # blocked, fail-closed
 
 
-def test_enforcing_allows_activation_with_attestation(monkeypatch):
+def test_enforcing_allows_activation_with_verified_checksum(monkeypatch):
+    # Strengthened gate (gap #1): under enforcement, a mere attestation ROW is no longer
+    # enough — its checksum must VERIFY against EXACT's recomputed projection.
     monkeypatch.setattr(activation, '_PROJECTION_GATE_ENFORCE', True)
     _ready_release(1)
-    publish_projection_attestation(1)
+    _trial('T1', [1])
+    _publish_matching_checksum(1)
     activate_release(1)
     assert active_release_id() == 1
+
+
+# ── gate: checksum verification (ADR 0002 §Gate 1 gap #1) ────────────────────
+
+def test_matching_checksum_activates_clean(caplog):
+    _ready_release(1)
+    _trial('T1', [1]); _trial('T2', [2])
+    _publish_matching_checksum(1)
+    with caplog.at_level(logging.WARNING, logger='vocab_mirror.activation'):
+        activate_release(1)
+    assert active_release_id() == 1
+    assert not any('projection' in r.message for r in caplog.records)  # verified → no warn
+
+
+def test_mismatched_checksum_observe_only_warns(caplog):
+    _ready_release(1)
+    _trial('T1', [1])
+    publish_projection_attestation(1, checksum='deadbeef' * 8, trial_count=1)  # wrong
+    with caplog.at_level(logging.WARNING, logger='vocab_mirror.activation'):
+        activate_release(1)
+    assert active_release_id() == 1                       # observe-only: activates anyway
+    assert any('checksum mismatch' in r.message for r in caplog.records)
+
+
+def test_trial_count_mismatch_warns(caplog):
+    _ready_release(1)
+    _trial('T1', [1])
+    from trials.services.omop.projection_checksum import compute_trial_projection_checksum
+    digest, count = compute_trial_projection_checksum()
+    publish_projection_attestation(1, checksum=digest, trial_count=count + 5)  # right hash, wrong count
+    with caplog.at_level(logging.WARNING, logger='vocab_mirror.activation'):
+        activate_release(1)
+    assert active_release_id() == 1
+    assert any('checksum mismatch' in r.message for r in caplog.records)
+
+
+def test_blank_checksum_is_pending_not_mismatch(caplog):
+    # CB has not published a checksum yet (Option D interim) → log-only, never alarm.
+    _ready_release(1)
+    _trial('T1', [1])
+    publish_projection_attestation(1, trial_count=1)     # attested, no checksum
+    with caplog.at_level(logging.INFO, logger='vocab_mirror.activation'):
+        activate_release(1)
+    assert active_release_id() == 1
+    assert any('verification pending' in r.message for r in caplog.records)
+    assert not any('mismatch' in r.message for r in caplog.records)
+
+
+def test_enforcing_blocks_on_checksum_mismatch(monkeypatch):
+    monkeypatch.setattr(activation, '_PROJECTION_GATE_ENFORCE', True)
+    _ready_release(1)
+    _trial('T1', [1])
+    publish_projection_attestation(1, checksum='deadbeef' * 8, trial_count=1)
+    with pytest.raises(ReleaseMatchFailed):
+        activate_release(1)
+    assert active_release_id() is None                   # blocked, fail-closed
+
+
+def test_enforcing_allows_on_matching_checksum(monkeypatch):
+    monkeypatch.setattr(activation, '_PROJECTION_GATE_ENFORCE', True)
+    _ready_release(1)
+    _trial('T1', [1])
+    _publish_matching_checksum(1)
+    activate_release(1)
+    assert active_release_id() == 1
+
+
+def test_enforcing_blocks_blank_checksum(monkeypatch):
+    # Enforced: a blank checksum cannot be verified → fail-closed (never activate an
+    # unverified projection). Enforcement stays OFF until CB publishes checksums, so this
+    # never blocks activation today; the observe-only path treats blank as pending.
+    monkeypatch.setattr(activation, '_PROJECTION_GATE_ENFORCE', True)
+    _ready_release(1)
+    _trial('T1', [1])
+    publish_projection_attestation(1, trial_count=1)     # attested, no checksum
+    with pytest.raises(ReleaseMatchFailed):
+        activate_release(1)
+    assert active_release_id() is None
+
+
+def test_gate_detects_trial_mutation_after_attestation(caplog):
+    # End-to-end: publish a MATCHING checksum, then mutate a trial's projection → the gate's
+    # recompute now mismatches (guards the closed loop through activate_release, not just the
+    # checksum fn). Observe-only → warns, activates anyway.
+    from trials.models import Trial
+    _ready_release(1)
+    t = TrialFactory(code='T1', omop_therapy_types_required=[1],
+                     omop_therapy_types_excluded=[])
+    _publish_matching_checksum(1)
+    Trial.objects.filter(pk=t.pk).update(omop_therapy_types_required=[1, 99])  # projection drift
+    with caplog.at_level(logging.WARNING, logger='vocab_mirror.activation'):
+        activate_release(1)
+    assert active_release_id() == 1
+    assert any('checksum mismatch' in r.message for r in caplog.records)
 
 
 # ── management command ───────────────────────────────────────────────────────

--- a/trials/services/omop/projection_checksum.py
+++ b/trials/services/omop/projection_checksum.py
@@ -1,0 +1,56 @@
+"""Canonical trial-projection checksum — the CB↔EXACT contract (ADR 0002 §Gate 1 gap #1,
+ADR 0003 Option D).
+
+EXACT recomputes this from its OWN trial rows at mirror activation and verifies it against
+the ``checksum`` CancerBot published in the ``ProjectionAttestation`` for the release, so a
+stale / partial / mid-reload trial projection cannot silently pass the activation gate.
+For the check to mean anything, **CB MUST compute the byte-identical value** over its own
+trial rows for the same release — hence this domain is a frozen cross-repo contract:
+
+Domain (do NOT change without a coordinated CB change):
+- **Universe:** every ``Trial`` row (``Trial.objects.all()``) — the complete projection.
+- **Per-trial tuple:** ``[code, required, excluded]`` where ``code`` is the unique business
+  key (CB-portable; EXACT's local ``pk`` is deliberately NOT used) and
+  ``required`` / ``excluded`` are the ``omop_therapy_types_{required,excluded}`` values
+  NORMALIZED to a sorted list of unique decimal strings. Normalization is essential: the
+  matcher treats these as SETS (``has_any_keys``), so the checksum must be independent of
+  the stored list's order and duplicates on either side.
+- **Order:** the per-trial tuples sorted by ``code`` **in-process, by Unicode codepoint**
+  (Python's default ``sort``) — NOT the database's ``ORDER BY`` (which depends on the DB's
+  ``LC_COLLATE`` and would diverge across deployments / from CB's recompute).
+- **Values:** ``omop_therapy_types_*`` are integer concept_ids; ``_normalize`` stringifies
+  them (a non-integer value would serialize differently and is out of contract).
+- **Serialization:** compact JSON (``separators=(',', ':')``, ``ensure_ascii=True``) of the
+  ordered list.
+- **Digest:** lowercase hex ``sha256`` of the UTF-8 bytes.
+
+The function is pure / read-only. It does NOT hardcode ``.using(...)``: ``Trial`` is routed
+to the optional ``trials`` DB when configured, else ``default`` — let the router pick.
+"""
+import hashlib
+import json
+
+
+def _normalize(values):
+    """A JSONField list → sorted list of unique decimal-strings (set semantics)."""
+    return sorted({str(v) for v in (values or [])})
+
+
+def compute_trial_projection_checksum():
+    """Return ``(sha256_hex, trial_count)`` over the current trial projection.
+
+    ``trial_count`` is the number of ``Trial`` rows hashed — CB publishes it alongside the
+    checksum so the gate can also catch a truncated/short projection.
+    """
+    from trials.models import Trial
+    rows = Trial.objects.values_list(
+        'code', 'omop_therapy_types_required', 'omop_therapy_types_excluded')
+    tuples = [[code, _normalize(required), _normalize(excluded)]
+              for code, required, excluded in rows.iterator()]
+    # Sort in-process by Unicode codepoint (portable) — NOT via the DB's ORDER BY, whose
+    # collation is environment-dependent and would make the "frozen" hash non-reproducible
+    # across deployments and CB.
+    tuples.sort(key=lambda t: t[0])
+    payload = json.dumps(tuples, separators=(',', ':'), ensure_ascii=True)
+    digest = hashlib.sha256(payload.encode('utf-8')).hexdigest()
+    return digest, len(tuples)

--- a/vocab_mirror/activation.py
+++ b/vocab_mirror/activation.py
@@ -161,26 +161,66 @@ def _component_lookup_matches_release(release_id):
 _PROJECTION_GATE_ENFORCE = False
 
 
-@register_release_match_check
-def _projection_matches_release(release_id):
-    """Cross-artifact gate for the trial ``omop_*`` projection (#265 / ADR 0002 #4).
-
-    The projection is CB-owned on the trials DB; rather than a racy cross-DB read,
-    the gate checks for CB's **attestation** (published into EXACT's ``default`` DB
-    once CB has validated the projection for R). Missing attestation → the projection
-    is not known-consistent with R. **Observe-only until Phase-T**: log it and
-    activate anyway (eligibility doesn't read the mirror yet); flip
-    ``_PROJECTION_GATE_ENFORCE`` when the graph goes on the eligibility path.
-    """
-    from vocab_mirror.attestation import projection_attested
-    if projection_attested(release_id):
-        return
-    msg = (f'trial omop_* projection has no attestation for release {release_id} '
-           '(CB has not published projection-ready)')
+def _projection_gate_fail(msg):
+    """Observe-only until Phase-T: raise (block activation) when enforced, else warn and
+    activate anyway (eligibility doesn't read the mirror yet)."""
     if _PROJECTION_GATE_ENFORCE:
         raise ReleaseMatchFailed(msg)
     logger.warning('vocab activation (observe-only): %s; activating anyway '
                    '(Phase-T not live)', msg)
+
+
+@register_release_match_check
+def _projection_matches_release(release_id):
+    """Cross-artifact gate for the trial ``omop_*`` projection (#265 / ADR 0002 #4 §Gate 1).
+
+    The projection is CB-owned on the trials DB; rather than a racy cross-DB read, the gate
+    reads CB's **attestation** (published into EXACT's ``default`` DB once CB has validated
+    the projection for R) and **VERIFIES its checksum** (ADR 0002 §Gate 1 gap #1) — existence
+    alone is fail-open, since ``checksum`` is a blank-default column. EXACT recomputes the
+    canonical trial-projection checksum from its OWN ``Trial`` rows
+    (:func:`compute_trial_projection_checksum`, the frozen CB↔EXACT contract) and compares:
+
+    - no attestation row → the projection is not known-consistent with R → fail;
+    - attested but ``checksum`` still blank → CB has not published a checksum yet (Option D
+      interim, ADR 0003) → log-only, do NOT alarm (verification pending);
+    - checksum (and ``trial_count``, when published) match the local recompute → pass;
+    - mismatch → the local projection differs from what CB attested for R → fail.
+
+    **Observe-only until Phase-T**: ``_projection_gate_fail`` logs and activates anyway;
+    flip ``_PROJECTION_GATE_ENFORCE`` only once gap #2 (projection immutability/revocation)
+    is closed too.
+    """
+    from vocab_mirror.attestation import get_projection_attestation
+    att = get_projection_attestation(release_id)
+    if att is None:
+        _projection_gate_fail(
+            f'trial omop_* projection has no attestation for release {release_id} '
+            '(CB has not published projection-ready)')
+        return
+    if not att.checksum:
+        # No checksum to verify. ENFORCED: cannot verify the projection → fail-closed
+        # (never activate an unverified projection once the gate is live). Observe-only:
+        # log pending, don't alarm — CB is not publishing checksums yet (Option D interim),
+        # and enforcement stays off until it does, so this never blocks activation today.
+        if _PROJECTION_GATE_ENFORCE:
+            raise ReleaseMatchFailed(
+                f'trial omop_* projection attested for release {release_id} but no checksum '
+                'published — cannot verify (enforced)')
+        logger.info(
+            'vocab activation: projection attested for release %s but no checksum published '
+            'yet (Option D interim; checksum verification pending)', release_id)
+        return
+    from trials.services.omop.projection_checksum import compute_trial_projection_checksum
+    local_digest, local_count = compute_trial_projection_checksum()
+    count_ok = att.trial_count is None or att.trial_count == local_count
+    if att.checksum == local_digest and count_ok:
+        return
+    _projection_gate_fail(
+        f'trial omop_* projection checksum mismatch for release {release_id}: attested '
+        f'{att.checksum[:12]}…/count={att.trial_count} vs local recompute '
+        f'{local_digest[:12]}…/count={local_count} — projection differs from what CB '
+        'attested (stale / partial / mid-reload)')
 
 
 def _run_release_match_gate(release_id):

--- a/vocab_mirror/attestation.py
+++ b/vocab_mirror/attestation.py
@@ -9,6 +9,13 @@ read of the CB trials table — so the pointer flip stays atomic on one DB.
 """
 from vocab_mirror.models import ProjectionAttestation
 
+# The attestation currently lives on EXACT's ``default`` DB (published via EXACT's mgmt
+# command). ADR 0003 ratified **Option D** — CB seals an immutable attestation in the
+# CB-owned ``trials`` DB and EXACT reads it via the trials alias. That relocation (moving
+# this model + all three helpers off ``default`` to a routed read model, and CB owning the
+# write) is a SEPARATE, module-wide change tracked as the Option-D relocation issue; the
+# checksum-verify below is orthogonal and consistent with the current on-``default`` module.
+# When the relocation lands, ``_DB`` moves for all three helpers together.
 _DB = 'default'
 
 
@@ -28,3 +35,11 @@ def projection_attested(release_id):
     """True when CB has published a projection attestation for ``release_id``."""
     return ProjectionAttestation.objects.using(_DB).filter(
         release_id=int(release_id)).exists()
+
+
+def get_projection_attestation(release_id):
+    """The ``ProjectionAttestation`` row for ``release_id`` (with its ``checksum`` /
+    ``trial_count``), or ``None`` if CB has not published one. Used by the activation gate
+    to VERIFY the checksum, not just its existence (ADR 0002 §Gate 1 gap #1)."""
+    return ProjectionAttestation.objects.using(_DB).filter(
+        release_id=int(release_id)).first()


### PR DESCRIPTION
Closes ADR 0002 §"Gate 1" **gap #1**: the mirror activation gate for the trial OMOP-type projection was **existence-only** (`projection_attested → .exists()`) — fail-open, since `checksum` is a blank-default column, so a stale / partial / mid-reload projection whose attestation row merely exists would pass. This strengthens it to **verify the checksum**. Still **observe-only** (`_PROJECTION_GATE_ENFORCE=False`) — logs a mismatch, activates anyway; flip only once gap #2 (projection immutability/revocation) is also closed.

## What

- **`trials/services/omop/projection_checksum.py`** (new) — `compute_trial_projection_checksum()` → `(sha256_hex, trial_count)`, the **frozen CB↔EXACT contract**. sha256 over **every** `Trial`: per-trial `[code, required, excluded]` where `code` is the CB-portable unique business key (not EXACT's local pk), the `omop_therapy_types_{required,excluded}` values are normalized to sorted unique decimal strings (set semantics — the matcher uses `has_any_keys`), tuples **sorted in-process by Unicode codepoint** (NOT the DB's collation-dependent `ORDER BY`, so CB and every deployment reproduce the same bytes), compact-JSON serialized. Router-selected DB.
- **`vocab_mirror/attestation.py`** — `get_projection_attestation(release_id)` returns the row (checksum/trial_count), not just existence.
- **`vocab_mirror/activation.py`** — `_projection_matches_release` now: no attestation → fail; **blank checksum** → observe-only INFO "verification pending" (CB isn't publishing checksums yet, Option D interim), **but fail-closed when enforced** (can't verify → don't activate); checksum (+ `trial_count` when present) match the local recompute → pass; **mismatch** → fail. Warn-vs-raise extracted to `_projection_gate_fail`.

## Scope note

The attestation currently lives on EXACT's `default` DB (the existing module). ADR 0003 ratified **Option D** (CB seals the attestation in the CB-owned `trials` DB, EXACT reads via the trials alias). That relocation is a **separate, module-wide change** (all three `attestation.py` helpers + the model + CB owning the write) tracked as the Option-D relocation issue; this checksum-verify is orthogonal and consistent with the current on-`default` module. When the relocation lands, `_DB` moves for all helpers together. (Documented inline.)

## Tests

Checksum: determinism / order+duplicate independence / **code-not-pk identity** / value + excluded participation / count. Gate: match-clean, mismatch-warns, count-mismatch-warns, blank-pending (not a mismatch), **enforce-blocks-on-mismatch**, **enforce-blocks-blank-checksum**, enforce-allows-verified-checksum, and an **end-to-end mutation** test (publish matching → mutate a trial → gate warns). Full suite **1239 passed**.

## Self-review (two-part, reconciled)

- **codex** `--base 2omop` × 2: found + fixed a fail-OPEN where a blank checksum was accepted under enforcement [P1]; flagged the Option-D `trials`-DB relocation [P1] — deferred with an inline note (separate module-wide + cross-repo change); final pass clean.
- **fresh-context subagent**: confirmed no fail-open and correct observe-only/pending behavior; caught the **DB-collation-dependent ordering** [P2] (fixed → in-process codepoint sort so CB can reproduce byte-for-byte) + folded in the mutation test and value-type contract note.