### PR TITLE
port(cb): accept several trial purposes in the purpose filter (#354)

### DIFF
--- a/cb_to_exact_port_reference.md
+++ b/cb_to_exact_port_reference.md
@@ -173,7 +173,7 @@ EXACT takes the same list of codes (#354) and keeps two differences on purpose:
 | trials whose purpose was never extracted | kept (`Q(purpose__isnull=True)`) | dropped | CB has applied this filter to every user by default since #4650, so an exact match would drop the whole unextracted corpus from the first page a patient sees. EXACT filters only when a caller asks it to. |
 | case | exact | `iexact` | pre-existing here; mirrors `by_trial_type` through `eligible_for_relation` |
 
-**Watch out**: CB's `StudyInfo.trial_purpose` now defaults to `["treatment"]`. A consumer forwarding CB's stored default straight to EXACT would silently lose every trial with no extracted purpose — the leniency that makes that default safe lives in CB's copy only. No CB→EXACT client exists today.
+**DRAIN-BLOCKING.** CB's `TrialQuerySet` subclasses this one and overrides `by_trial_purpose` (CB `trials/querysets/trial.py` on `2omop`). The two are **not** evaluated-result-identical, so this predicate must not be drained under QR2 of CB's `docs/exact-queryset-reconciliation.md`. Dropping CB's override would hand CB the strict version, and since #4650 defaults every CB user to `["treatment"]`, the first page a patient sees would silently lose every trial whose purpose was never extracted. Same trap for anyone forwarding CB's stored selection to this API directly.
 
 ---
 

--- a/cb_to_exact_port_reference.md
+++ b/cb_to_exact_port_reference.md
@@ -154,15 +154,26 @@ EXACT target: create `trials/trial_taxonomy.py` mirroring the structure, plus a 
 
 ---
 
-## Issue: by_trial_purpose() queryset
+## Issue: by_trial_purpose() queryset — PORTED, with deliberate divergences
 
-CB source: `trials/querysets/trial.py:407-410`
+CB source as of cancerbot-org/cancerbot#4663 (`trials/querysets/trial.py`):
 ```python
-def by_trial_purpose(self, purpose):
-    return self.filter(purpose=purpose)
+if isinstance(trial_purpose, str):
+    trial_purpose = [trial_purpose] if trial_purpose else []
+codes = [code for code in (trial_purpose or []) if code]
+if not codes:
+    return self
+return self.filter(Q(purpose__code__in=codes) | Q(purpose__isnull=True))
 ```
 
-Note: requires `Trial.purpose` FK to a `TrialPurpose` model — check if EXACT has either; likely needs both model + field + queryset method.
+EXACT takes the same list of codes (#354) and keeps two differences on purpose:
+
+| | CB | EXACT | Why |
+|---|---|---|---|
+| trials whose purpose was never extracted | kept (`Q(purpose__isnull=True)`) | dropped | CB has applied this filter to every user by default since #4650, so an exact match would drop the whole unextracted corpus from the first page a patient sees. EXACT filters only when a caller asks it to. |
+| case | exact | `iexact` | pre-existing here; mirrors `by_trial_type` through `eligible_for_relation` |
+
+**Watch out**: CB's `StudyInfo.trial_purpose` now defaults to `["treatment"]`. A consumer forwarding CB's stored default straight to EXACT would silently lose every trial with no extracted purpose — the leniency that makes that default safe lives in CB's copy only. No CB→EXACT client exists today.
 
 ---
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -121,6 +121,7 @@ trial-search request.
 | `sponsor` | string | Filter by sponsor name |
 | `register` | string | Filter by trial register (e.g. `clinicaltrials.gov`) |
 | `trialType` | string | Filter by trial-type code |
+| `trialPurpose` | string, repeatable | Filter by trial-purpose code (`treatment`, `screening`, …), case-insensitive. Several purposes are a union — a trial matching any of them comes back: repeat the param (`?trialPurpose=treatment&trialPurpose=supportive_care`) or pass one comma-separated value. Trials whose purpose was never extracted are not returned. |
 | `validatedOnly` | boolean | Only return manually validated trials |
 | `distance` | number | Maximum distance from patient location |
 | `distanceUnits` | `km` \| `miles` | Units for `distance` (default `km`) |

--- a/matcher_app/exact_matching/querysets/trial.py
+++ b/matcher_app/exact_matching/querysets/trial.py
@@ -649,8 +649,9 @@ class TrialQuerySet(models.QuerySet):
         patient sees. Here a caller only gets the filter by asking for it.
         """
         # Scalar unless it is genuinely a collection of them, rather than a
-        # whitelist of container types: a frozenset or a generator would
-        # otherwise fall through and reach SQL as a literal object.
+        # whitelist of container types: a frozenset would otherwise fall through
+        # and reach SQL as a literal object. Anything not iterable at all stays
+        # a scalar, the way it was before this took lists.
         if (
             trial_purpose is None
             or isinstance(trial_purpose, str)
@@ -658,17 +659,23 @@ class TrialQuerySet(models.QuerySet):
         ):
             values = [trial_purpose]
         else:
-            values = list(trial_purpose)
-        # Sorted when the caller's own order is arbitrary, so the same request
-        # does not render as two different statements between processes.
+            try:
+                values = list(trial_purpose)
+            except TypeError:
+                values = [trial_purpose]
+        # Sorted when the caller's own order is arbitrary, so the same selection
+        # does not render as two different statements between processes. By code
+        # rather than str(), which for a TrialPurpose is its title.
         if isinstance(trial_purpose, (set, frozenset)):
-            values.sort(key=str)
+            values.sort(key=lambda value: str(getattr(value, 'code', value)))
 
         # Deduplicated the way they are matched, keeping the first spelling, or
         # 'treatment,TREATMENT' is two clauses selecting the same rows.
         codes, seen = [], set()
         for value in values:
             code = getattr(value, 'code', value)
+            if isinstance(code, str):
+                code = code.strip()
             if code is None or code == '':
                 continue
             key = str(code).casefold()
@@ -679,12 +686,11 @@ class TrialQuerySet(models.QuerySet):
 
         if not codes:
             return self
-        if len(codes) == 1:
-            return self.eligible_for_relation('purpose__code', codes[0])
 
-        # Spelled out rather than through eligible_for_relation, which takes one
-        # value, and as an OR of iexact rather than __in, which would quietly
-        # make the multi-code path case-sensitive where the single one is not.
+        # An OR of iexact rather than __in, which would quietly make this
+        # case-sensitive where the rest of the class is not. A single code
+        # renders exactly what eligible_for_relation builds, so it is not given
+        # a path of its own to drift from.
         condition = Q()
         for code in codes:
             condition |= Q(purpose__code__iexact=code)

--- a/matcher_app/exact_matching/querysets/trial.py
+++ b/matcher_app/exact_matching/querysets/trial.py
@@ -639,13 +639,56 @@ class TrialQuerySet(models.QuerySet):
         return self.eligible_for_relation('trial_type__code', trial_type)
 
     def by_trial_purpose(self, trial_purpose):
-        """Filter by Trial.purpose. Accepts a code string or a TrialPurpose
-        instance (uses its `.code`); blank/None is a no-op.
+        """Filter by Trial.purpose. Accepts a list of codes (CB #4663), a single
+        code string, or a TrialPurpose instance (uses its `.code`); an empty
+        selection is a no-op. A trial matching any of the codes is kept.
+
+        Strict about trials whose purpose was never extracted, where CB's copy
+        keeps them: there the filter applies to every user by default, so an
+        exact match would drop every unextracted trial from the first page a
+        patient sees. Here a caller only gets the filter by asking for it.
         """
-        if trial_purpose is None or trial_purpose == '':
+        # Scalar unless it is genuinely a collection of them, rather than a
+        # whitelist of container types: a frozenset or a generator would
+        # otherwise fall through and reach SQL as a literal object.
+        if (
+            trial_purpose is None
+            or isinstance(trial_purpose, str)
+            or hasattr(trial_purpose, 'code')
+        ):
+            values = [trial_purpose]
+        else:
+            values = list(trial_purpose)
+        # Sorted when the caller's own order is arbitrary, so the same request
+        # does not render as two different statements between processes.
+        if isinstance(trial_purpose, (set, frozenset)):
+            values.sort(key=str)
+
+        # Deduplicated the way they are matched, keeping the first spelling, or
+        # 'treatment,TREATMENT' is two clauses selecting the same rows.
+        codes, seen = [], set()
+        for value in values:
+            code = getattr(value, 'code', value)
+            if code is None or code == '':
+                continue
+            key = str(code).casefold()
+            if key in seen:
+                continue
+            seen.add(key)
+            codes.append(code)
+
+        if not codes:
             return self
-        code = getattr(trial_purpose, 'code', trial_purpose)
-        return self.eligible_for_relation('purpose__code', code)
+        if len(codes) == 1:
+            return self.eligible_for_relation('purpose__code', codes[0])
+
+        # Spelled out rather than through eligible_for_relation, which takes one
+        # value, and as an OR of iexact rather than __in, which would quietly
+        # make the multi-code path case-sensitive where the single one is not.
+        condition = Q()
+        for code in codes:
+            condition |= Q(purpose__code__iexact=code)
+        return self.filter(condition)
 
     def by_study_type(self, study_type):
         if not study_type or str(study_type).upper() in ('', 'ALL'):

--- a/tests/querysets/test_trial_querysets.py
+++ b/tests/querysets/test_trial_querysets.py
@@ -797,6 +797,8 @@ class TestTrialQuerySet:
         # None / empty is a no-op (returns full set)
         assert list(Trial.objects.by_trial_purpose(None).order_by('id')) == [t1, t2, t3, t4]
         assert list(Trial.objects.by_trial_purpose('').order_by('id')) == [t1, t2, t3, t4]
+        assert list(Trial.objects.by_trial_purpose([]).order_by('id')) == [t1, t2, t3, t4]
+        assert list(Trial.objects.by_trial_purpose(['']).order_by('id')) == [t1, t2, t3, t4]
 
         # Code-string accepted, case-insensitive (mirrors by_trial_type via eligible_for_relation)
         assert list(Trial.objects.by_trial_purpose('treatment').order_by('id')) == [t1, t2]
@@ -808,8 +810,55 @@ class TestTrialQuerySet:
         assert list(Trial.objects.by_trial_purpose(treatment).order_by('id')) == [t1, t2]
         assert list(Trial.objects.by_trial_purpose(prevention).order_by('id')) == [t3]
 
+        # Several purposes at once (CB #4663): the union, not the intersection
+        assert list(Trial.objects.by_trial_purpose(['treatment']).order_by('id')) == [t1, t2]
+        assert list(
+            Trial.objects.by_trial_purpose(['treatment', 'prevention']).order_by('id')
+        ) == [t1, t2, t3]
+        # ...case-insensitive on that path too, and instances still accepted
+        assert list(
+            Trial.objects.by_trial_purpose(['TREATMENT', 'Prevention']).order_by('id')
+        ) == [t1, t2, t3]
+        assert list(
+            Trial.objects.by_trial_purpose([treatment, prevention]).order_by('id')
+        ) == [t1, t2, t3]
+
+        # Any collection of codes, not a whitelist of container types
+        assert list(
+            Trial.objects.by_trial_purpose(('treatment', 'prevention')).order_by('id')
+        ) == [t1, t2, t3]
+        assert list(
+            Trial.objects.by_trial_purpose({'treatment', 'prevention'}).order_by('id')
+        ) == [t1, t2, t3]
+        assert list(
+            Trial.objects.by_trial_purpose(frozenset(['treatment'])).order_by('id')
+        ) == [t1, t2]
+        assert list(
+            Trial.objects.by_trial_purpose(c for c in ('treatment',)).order_by('id')
+        ) == [t1, t2]
+
+        # A purpose nobody has adds nothing and takes nothing away
+        assert list(
+            Trial.objects.by_trial_purpose(['treatment', 'nonexistent']).order_by('id')
+        ) == [t1, t2]
+        # Blanks in the list are dropped, not treated as a purpose
+        assert list(
+            Trial.objects.by_trial_purpose(['', 'treatment']).order_by('id')
+        ) == [t1, t2]
+
+        # The same purpose twice, in either spelling, is still one clause and
+        # one row per trial — the filter must not fan the join out.
+        repeated = Trial.objects.by_trial_purpose(['treatment', 'TREATMENT'])
+        assert list(repeated.order_by('id')) == [t1, t2]
+        assert repeated.count() == repeated.distinct().count()
+
         # Unknown code → empty queryset
         assert list(Trial.objects.by_trial_purpose('nonexistent').order_by('id')) == []
+        assert list(Trial.objects.by_trial_purpose(['nonexistent']).order_by('id')) == []
+
+        # A trial whose purpose was never extracted stays out whatever is asked
+        # for — unlike CB, where this filter is on by default for everyone.
+        assert t4 not in list(Trial.objects.by_trial_purpose(['treatment', 'prevention']))
 
     @pytest.mark.django_db
     def test_by_study_type(self):

--- a/tests/querysets/test_trial_querysets.py
+++ b/tests/querysets/test_trial_querysets.py
@@ -833,8 +833,20 @@ class TestTrialQuerySet:
         assert list(
             Trial.objects.by_trial_purpose(frozenset(['treatment'])).order_by('id')
         ) == [t1, t2]
+        # A one-shot iterator is deliberately NOT canonised: filter_by_study_info
+        # reads study_info.trial_purpose twice, once to filter and once for the
+        # trace, and the second read of a generator is empty.
+
+        # Something that is not a collection at all is still treated as one
+        # code rather than raising TypeError on the way in — same as before
+        # this took lists. (Postgres then rejects UPPER(int) on evaluation,
+        # which it did then too; the point is that building the queryset does
+        # not blow up in a new place.)
+        Trial.objects.by_trial_purpose(5)
+
+        # Surrounding whitespace is not part of a code, matching the parser
         assert list(
-            Trial.objects.by_trial_purpose(c for c in ('treatment',)).order_by('id')
+            Trial.objects.by_trial_purpose([' treatment ']).order_by('id')
         ) == [t1, t2]
 
         # A purpose nobody has adds nothing and takes nothing away
@@ -859,6 +871,40 @@ class TestTrialQuerySet:
         # A trial whose purpose was never extracted stays out whatever is asked
         # for — unlike CB, where this filter is on by default for everyone.
         assert t4 not in list(Trial.objects.by_trial_purpose(['treatment', 'prevention']))
+
+    @pytest.mark.django_db
+    def test_by_trial_purpose_reaches_the_filter_through_study_info(self):
+        """The plumbing, not just the predicate: StudyPreferences now carries a
+        list where it carried a string, and nothing else covers that hop."""
+        from trials.services.study_preferences import (
+            StudyPreferences,
+            study_preferences_from_query_params,
+        )
+
+        treatment = TrialPurposeFactory(code='treatment', title='Treatment')
+        prevention = TrialPurposeFactory(code='prevention', title='Prevention')
+
+        t1 = TrialFactory(purpose=treatment)
+        t2 = TrialFactory(purpose=prevention)
+        TrialFactory(purpose=TrialPurposeFactory(code='screening', title='Screening'))
+        TrialFactory(purpose=None)
+
+        prefs = StudyPreferences(trial_purpose=['treatment', 'prevention'])
+        filtered, _ = Trial.objects.filter_by_study_info(prefs)
+        assert list(filtered.order_by('id')) == [t1, t2]
+
+        # ...and the same set arriving as a query string
+        from django.http import QueryDict
+
+        prefs = study_preferences_from_query_params(
+            QueryDict('trialPurpose=treatment&trialPurpose=prevention')
+        )
+        filtered, _ = Trial.objects.filter_by_study_info(prefs)
+        assert list(filtered.order_by('id')) == [t1, t2]
+
+        # An empty selection is no filter at all
+        filtered, _ = Trial.objects.filter_by_study_info(StudyPreferences())
+        assert filtered.count() == 4
 
     @pytest.mark.django_db
     def test_by_study_type(self):

--- a/tests/services/test_study_preferences.py
+++ b/tests/services/test_study_preferences.py
@@ -59,6 +59,14 @@ class TestStudyPreferencesParsing:
         )
         assert prefs.trial_purpose == ['treatment', 'supportive_care']
 
+    def test_trial_purpose_is_capped(self):
+        # Each code becomes another OR clause and the taxonomy has nine
+        # purposes, so a query string must not be able to ask for thousands.
+        many = ','.join(f'code_{i}' for i in range(200))
+        prefs = study_preferences_from_query_params({'trialPurpose': many})
+        assert len(prefs.trial_purpose) == 50
+        assert prefs.trial_purpose[0] == 'code_0'
+
     def test_trial_purpose_independent_from_trial_type(self):
         prefs = study_preferences_from_query_params({
             'trialType': 'interventional',

--- a/tests/services/test_study_preferences.py
+++ b/tests/services/test_study_preferences.py
@@ -1,4 +1,6 @@
 """Tests for StudyPreferences dataclass + query-param parsing."""
+from django.http import QueryDict
+
 from trials.services.study_preferences import (
     StudyPreferences,
     study_preferences_from_query_params,
@@ -9,15 +11,53 @@ class TestStudyPreferencesParsing:
     def test_trial_purpose_param_populated(self):
         """`?trialPurpose=treatment` should land on `study_info.trial_purpose` (#44)."""
         prefs = study_preferences_from_query_params({'trialPurpose': 'treatment'})
-        assert prefs.trial_purpose == 'treatment'
+        assert prefs.trial_purpose == ['treatment']
 
-    def test_trial_purpose_param_absent_defaults_to_none(self):
+    def test_trial_purpose_param_absent_defaults_to_empty(self):
         prefs = study_preferences_from_query_params({})
-        assert prefs.trial_purpose is None
+        assert prefs.trial_purpose == []
 
-    def test_trial_purpose_empty_string_normalized_to_none(self):
+    def test_trial_purpose_empty_string_normalized_away(self):
         prefs = study_preferences_from_query_params({'trialPurpose': ''})
-        assert prefs.trial_purpose is None
+        assert prefs.trial_purpose == []
+
+    def test_trial_purpose_repeated_param(self):
+        """Several purposes at once (CB #4663), the therapy_id spelling.
+
+        Through a real QueryDict, which is what DRF hands the parser.
+        """
+        params = QueryDict('trialPurpose=treatment&trialPurpose=supportive_care')
+        prefs = study_preferences_from_query_params(params)
+        assert prefs.trial_purpose == ['treatment', 'supportive_care']
+
+    def test_trial_purpose_blank_repeat_dropped(self):
+        params = QueryDict('trialPurpose=&trialPurpose=treatment')
+        assert study_preferences_from_query_params(params).trial_purpose == ['treatment']
+
+    def test_trial_purpose_none_value_is_not_a_code(self):
+        # A dict-like caller can hand us None where a QueryDict never would;
+        # stringified it would become the code 'None' and match nothing.
+        prefs = study_preferences_from_query_params({'trialPurpose': None})
+        assert prefs.trial_purpose == []
+
+    def test_trial_purpose_deduplicated_case_insensitively(self):
+        # The queryset matches iexact, so these are one purpose, not two.
+        prefs = study_preferences_from_query_params(
+            {'trialPurpose': 'treatment,TREATMENT'}
+        )
+        assert prefs.trial_purpose == ['treatment']
+
+    def test_trial_purpose_comma_separated(self):
+        prefs = study_preferences_from_query_params(
+            {'trialPurpose': 'treatment, supportive_care'}
+        )
+        assert prefs.trial_purpose == ['treatment', 'supportive_care']
+
+    def test_trial_purpose_deduplicated(self):
+        prefs = study_preferences_from_query_params(
+            {'trialPurpose': 'treatment,treatment,,supportive_care'}
+        )
+        assert prefs.trial_purpose == ['treatment', 'supportive_care']
 
     def test_trial_purpose_independent_from_trial_type(self):
         prefs = study_preferences_from_query_params({
@@ -25,7 +65,12 @@ class TestStudyPreferencesParsing:
             'trialPurpose': 'treatment',
         })
         assert prefs.trial_type == 'interventional'
-        assert prefs.trial_purpose == 'treatment'
+        assert prefs.trial_purpose == ['treatment']
 
     def test_dataclass_default(self):
-        assert StudyPreferences().trial_purpose is None
+        assert StudyPreferences().trial_purpose == []
+
+    def test_dataclass_default_is_not_shared(self):
+        first = StudyPreferences()
+        first.trial_purpose.append('treatment')
+        assert StudyPreferences().trial_purpose == []

--- a/trials/services/study_preferences.py
+++ b/trials/services/study_preferences.py
@@ -82,12 +82,19 @@ def study_preferences_from_query_params(params) -> StudyPreferences:
             return value if isinstance(value, list) else [value]
         return []
 
-    def _str_list(key):
+    def _str_list(key, limit=50):
         """Repeated params and one comma-separated value both spell a list.
 
-        CB's /trials/form-settings/ reads the purpose param both ways, and a
-        caller holding the pre-#4663 single-value contract keeps working under
-        either spelling.
+        Repetition is the query-string convention, and what CB's
+        /trials/form-settings/ reads for its own `trial_purpose` param — but not
+        every caller can emit it, so one comma-separated value is accepted too.
+        Either way a caller holding the pre-#4663 single-value contract keeps
+        working.
+
+        Capped, because every code becomes another clause in the WHERE: the
+        purpose taxonomy has nine entries, so a longer list is junk, and an
+        unvalidated query string should not turn into thousands of them. CB
+        bounds the same field at 50.
         """
         codes = [
             code.strip()
@@ -102,7 +109,7 @@ def study_preferences_from_query_params(params) -> StudyPreferences:
             if code and code.casefold() not in seen:
                 seen.add(code.casefold())
                 result.append(code)
-        return result
+        return result[:limit]
 
     def _int_list(key):
         result = []

--- a/trials/services/study_preferences.py
+++ b/trials/services/study_preferences.py
@@ -26,7 +26,9 @@ class StudyPreferences:
 
     # Trial classification filters
     trial_type: Optional[str] = None
-    trial_purpose: Optional[str] = None
+    # Several purposes at once (CB #4663), like therapy_id above: accepts
+    # ?trialPurpose= one or more times. Empty means no filter.
+    trial_purpose: list[str] = field(default_factory=list)
     study_type: Optional[str] = None
 
     # Recruitment filter
@@ -72,16 +74,39 @@ def study_preferences_from_query_params(params) -> StudyPreferences:
         val = params.get(key)
         return val if val else None
 
-    def _int_list(key):
+    def _raw_list(key):
         if hasattr(params, 'getlist'):
-            raw = params.getlist(key)
-        elif key in params:
-            v = params[key]
-            raw = v if isinstance(v, list) else [v]
-        else:
-            raw = []
+            return params.getlist(key)
+        if key in params:
+            value = params[key]
+            return value if isinstance(value, list) else [value]
+        return []
+
+    def _str_list(key):
+        """Repeated params and one comma-separated value both spell a list.
+
+        CB's /trials/form-settings/ reads the purpose param both ways, and a
+        caller holding the pre-#4663 single-value contract keeps working under
+        either spelling.
+        """
+        codes = [
+            code.strip()
+            for value in _raw_list(key)
+            if value is not None  # or a dict-like caller's None becomes 'None'
+            for code in str(value).split(',')
+        ]
+        # Deduplicated the way the queryset matches them — case-insensitively,
+        # first spelling wins.
+        result, seen = [], set()
+        for code in codes:
+            if code and code.casefold() not in seen:
+                seen.add(code.casefold())
+                result.append(code)
+        return result
+
+    def _int_list(key):
         result = []
-        for v in raw:
+        for v in _raw_list(key):
             try:
                 result.append(int(v))
             except (TypeError, ValueError):
@@ -97,7 +122,7 @@ def study_preferences_from_query_params(params) -> StudyPreferences:
         register=_str('register'),
         study_id=_str('studyId'),
         trial_type=_str('trialType'),
-        trial_purpose=_str('trialPurpose'),
+        trial_purpose=_str_list('trialPurpose'),
         study_type=_str('studyType'),
         recruitment_status=_str('recruitmentStatus'),
         country=_str('country'),


### PR DESCRIPTION
Ports cancerbot-org/cancerbot#4663 (CB PR #4700), where the trial purpose filter became multi-value. Treatment + Supportive Care is one search a patient legitimately wants, and this engine reads the same queryset code.

Closes #354

> Rebased from `main` onto **`2omop`**, which is where CB + EXACT migration changes accumulate. That also moved the change into the extracted package: on this branch `trials/querysets/trial.py` is only a re-export shim over `matcher_app/exact_matching/`, so the version I first wrote against `main` would not have executed here at all.

## What changed

- **`by_trial_purpose()`** takes a collection of codes and returns trials matching any of them, still accepting the shapes it already did: one code string, or a `TrialPurpose` instance. Written as an OR of `iexact` rather than `__in`, which would have made it case-sensitive where the rest of the class is not. Codes are deduplicated the way they are matched (case-insensitively, first spelling wins), whitespace-stripped, and a set input is sorted by code so the same selection cannot render as two different statements. `purpose` is a forward FK, so it stays one join with no row multiplication — pinned by a `count() == distinct().count()` assert.
- **`StudyPreferences.trial_purpose`** is a `list[str]`, filled from a repeated `?trialPurpose=` the way `therapy_id` already is, or from one comma-separated value. Capped at 50, as CB caps the same field: each code is another clause in the WHERE, the taxonomy has nine purposes, and this arrives from an unvalidated query string.
- `_int_list` now shares its raw-param reader with the new `_str_list` instead of repeating it.
- `docs/api.md` gains the `trialPurpose` row — it was not documented at all.

## Deliberately not ported, and it blocks a drain

CB also keeps trials whose purpose was never extracted (`Q(purpose__isnull=True)`). That leniency exists because CB has applied this filter to **every** user by default since #4650, so an exact match would drop the whole unextracted corpus from the first page a patient sees. Here the filter only exists when a caller asks for it, and adding the leniency would quietly widen every existing caller's result set.

CB's `TrialQuerySet` subclasses this one and overrides `by_trial_purpose`, so the two are **not** evaluated-result-identical: this predicate must not be drained under QR2 of CB's `docs/exact-queryset-reconciliation.md`. `cb_to_exact_port_reference.md` now says so — worth mirroring one line into CB's reconciliation doc when someone is next on that branch.

## Verification

CI is green — build and all three test shards. Locally two tests fail (`test_filter_by_patient_info`, `test_blank_list_attrs_not_in_traces`), but they fail on the untouched merge-base too (verified by stashing and by running an exported copy of the base in a clean tree) and they pass in CI, so they are an artefact of my machine's environment, not of this branch. 1292 pass locally either way.

New coverage: several purposes at once, case-insensitivity on that path, `TrialPurpose` instances in a list, tuple/set/frozenset inputs, blanks, duplicates in either spelling, whitespace, the join not fanning out, the 50 cap, the parser through a real `QueryDict`, and the hop nothing covered before — `StudyPreferences` → `filter_by_study_info` → the filter, which is exactly where the field's type changed from `str` to `list[str]`.

Reviewed twice on this base (fresh-context Claude + `codex review`); the second commit is the first review's findings.
