### PR TITLE
test(omop): pin the CB↔EXACT projection-checksum golden vector (gap #2)

### DIFF
--- a/tests/services/test_projection_checksum.py
+++ b/tests/services/test_projection_checksum.py
@@ -21,6 +21,23 @@ def _trial(code, required=None, excluded=None):
                         omop_therapy_types_excluded=excluded or [])
 
 
+def test_golden_vector_locks_cb_contract():
+    """The frozen CB↔EXACT byte contract, pinned to a hardcoded hash on BOTH sides.
+
+    CB's publisher (cancerbot #4696) asserts this SAME vector, so neither repo can change
+    the checksum domain (normalization / sort / JSON serialization / universe) without a
+    red test. Self-consistency tests alone would let EXACT drift silently and break the
+    gap-#2 gate (EXACT's recompute would stop matching CB's published manifest_checksum,
+    failing closed on every projection). If this changes, change it in lockstep with CB.
+    """
+    _trial('NCT-A', [35803229, 35803227], [35803228])
+    _trial('NCT-B')
+    digest, count = compute_trial_projection_checksum()
+    assert count == 2
+    assert digest == (
+        'bace8c2843d1ce44f658332e8647927a647563f3b4b1ddb808850a2fad927d12')
+
+
 def test_normalize_sorts_dedups_stringifies():
     assert _normalize([3, 1, 2, 2]) == ['1', '2', '3']
     assert _normalize(None) == []


### PR DESCRIPTION
Hardens the frozen **CB↔EXACT checksum contract** — the linchpin of Gate 1 gap #2 (Design S).

## Why
CB's publisher (cancerbot #4696) computes `manifest_checksum` over a projection; EXACT recomputes the **byte-identical** value and fails closed unless they match. The two `compute_trial_projection_checksum` implementations are separate copies. CB's test pins a hardcoded golden hash — but EXACT's test asserted only **self-consistency** (determinism, order/dup independence). So a future change to EXACT's checksum domain (normalization / sort / JSON serialization / universe) would stay green here while silently diverging from CB → at runtime EXACT's recompute stops matching CB's published `manifest_checksum` and **fails closed on every projection** (the whole type-matching feature breaks).

## What
Pin the **same** golden vector CB asserts: input `[NCT-A: required 35803229/35803227, excluded 35803228; NCT-B: empty]` → sha256 `bace8c2843d1ce44f658332e8647927a647563f3b4b1ddb808850a2fad927d12`, count 2. Now **neither repo can drift the checksum domain without a red test**.

Passing here also **proves byte-identity with CB's implementation today** (not just "should be").

Test-only; no production code. Reviewed: `codex review` + fresh-context subagent — both independently recomputed the hash and confirmed the match. Closes the fresh-review follow-up from cancerbot #4702 (S2). Part of #350 / epic (ratified in the CB ADR `docs/omop/adr-projection-revocation-trigger.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)