### PR TITLE
fix(matcher): master-gate the #286 release-scope import in filter_by_patient_info

### DIFF
--- a/matcher_app/exact_matching/querysets/trial.py
+++ b/matcher_app/exact_matching/querysets/trial.py
@@ -1561,6 +1561,15 @@ class TrialQuerySet(models.QuerySet):
         # filtered_trials), the embedded ExactMatcher backend, mgmt commands, and direct
         # callers. Reset on exit (no cross-call leak). The matcher verdict / detail-display
         # seams pass the release explicitly instead (they hold the patient_info_attr).
+        #
+        # Master-gated on OMOP therapy (same seam as `_omop_therapy_ids` / #342): the
+        # release scope only affects the OMOP-type prefilter, which is itself inert when
+        # OMOP is off, so skipping the binding in legacy mode is behaviour-preserving. It
+        # also keeps the `trials.services.omop.patient_release_gate` import off the legacy
+        # path, so a host without the OMOP release-gate infra (CB, at the QR4d orchestrator
+        # drain) can run this method instead of ImportError-ing on a module it doesn't ship.
+        if not omop_therapy_enabled():
+            return self._filter_by_patient_info(patient_info, add_traces=add_traces)
         from exact_matching.patient_info.patient_info_attributes import PatientInfoAttributes
         from trials.services.omop.patient_release_gate import patient_release_scope
         release = (PatientInfoAttributes(patient_info).get_user_therapy_release_id()

--- a/tests/querysets/test_custom_search_dispatch.py
+++ b/tests/querysets/test_custom_search_dispatch.py
@@ -194,3 +194,34 @@ class TestTherapyLinesOnceFlag:
         assert not scope.eligible_for_therapy_related_things_from_lines.called
         # Returns the unchanged scope.
         assert result is scope
+
+
+class TestFilterByPatientInfoLegacyNoReleaseGate:
+    """QR4d orchestrator drain: the `filter_by_patient_info` wrapper binds the #286
+    Gate-1 release scope, which imports `trials.services.omop.patient_release_gate`.
+    In legacy mode (OMOP master flag off) the wrapper must NOT import that module —
+    a host that doesn't ship it (CB, when it delegates to super() at the orchestrator
+    drain) would ImportError. Master-gating the scope (mirrors `_omop_therapy_ids`,
+    #342) is behaviour-preserving because the scope only feeds the OMOP-type prefilter,
+    which is inert when OMOP is off.
+    """
+
+    @pytest.mark.django_db
+    def test_legacy_wrapper_does_not_import_release_gate(self, monkeypatch, settings):
+        import sys
+        from trials.models import Trial
+        from trials.services.patient_info.patient_info import PatientInfo
+        from tests.factories import TrialFactory
+
+        settings.EXACT_OMOP_THERAPY = False  # master off → legacy path
+        # None in sys.modules makes `import ...patient_release_gate` raise ImportError,
+        # simulating a host (CB) that doesn't ship the OMOP release-gate infra.
+        monkeypatch.setitem(sys.modules, 'trials.services.omop.patient_release_gate', None)
+
+        TrialFactory(disease='mantle cell lymphoma')
+        # prior_therapy='None' drives the therapy dispatch too (has_no_prior_therapy),
+        # exercising the _omop_therapy_ids gate on the same call.
+        pi = PatientInfo(disease='mantle cell lymphoma', prior_therapy='None')
+
+        result, _ = Trial.objects.filter_by_patient_info(pi)  # must not ImportError
+        assert result.count() >= 1


### PR DESCRIPTION
## Last package-side blocker for the CB orchestrator drain

The `filter_by_patient_info` wrapper (added by #286 Gate-1) unconditionally imported `trials.services.omop.patient_release_gate.patient_release_scope` and bound it around the whole eligibility build. A host without the OMOP release-gate infra — **CancerBot, when it delegates to `super().filter_by_patient_info(...)` at the QR4d orchestrator drain** — `ImportError`s on a module it doesn't ship.

### Fix
Master-gate it exactly like #342 gated the therapy dispatch (`_omop_therapy_ids`): in legacy mode (`omop_therapy_enabled()` False) return `self._filter_by_patient_info(...)` directly, before the import — skipping both the import and the scope binding.

### Why it's behavior-preserving
The release scope sets one contextvar (`_request_patient_release`). Its **only** reader is `gate1_fail_closed`, whose **only** caller is `resolve_type_validation` (the OMOP-type prefilter), which runs **only** under `omop_therapy_types_enabled()` — and types requires the master flag. So when the master flag is off the sole reader is unreachable. (Additionally `gate1_fail_closed` short-circuits to `False` while `_PATIENT_RELEASE_GATE_ENFORCE` is off, the current observe-only default.) Skipping the binding in legacy mode cannot change any verdict. When OMOP is **on**, the code path is byte-identical to before.

### Blocker chain status (QR4d orchestrator drain)
- ✅ #342 — master-gated the release-gate import in the therapy dispatch (`_omop_therapy_ids`)
- ✅ CB #4679 — extended CB's `eligible_for_therapy_related_things_from_lines` override to accept the OMOP consumer-id kwargs
- ✅ **this PR** — master-gates the last unconditional release-gate import (the `filter_by_patient_info` wrapper)

### Tests
- New regression (`TestFilterByPatientInfoLegacyNoReleaseGate`, mirrors #342's test): sets `EXACT_OMOP_THERAPY=False`, monkeypatches `sys.modules['trials.services.omop.patient_release_gate'] = None`, asserts the legacy wrapper still filters without importing it. Verified **non-vacuous** — fails with `ModuleNotFoundError` when the gate is removed.
- Full suite **1240 passed, 5 skipped** (OMOP off, CI-equivalent). OMOP-on path covered by the per-test-flag OMOP suites (`test_omop_therapy_types_matching`, `test_patient_release_gate`, `test_retrieve_match`, all green).

### Self-review
Two-part per policy, both reconciled:
- **codex** `--base 2omop`: clean — "legacy-mode early return prevents the optional release-gate import while preserving the existing filtering path; OMOP-enabled behavior retains the prior release-scope binding."
- **Fresh-context Claude subagent**: **SHIP** — independently traced the full contextvar reader chain (only consumer is the types-gated OMOP prefilter), confirmed OMOP-on byte-identical, master-gating is the correct gate, regression non-vacuous, exception-safety/None-path fine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)