### PR TITLE
feat(matcher): host-data-contract seam for USER_TO_TRIAL_ATTRS_MAPPING (WBC)

### DIFF
--- a/matcher_app/exact_matching/patient_info/configs.py
+++ b/matcher_app/exact_matching/patient_info/configs.py
@@ -1255,6 +1255,26 @@ USER_TO_TRIAL_ATTRS_MAPPING = {
     },
 }
 
+
+# Host-data-contract seam: a downstream host whose patient data uses a different
+# unit basis (or migration-window guard) for some attrs than EXACT's own contract
+# injects per-entry field overrides via the ``EXACT_ATTRS_MAPPING_OVERRIDES``
+# setting, so the extracted matcher body honours the host's contract without this
+# config hardcoding a single host. The canonical case is white_blood_cell_count:
+# CancerBot stores it in cells/µL with a ``sane_range`` migration guard (#4559/#4561),
+# EXACT in cells/L. Fields are shallow-merged over the base entry (matching keys
+# win); an unknown attr key is ignored. Default (setting unset) → EXACT unchanged.
+def _apply_attrs_mapping_overrides():
+    from django.conf import settings
+    overrides = getattr(settings, 'EXACT_ATTRS_MAPPING_OVERRIDES', None) or {}
+    for attr_key, field_overrides in overrides.items():
+        base = USER_TO_TRIAL_ATTRS_MAPPING.get(attr_key)
+        if base is not None:
+            USER_TO_TRIAL_ATTRS_MAPPING[attr_key] = {**base, **field_overrides}
+
+
+_apply_attrs_mapping_overrides()
+
 # -------
 # Disease
 # -------

--- a/tests/querysets/test_min_max_sane_range.py
+++ b/tests/querysets/test_min_max_sane_range.py
@@ -73,3 +73,46 @@ def test_in_band_threshold_matches_normally():
     qs = Trial.objects.filter(pk=t_ok.pk).eligible_for_min_max_value(
         _MIN, _MAX, 3000, sane_range=(0, 1_000_000))
     assert t_ok.pk in set(qs.values_list('pk', flat=True))
+
+
+class TestAttrsMappingHostOverride:
+    """Config-injection seam (QR4d orchestrator drain): a host injects per-entry
+    field overrides via EXACT_ATTRS_MAPPING_OVERRIDES so the shared config honours a
+    host data contract (CB's white_blood_cell_count is cells/µL + sane_range; EXACT's
+    is cells/L, no guard) without hardcoding one host. Default (setting unset) leaves
+    the EXACT contract untouched. Lets CB drain filter_by_patient_info to the package
+    body while staying behaviour-identical to its own retained orchestrator."""
+
+    def test_wbc_default_is_exact_contract(self):
+        from exact_matching.patient_info import configs
+        entry = configs.USER_TO_TRIAL_ATTRS_MAPPING['white_blood_cell_count']
+        assert entry['default_unit'] == 'cells/L'
+        assert 'sane_range' not in entry
+
+    def test_override_merges_host_fields_and_preserves_the_rest(self, settings):
+        from exact_matching.patient_info import configs
+        key = 'white_blood_cell_count'
+        original = dict(configs.USER_TO_TRIAL_ATTRS_MAPPING[key])
+        try:
+            settings.EXACT_ATTRS_MAPPING_OVERRIDES = {
+                key: {'default_unit': 'cells/UL', 'sane_range': (100, 100000)}
+            }
+            configs._apply_attrs_mapping_overrides()
+            entry = configs.USER_TO_TRIAL_ATTRS_MAPPING[key]
+            # overridden fields win
+            assert entry['default_unit'] == 'cells/UL'
+            assert entry['sane_range'] == (100, 100000)
+            # untouched fields preserved (shallow-merge, same object identity)
+            assert entry['attr'] == 'white_blood_cell_count'
+            assert entry['type'] == 'min_max_value'
+            assert entry['units_convertor'] is original['units_convertor']
+            assert entry['user_input_units_attr'] == original['user_input_units_attr']
+        finally:
+            configs.USER_TO_TRIAL_ATTRS_MAPPING[key] = original
+
+    def test_override_ignores_unknown_attr_key(self, settings):
+        from exact_matching.patient_info import configs
+        before = set(configs.USER_TO_TRIAL_ATTRS_MAPPING)
+        settings.EXACT_ATTRS_MAPPING_OVERRIDES = {'not_a_real_attr': {'default_unit': 'x'}}
+        configs._apply_attrs_mapping_overrides()  # must not raise or add the key
+        assert set(configs.USER_TO_TRIAL_ATTRS_MAPPING) == before


### PR DESCRIPTION
## Config-injection seam — the last divergence for the CB orchestrator drain

The flag-on orchestrator-drain shadow (CB `filter_by_patient_info` → package body, 743-test broad run) surfaced **exactly one** behavioural divergence: `white_blood_cell_count`. It's a genuine host data contract — CancerBot stores WBC in **cells/µL** with a `sane_range (100,100000)` migration guard (#4559/#4561, skips the min/max filter for not-yet-re-extracted trial thresholds), EXACT stores it in **cells/L** with no guard.

### The seam
`_apply_attrs_mapping_overrides()` reads the new `EXACT_ATTRS_MAPPING_OVERRIDES` setting (dict of `attr_key -> field-override dict`) and shallow-merges each into the matching `USER_TO_TRIAL_ATTRS_MAPPING` entry at config import. **Default (setting unset) → EXACT unchanged.** A host injects only the fields that differ.

### Why a shallow merge suffices (behaviour-identical for CB)
The two WBC entries are **identical** in `type`, `searchable`, `attr`, `units_convertor` (both `BaseConvertor`), and `user_input_units_attr` — they differ in **exactly two** fields: `default_unit` and `sane_range`. So CB injects just `{'default_unit': 'cells/UL', 'sane_range': (100,100000)}` and the package entry becomes byte-for-byte CB's own. No field needs removing.

No code path changes: the min_max machinery already forwards `sane_range=trial_attr_meta.get("sane_range")` into `eligible_for_min_max_value`, and `get_value`'s unit conversion already reads `default_unit`/`units_convertor`/`user_input_units_attr` — all present after the merge.

### Tests
3 regressions in `tests/querysets/test_min_max_sane_range.py`: default-is-EXACT-contract, override-merges-and-preserves-the-rest (incl. `units_convertor` identity), unknown-key-ignored. Full suite **1242 passed, 5 skipped** (OMOP off).

### Companion (not in this PR)
The CB side sets `EXACT_ATTRS_MAPPING_OVERRIDES = {'white_blood_cell_count': {...}}` and routes `filter_by_patient_info` to the package body (the actual drain flip) — landed after this + #347 merge and the CB pin bump.

### Blocker chain (QR4d orchestrator drain)
- ✅ #342 — master-gate release-gate import in therapy dispatch
- ✅ CB #4679 — CB therapy override accepts OMOP kwargs
- 🔵 #347 — master-gate release-scope import in `filter_by_patient_info` wrapper (open)
- 🔵 **this PR** — host-data-contract seam for the sole config divergence (WBC)

After both EXACT PRs merge → CB pin bump → CB drain PR (delegation + override + flag).

### Self-review
Two-part per policy, reconciled:
- **codex** `--base 2omop`: clean — "applied at config import, shallow-merges only known mapping entries, preserves default behavior when the setting is absent."
- **Fresh-context Claude subagent**: **SHIP** — verified import-time settings safety (configs imported only post-`django.setup()`; `exact/settings.py` never imports the chain), idempotency/no cross-test leak, and that the two WBC entries differ in exactly two add/replace fields so merge is sufficient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)