### PR TITLE
feat(matcher): host-agnostic study_info.therapy_id + apply_trial_purpose (A2 R2)

### DIFF
--- a/matcher_app/exact_matching/querysets/trial.py
+++ b/matcher_app/exact_matching/querysets/trial.py
@@ -339,12 +339,22 @@ class TrialQuerySet(models.QuerySet):
 
         query = self
 
-        # therapy_id applies to all search paths (standard and admin).
+        # therapy_id applies to all search paths (standard and admin). It is an
+        # EXACT-native OMOP search param (?therapy_id=, PR #211/#212). Read it
+        # host-agnostically: a host whose study_info has no such field (e.g. CB's
+        # StudyInfo model) simply doesn't do therapy-id search, and by_therapy_id
+        # no-ops on the resulting None — so the shared body runs on that host too.
         if study_info:
-            query = query.by_therapy_id(study_info.therapy_id)
+            query = query.by_therapy_id(getattr(study_info, 'therapy_id', None))
 
         if search_type in ['all', 'favorites', 'my_trials']:
-            query, _ = query.filter_for_admin(study_info, patient_info)
+            # Favorites / my_trials are trials the patient picked by hand — do NOT apply
+            # the trial-purpose filter to them (it would drop saved trials with a
+            # non-matching purpose off the only page that lists them). Matches CB.
+            query, _ = query.filter_for_admin(
+                study_info, patient_info,
+                apply_trial_purpose=search_type not in ('favorites', 'my_trials'),
+            )
             max_distance = D(mi=1000)
             if study_info.distance:
                 max_distance = D(mi=study_info.distance) if str(study_info.distance_units).lower() == 'miles' else D(
@@ -363,7 +373,7 @@ class TrialQuerySet(models.QuerySet):
 
             return query, list(study_traces) + list(patient_traces)
 
-    def filter_for_admin(self, study_info, patient_info):
+    def filter_for_admin(self, study_info, patient_info, apply_trial_purpose=True):
         traces = []
         if not study_info:
             return self, traces
@@ -374,7 +384,10 @@ class TrialQuerySet(models.QuerySet):
         query = query.by_study_id(study_info.study_id)
         query = query.by_register(study_info.register)
         query = query.by_trial_type(study_info.trial_type)
-        query = query.by_trial_purpose(study_info.trial_purpose)
+        # apply_trial_purpose=False for favorites / my_trials (hand-picked lists) so the
+        # purpose filter doesn't remove saved trials — the caller decides. Matches CB.
+        if apply_trial_purpose:
+            query = query.by_trial_purpose(study_info.trial_purpose)
         query = query.by_study_type(study_info.study_type)
         query = query.by_validated_only(study_info.validated_only)
         if patient_info and patient_info.disease is not None and patient_info.disease != '':
@@ -406,12 +419,13 @@ class TrialQuerySet(models.QuerySet):
             })
             count = new_count
 
-        query = query.by_therapy_id(study_info.therapy_id)
+        therapy_id = getattr(study_info, 'therapy_id', None)  # host-agnostic (see filtered_trials)
+        query = query.by_therapy_id(therapy_id)
         if add_traces:
             new_count = query.count()
             traces.append({
                 'attr': 'study_info.therapy_id',
-                'val': study_info.therapy_id,
+                'val': therapy_id,
                 'records': new_count,
                 'dropped': count - new_count,
             })

--- a/tests/querysets/test_by_therapy_id.py
+++ b/tests/querysets/test_by_therapy_id.py
@@ -4,7 +4,7 @@ import pytest
 
 from trials.models import Trial
 from trials.querysets.trial import TrialQuerySet
-from trials.services.study_preferences import study_preferences_from_query_params
+from trials.services.study_preferences import StudyPreferences, study_preferences_from_query_params
 from tests.factories import TrialFactory
 
 
@@ -62,3 +62,68 @@ class TestByTherapyId:
 
         prefs = study_preferences_from_query_params(MultiParams())
         assert prefs.therapy_id == [19140573, 19136050]
+
+
+@pytest.mark.django_db
+class TestTherapyIdHostAgnostic:
+    """R2: ?therapy_id= is an EXACT-native OMOP search param; a downstream host whose
+    study_info has no therapy_id field (CB's StudyInfo model) must still be able to run
+    the shared filtered_trials / filter_by_study_info body. The package reads therapy_id
+    via getattr(..., None), so it no-ops on such a host instead of AttributeError-ing.
+    Modelled by deleting therapy_id from a real StudyPreferences instance.
+    """
+
+    def test_filter_by_study_info_tolerates_study_info_without_therapy_id(self):
+        TrialFactory(omop_intervention_concept_ids=[19140573])
+        prefs = StudyPreferences()
+        del prefs.therapy_id  # a host (CB StudyInfo model) that has no therapy_id field
+        qs, _ = Trial.objects.all().filter_by_study_info(prefs)  # must NOT AttributeError
+        assert qs.count() >= 1  # read as None -> by_therapy_id no-op
+
+    def test_filtered_trials_all_path_tolerates_missing_therapy_id(self):
+        TrialFactory()
+        prefs = StudyPreferences()
+        del prefs.therapy_id
+        qs, _ = Trial.objects.all().filtered_trials(
+            search_options={}, study_info=prefs, patient_info=None, search_type='all')
+        assert qs is not None  # ran through by_therapy_id + filter_for_admin without raising
+
+    def test_therapy_id_still_filters_when_present(self):
+        t = TrialFactory(omop_intervention_concept_ids=[19140573])
+        TrialFactory(omop_intervention_concept_ids=[])
+        prefs = StudyPreferences(therapy_id=[19140573])
+        qs, _ = Trial.objects.all().filter_by_study_info(prefs)
+        assert t in qs and qs.count() == 1  # EXACT behavior preserved
+
+
+@pytest.mark.django_db
+class TestFilterForAdminTrialPurpose:
+    """R2: filter_for_admin gained an apply_trial_purpose flag so favorites / my_trials
+    (hand-picked lists) skip the trial-purpose filter — matches CB's filtered_trials,
+    which passes apply_trial_purpose=False for those. Without it the drain would drop
+    saved trials with a non-matching purpose.
+    """
+
+    def _spy_by_trial_purpose(self, monkeypatch):
+        calls = []
+        orig = TrialQuerySet.by_trial_purpose
+        monkeypatch.setattr(TrialQuerySet, 'by_trial_purpose',
+                            lambda self, tp: (calls.append(tp), orig(self, tp))[1])
+        return calls
+
+    def test_apply_trial_purpose_true_applies_filter(self, monkeypatch):
+        calls = self._spy_by_trial_purpose(monkeypatch)
+        Trial.objects.all().filter_for_admin(
+            StudyPreferences(trial_purpose='treatment'), None, apply_trial_purpose=True)
+        assert calls == ['treatment']
+
+    def test_apply_trial_purpose_false_skips_filter(self, monkeypatch):
+        calls = self._spy_by_trial_purpose(monkeypatch)
+        Trial.objects.all().filter_for_admin(
+            StudyPreferences(trial_purpose='treatment'), None, apply_trial_purpose=False)
+        assert calls == []  # skipped for favorites / my_trials
+
+    def test_default_applies_trial_purpose(self, monkeypatch):
+        calls = self._spy_by_trial_purpose(monkeypatch)
+        Trial.objects.all().filter_for_admin(StudyPreferences(trial_purpose='treatment'), None)
+        assert calls == ['treatment']  # default True


### PR DESCRIPTION
## A2 R2 — two host-agnostic seams so CB can drain `filtered_trials`

Prereqs for CancerBot adopting `ExactMatcher`: CB drains its `filtered_trials` override onto this package body. Two package reads assumed EXACT's `study_info` shape; this makes them host-agnostic **without any CB schema change**.

### 1. `therapy_id` read host-agnostically
`filtered_trials` / `filter_by_study_info` read `study_info.therapy_id` unconditionally to drive the `?therapy_id=` OMOP intervention search (an EXACT-native feature, PR #211/#212 — **kept**, confirmed not deprecated: it serves the SoC "Show Trials" UI). CB's `study_info` is a Django `StudyInfo` model with **no** `therapy_id` field, so that read `AttributeError`'d on CB. Now `getattr(study_info, 'therapy_id', None)`: EXACT keeps the feature (has the field), CB no-ops (`by_therapy_id` short-circuits on `None`/`[]`), and CB picks it up automatically if it later adds the `omop_intervention_concept_ids` column + `?therapy_id=`. **No `omop_intervention_concept_ids` needed in CB.**

Verified `therapy_id` is the **only** `study_info.*` attribute the package reads that CB's `StudyInfo` model lacks — a full diff of all 18 package reads vs CB's model fields — so the drain won't crash on a next-line AttributeError.

### 2. `apply_trial_purpose` flag on `filter_for_admin`
CB's `filtered_trials` calls `filter_for_admin(apply_trial_purpose = search_type not in ('favorites','my_trials'))` so the trial-purpose filter is **not** applied to favorites / my_trials (hand-picked lists); the package always applied it, which would drop saved trials on the drain. Ported the param (default `True`) + wired `filtered_trials` to pass it. Standard search still applies purpose (via `filter_by_study_info`), matching CB.

### Tests
`tests/querysets/test_by_therapy_id.py`: host-agnostic (study_info without `therapy_id` runs `filter_by_study_info` / `filtered_trials`-all without AttributeError; still filters when present) + `apply_trial_purpose` (applied when True/default, skipped when False). Full suite **1251 passed** (OMOP off).

### Self-review
Two-part, reconciled:
- **codex** (consult + `review --base 2omop`): feature not deprecated; getattr is the right fix; apply to every read; port `apply_trial_purpose`. Review clean, no regressions.
- **Fresh-context Claude subagent**: **SHIP** — verified `therapy_id` is the sole CB-missing attr (both reads guarded), EXACT behaviour byte-identical (trace values unchanged), only production caller of `filter_for_admin` is `filtered_trials`, and the new tests are non-vacuous (a mutation reverting the fix fails exactly 3/13).

### Next in A2
CB pin bump → CB drains `filtered_trials` (flag, verify via `compare_method('filtered_trials')` + favorites/my_trials regression); then R3 no-op flip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)