### PR TITLE
refactor(matcher): align MCL attr key order to CB (QR4d.3 trace-parity)

### DIFF
--- a/matcher_app/exact_matching/patient_info/configs.py
+++ b/matcher_app/exact_matching/patient_info/configs.py
@@ -485,16 +485,25 @@ USER_TO_TRIAL_ATTRS_MAPPING = {
     # CLL-specific END
 
     # MCL-specific START
-    "morphologic_variant": {
+    # Key order matches CB's USER_TO_TRIAL_ATTRS_MAPPING (source of truth) so
+    # filter_by_patient_info's add_traces trace order is byte-identical across the
+    # CB-orchestrator / package-orchestrator boundary (QR4d.3 drain follow-up).
+    "bulky_disease_criteria": {
         "type": ATTR_MAPPING_TYPE_COMPUTED,
         "custom_search": True,
+        # Host-agnostic seam (matches CB): CB exposes bulky_disease_criteria as a
+        # computed @property (no model field), so is_attr_blank's fallback
+        # get_field() would raise there. computed_value_type short-circuits that
+        # lookup with the value's type. Inert for EXACT, where it is a TextField —
+        # both resolve to the same str/'' blank check. is_computed_value is inert
+        # metadata (not read by the package) kept for parity.
+        "is_computed_value": True,
+        "computed_value_type": "str",
         "disease": "MCL",
-        "attr": ["morphologic_variants_required", "morphologic_variants_excluded"],
+        "attr": ["bulky_disease_criteria_required"],
         "uvalue_function": {
-            "morphologic_variants_required":
-                lambda patient_info: patient_info.morphologic_variant,
-            "morphologic_variants_excluded":
-                lambda patient_info: patient_info.morphologic_variant,
+            "bulky_disease_criteria_required":
+                lambda patient_info: patient_info.bulky_disease_criteria,
         }
     },
     "largest_lesion_size": {
@@ -516,6 +525,18 @@ USER_TO_TRIAL_ATTRS_MAPPING = {
         "attr_max": "p53_ihc_max",
         "attr": ["p53_ihc_min", "p53_ihc_max"],
     },
+    "morphologic_variant": {
+        "type": ATTR_MAPPING_TYPE_COMPUTED,
+        "custom_search": True,
+        "disease": "MCL",
+        "attr": ["morphologic_variants_required", "morphologic_variants_excluded"],
+        "uvalue_function": {
+            "morphologic_variants_required":
+                lambda patient_info: patient_info.morphologic_variant,
+            "morphologic_variants_excluded":
+                lambda patient_info: patient_info.morphologic_variant,
+        }
+    },
     "disease_behavior": {
         "type": ATTR_MAPPING_TYPE_COMPUTED,
         "custom_search": True,
@@ -534,16 +555,6 @@ USER_TO_TRIAL_ATTRS_MAPPING = {
         "uvalue_function": {
             "disease_subtypes_required":
                 lambda patient_info: patient_info.disease_subtype,
-        }
-    },
-    "extranodal_sites": {
-        "type": ATTR_MAPPING_TYPE_COMPUTED,
-        "custom_search": True,
-        "disease": "MCL",
-        "attr": ["extranodal_sites_required"],
-        "uvalue_function": {
-            "extranodal_sites_required":
-                lambda patient_info: patient_info.extranodal_sites,
         }
     },
     "mipi_risk": {
@@ -566,22 +577,14 @@ USER_TO_TRIAL_ATTRS_MAPPING = {
                 lambda patient_info: patient_info.mipi_c_risk,
         }
     },
-    "bulky_disease_criteria": {
+    "extranodal_sites": {
         "type": ATTR_MAPPING_TYPE_COMPUTED,
         "custom_search": True,
-        # Host-agnostic seam (matches CB): CB exposes bulky_disease_criteria as a
-        # computed @property (no model field), so is_attr_blank's fallback
-        # get_field() would raise there. computed_value_type short-circuits that
-        # lookup with the value's type. Inert for EXACT, where it is a TextField —
-        # both resolve to the same str/'' blank check. is_computed_value is inert
-        # metadata (not read by the package) kept for parity.
-        "is_computed_value": True,
-        "computed_value_type": "str",
         "disease": "MCL",
-        "attr": ["bulky_disease_criteria_required"],
+        "attr": ["extranodal_sites_required"],
         "uvalue_function": {
-            "bulky_disease_criteria_required":
-                lambda patient_info: patient_info.bulky_disease_criteria,
+            "extranodal_sites_required":
+                lambda patient_info: patient_info.extranodal_sites,
         }
     },
     # Authoring compound/"tiered" rules (e.g. Jain classification, NCT05861050):

--- a/tests/querysets/test_custom_search_dispatch.py
+++ b/tests/querysets/test_custom_search_dispatch.py
@@ -38,6 +38,24 @@ def test_omop_therapy_ids_legacy_returns_none_without_importing_release_gate(mon
     assert _omop_therapy_ids({}) == (None, None)  # missing key == off
 
 
+def test_mcl_attr_block_key_order_matches_cb():
+    """QR4d.3 drain follow-up: the MCL attr block key order must match CB's
+    USER_TO_TRIAL_ATTRS_MAPPING (the source of truth). filter_by_patient_info
+    iterates mapping.keys(), so a divergent order makes the add_traces trace order
+    (and per-step records/dropped) differ across the CB-orchestrator / package-
+    orchestrator boundary for an MCL patient. Re-drift here silently re-introduces
+    that divergence — the drain review caught it because the package block had been
+    reordered vs CB."""
+    from exact_matching.patient_info.configs import USER_TO_TRIAL_ATTRS_MAPPING
+    keys = list(USER_TO_TRIAL_ATTRS_MAPPING)
+    i = keys.index('bone_marrow_involvement')
+    assert keys[i + 1:i + 10] == [
+        'bulky_disease_criteria', 'largest_lesion_size', 'p53_ihc',
+        'morphologic_variant', 'disease_behavior', 'disease_subtype',
+        'mipi_risk', 'mipi_c_risk', 'extranodal_sites',
+    ]
+
+
 # Stateful handlers that take ctx — they call multiple queryset methods or
 # branch on ctx, so the "exactly one queryset call with the value" assertion
 # doesn't fit. Verified by hand in the dispatch refactor and covered by the


### PR DESCRIPTION
## Trace-parity follow-up to the orchestrator drain (QR4d.3)

`filter_by_patient_info` iterates `USER_TO_TRIAL_ATTRS_MAPPING.keys()`, so the config key order drives the `add_traces` trace order (and per-step `records`/`dropped`). The package block for ~9 MCL attrs had drifted from CB during extraction, so an MCL patient got a different **trace order** across the CB-orchestrator / package-orchestrator boundary — the note the CB drain review (#4693) flagged. Diagnostic-only: no effect on the returned trial set or matcher verdict (filtering is a commutative AND).

### Change
Reorder the MCL block to match CB (source of truth):
`bulky_disease_criteria, largest_lesion_size, p53_ihc, morphologic_variant, disease_behavior, disease_subtype, mipi_risk, mipi_c_risk, extranodal_sites`.

**Pure reorder — entry contents unchanged.** Proven by AST: all 133 mapping entry bodies (lambdas included) are byte-identical to `HEAD~1`; only the order of the 9 MCL keys changed; a sorted-line diff of the file shows only the 3 new comment lines. After this, the package's **full 133-key order matches CB exactly** — zero residual divergence.

### Verified end-to-end
With this package, CB `filter_by_patient_info(add_traces=True)` is **byte-identical flag-off vs flag-on for an MCL patient** (temp cross-check). Full EXACT suite **1243 passed** (OMOP off).

### Regression
`test_mcl_attr_block_key_order_matches_cb` pins the 9-key block order so it can't re-drift from CB (non-vacuous; any reorder fails it).

### Companion
CB bumps its `exact-matching` pin to include this so the flag-on trace path becomes byte-identical in CB CI too (small follow-up PR).

### Self-review
Two-part, reconciled:
- **codex** `--base 2omop`: clean — "only reorders the MCL mapping entries + adds a regression test; metadata and filtering behavior unchanged."
- **Fresh-context Claude subagent**: **SHIP** — AST-proved all 133 bodies byte-identical, full key list now equals CB's, no order-dependent logic breakage (`is_therapies_filter_applied` guard / `criteria_count_match` unaffected; no dict-first/last assumptions), structural test correct. One minor non-blocking note: no EXACT-side golden-trace test (the structural test is the proxy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)