### PR TITLE
refactor(omop): fold drug-class TYPES into the base EXACT_OMOP_THERAPY flag (#285)

### DIFF
--- a/matcher_app/exact_matching/data_port.py
+++ b/matcher_app/exact_matching/data_port.py
@@ -36,7 +36,7 @@ class MatcherDataPort(Protocol):
         """Return (component_codes, therapy_types) for the patient's therapies.
 
         ``patient_class_ids`` supplies the patient's pre-expanded drug-class "type"
-        concept_ids (used as type_values under EXACT_OMOP_THERAPY_TYPES / #285).
+        concept_ids (used as type_values under the OMOP flag; #285 folded types in).
         """
         ...
 
@@ -50,7 +50,7 @@ class DjangoMatcherData:
 
         therapies = {}                       # regimen match-value -> title
         therapy_components_to_therapy = {}   # component match-value -> title
-        therapy_types_to_therapy = {}        # CB category code -> title (types not OMOP-mapped)
+        therapy_types_to_therapy = {}        # class concept_id -> title (#285 folded types into OMOP)
 
         if therapy_codes:
             for therapy in resolve_regimens(therapy_codes).prefetch_related('components__categories'):
@@ -72,8 +72,7 @@ class DjangoMatcherData:
             # original DB-query order.
             component_ids = get_component_ids() or []
             if component_ids:
-                from trials.models import TherapyComponent, TherapyComponentCategory
-                from trials.services.omop.component_category_lookup import component_concept_ids_to_type_codes
+                from trials.models import TherapyComponent
                 keys = [str(c) for c in component_ids]
                 int_cids = [int(k) for k in keys if k.isdigit()]
                 title_by_cid = dict(
@@ -86,16 +85,9 @@ class DjangoMatcherData:
                     # value here later TypeErrors in match_required's sorted(set(values)).
                     title = title_by_cid.get(int(key)) if key.isdigit() else None
                     therapy_components_to_therapy.setdefault(key, title or key)
-                if not omop_types:
-                    # Legacy types: component concept_ids -> CB category codes (#4502).
-                    type_codes = component_concept_ids_to_type_codes(keys) or []
-                    if type_codes:
-                        title_by_code = dict(
-                            TherapyComponentCategory.objects.filter(code__in=type_codes)
-                            .values_list('code', 'title')
-                        )
-                        for code in type_codes:
-                            therapy_types_to_therapy.setdefault(code, title_by_code.get(code) or code)
+                # (The old component->CB-category lookup TYPE display path is retired —
+                # types are folded into the base OMOP flag, #285; the type display map is
+                # built from the patient's class concept_ids below.)
 
             if omop_types:
                 # OMOP types (#285): keys are the patient's class concept_ids as-is

--- a/matcher_app/exact_matching/matcher.py
+++ b/matcher_app/exact_matching/matcher.py
@@ -305,7 +305,7 @@ class UserToTrialAttrMatcher:
         # per the active profile, so match_required/excluded overlap correctly. Regimen
         # keys: concept_ids under OMOP, codes legacy. Component/type keys: OMOP (Phase P,
         # #234) — components are consumer-supplied concept_ids (get_user_therapy_component_ids),
-        # types are CB category codes via the flat lookup; legacy — the CB graph walk.
+        # types are consumer-supplied class concept_ids (#285 folded); legacy — the CB graph walk.
         # The regimen/component/category data access lives behind the data port
         # (E1.2b); DjangoMatcherData reproduces the previous inline logic 1:1.
         omop = omop_therapy_enabled()
@@ -389,9 +389,10 @@ class UserToTrialAttrMatcher:
         if types_excluded_conservative and getattr(self.trial, THERAPY_MATCH_PROFILE.therapy_types_excluded):
             out['therapyTypesExcluded']['status'] = 'not_matched'
 
-        # OMOP code + title per criterion (additive). Only the OMOP-mapped levels
-        # (regimen + component) hold concept_ids; resolve the TRIAL's required/excluded
-        # concept_ids to OMOP names via OmopConcept. Types stay CB-coded (no OMOP).
+        # OMOP code + title per criterion (additive). Resolve the TRIAL's required/excluded
+        # concept_ids to OMOP names via OmopConcept for regimen + component. Types are OMOP
+        # class concept_ids too (#285) but are NOT yet added to this omopConcepts display
+        # block — a display-parity follow-up (behaviour unchanged from before the fold).
         if omop_therapy_enabled():
             for key, col in (
                 ('therapiesRequired', THERAPY_MATCH_PROFILE.therapies_required),
@@ -467,7 +468,7 @@ class UserToTrialAttrMatcher:
         return 'matched'
 
     def _match_omop_type_things(self, type_values, required_list, excluded_list, has_no_prior_therapy):
-        """OMOP drug-class TYPE overlap under EXACT_OMOP_THERAPY_TYPES (#285) with
+        """OMOP drug-class TYPE overlap under the OMOP flag (#285, types folded in) with
         #286 per-concept release validation applied ASYMMETRICALLY.
 
         ``type_values`` is the patient's RAW class concept_ids: ``None`` = unknown,
@@ -512,12 +513,12 @@ class UserToTrialAttrMatcher:
 
         # Component + type (class) values. OMOP mode (Phase P, #234): components are the
         # consumer-supplied pre-expanded concept_ids (get_user_therapy_component_ids); types
-        # are CB category codes via the flat lookup (types are not OMOP-mapped). Legacy:
-        # derived from the regimen via the CB graph. See #197 / therapy_graph.
+        # are the consumer's pre-expanded class concept_ids (#285 folded types into OMOP).
+        # Legacy: derived from the regimen via the CB graph. See #197 / therapy_graph.
         from exact_matching.therapy_match_profile import omop_therapy_enabled, omop_therapy_types_enabled
         # OMOP only: read the consumer-supplied components. Gated so the legacy path
-        # does no OMOP-specific work (byte-identical to CB). Under EXACT_OMOP_THERAPY_TYPES
-        # (#285) also read the consumer's pre-expanded drug-class concept_ids for types.
+        # does no OMOP-specific work (byte-identical to CB). Under OMOP (#285, types folded
+        # in) also read the consumer's pre-expanded drug-class concept_ids for types.
         patient_component_ids = (self.patient_info_attr.get_user_therapy_component_ids()
                                  if omop_therapy_enabled() else None)
         patient_class_ids = (self.patient_info_attr.get_user_therapy_type_ids()

--- a/matcher_app/exact_matching/patient_info/patient_info_attributes.py
+++ b/matcher_app/exact_matching/patient_info/patient_info_attributes.py
@@ -267,8 +267,8 @@ class PatientInfoAttributes:
         OMOP mode only; promop#370, ADR 0002). Mirror of
         get_user_therapy_component_ids: None when the field is absent (unknown ->
         callers fail-closed), else a normalized (stringified digit) list or [].
-        Consumed as the patient's type match-values once EXACT_OMOP_THERAPY_TYPES
-        is on (#285); inert before that.
+        Consumed as the patient's type match-values once OMOP therapy is on (#285
+        folded types into the base flag); inert before that.
         """
         val = self.get_value('therapy_type_ids')
         if val is None:

--- a/matcher_app/exact_matching/querysets/trial.py
+++ b/matcher_app/exact_matching/querysets/trial.py
@@ -127,8 +127,9 @@ def _omop_therapy_ids(ctx):
 
     #286 Gate 1 (observe-only release-skew metric) is imported and run ONLY in OMOP mode
     (``ctx['omop_therapy']`` — the master flag). ``release_gated_class_ids`` short-circuits
-    to ``None`` without measuring when the TYPES flag is off, so master-gating the whole
-    thing is behaviour-preserving (legacy already resolved to ``None``). It also keeps the
+    to ``None`` without measuring when OMOP therapy is off (types are folded into the base
+    flag, #285), so master-gating the whole thing is behaviour-preserving (legacy already
+    resolved to ``None``). It also keeps the
     ``trials.services.omop.patient_release_gate`` import off the legacy path, so a host
     without the OMOP release-gate infra (CB, at the QR4d orchestrator drain) can run this
     dispatch instead of ImportError-ing on a module it doesn't ship.
@@ -1162,9 +1163,9 @@ class TrialQuerySet(models.QuerySet):
 
         # Component + type values (shared with the matcher). OMOP mode (Phase P, #234):
         # components are the consumer-supplied pre-expanded concept_ids
-        # (patient_component_ids). Types: OMOP-types mode (#285) uses the consumer's
-        # class concept_ids (patient_class_ids); else CB category codes via the flat
-        # lookup. Legacy: derived from the regimen via the CB graph. See therapy_graph.
+        # (patient_component_ids). Types (#285 folded into OMOP): the consumer's pre-expanded
+        # class concept_ids (patient_class_ids). Legacy: derived from the regimen via the CB
+        # graph. See therapy_graph.
         from trials.services.omop.therapy_graph import derive_component_and_type_values
         # measure=True: this is the once-per-search derivation, so the Phase-T
         # gating metric (#263) is recorded here, not per-trial in the matcher.

--- a/matcher_app/exact_matching/therapy_match_profile.py
+++ b/matcher_app/exact_matching/therapy_match_profile.py
@@ -20,17 +20,19 @@ trial columns are read; both sides must speak the same vocabulary, which is the
 consumer's responsibility. This profile deliberately does NOT change dispatch
 order / matching semantics (kept behavior-identical).
 
-Regimen, drug-component, and supportive flip to OMOP concept_ids under the OMOP
-profile. The columns that stay on the legacy (internal-code) columns:
-- ``therapy_types_*`` (drug class / component-category): types are deliberately
-  NOT OMOP-mapped (HemOnc's class structure is poor) — EXACT keeps CB's own
-  category vocabulary and matches types through the CB graph
-  ``categories ↔ components ↔ therapies`` (the matcher reverse-maps the patient's
-  component concept_ids back to internal components, then to CB categories, and
-  overlaps those against the legacy ``therapy_types_*`` columns). See #197.
-- ``planned_*``: stays legacy — ``PlannedTherapy`` has no ``omop_concept_id`` and
-  76/85 planned codes are drug-classes/modalities, so ``omop_planned_therapies_*``
-  is empty and flipping would silently drop the constraint (#230 decision pending).
+Regimen, drug-component, drug-class TYPES, and supportive all flip to OMOP concept_ids
+under the OMOP profile — they are one unified projection and flip together with
+``EXACT_OMOP_THERAPY``; there is no separate types toggle (#285 folded types into the
+base flag). ``therapy_types_*`` now reads ``omop_therapy_types_*`` (drug-class concept_id
+overlap): reverses the earlier "types stay legacy / not OMOP-mapped" stance (decision A /
+#4502 / #197) now that the patient carries pre-expanded class concept_ids (promop#370). A
+non-mappable subset of umbrella/modality type criteria is handled per-criterion inside the
+type path (hybrid), independent of this flag.
+
+The only column that stays legacy:
+- ``planned_*``: ``PlannedTherapy`` has no ``omop_concept_id`` and 76/85 planned codes are
+  drug-classes/modalities, so ``omop_planned_therapies_*`` is empty and flipping would
+  silently drop the constraint (#230 decision pending).
 
 ``supportive_*`` flips to ``omop_supportive_therapies_*`` under the OMOP profile
 (#228): the dedicated supportive matching (#4449 — the matcher's
@@ -44,7 +46,7 @@ the trial-side flip is a safe no-op. When promop#230 lands, matching works
 end-to-end with no EXACT change; the #221 gate validates coverage before the prod
 flip. See #231.
 """
-from dataclasses import dataclass, replace
+from dataclasses import dataclass
 
 from django.conf import settings
 
@@ -70,15 +72,20 @@ class TherapyMatchProfile:
 # Legacy (internal-code) columns — the default.
 LEGACY_THERAPY_MATCH_PROFILE = TherapyMatchProfile()
 
-# OMOP cutover profile: regimen + component + supportive read the omop_* concept_id
-# columns. therapy_types_* and planned_* intentionally stay legacy (see module
-# docstring): types are matched via the CB category graph, not OMOP concept_ids;
-# planned has no concept_ids yet (#230).
+# OMOP cutover profile: regimen + component + supportive + drug-class TYPES read the
+# omop_* concept_id columns. Only planned_* stays legacy (no concept_ids yet, #230).
+# Types are FOLDED into this one OMOP profile (promop ADR 0002, #285) — therapies,
+# components and types are one unified projection, so they flip together with the base
+# EXACT_OMOP_THERAPY flag; there is no separate types toggle. (This reverses "types stay
+# legacy" / decision A / #4502, now that the patient carries pre-expanded class
+# concept_ids, promop#370.)
 OMOP_THERAPY_MATCH_PROFILE = TherapyMatchProfile(
     therapies_required='omop_therapies_required',
     therapies_excluded='omop_therapies_excluded',
     therapy_components_required='omop_therapy_components_required',
     therapy_components_excluded='omop_therapy_components_excluded',
+    therapy_types_required='omop_therapy_types_required',
+    therapy_types_excluded='omop_therapy_types_excluded',
     # Supportive flips too (#228): the dedicated supportive path (#4449 — the
     # _match_supportive_therapies matcher handler + eligible_for_supportive_therapies
     # queryset) reads the trial supportive columns via THIS profile, and the backfill
@@ -88,17 +95,6 @@ OMOP_THERAPY_MATCH_PROFILE = TherapyMatchProfile(
     # [] -> would silently drop the constraint) before the flag is flipped on prod.
     supportive_therapies_required='omop_supportive_therapies_required',
     supportive_therapies_excluded='omop_supportive_therapies_excluded',
-)
-
-# OMOP + drug-class TYPES profile (promop ADR 0002, #285): additionally flips
-# therapy_types_* to the omop_therapy_types_* class-concept_id columns. Only
-# active when BOTH EXACT_OMOP_THERAPY and EXACT_OMOP_THERAPY_TYPES are on — types
-# ride on top of the OMOP profile. Reverses "types stay legacy" (decision A/#4502)
-# now that the patient carries pre-expanded class concept_ids (promop#370).
-OMOP_THERAPY_WITH_TYPES_MATCH_PROFILE = replace(
-    OMOP_THERAPY_MATCH_PROFILE,
-    therapy_types_required='omop_therapy_types_required',
-    therapy_types_excluded='omop_therapy_types_excluded',
 )
 
 
@@ -113,24 +109,21 @@ def omop_therapy_enabled() -> bool:
 
 
 def omop_therapy_types_enabled() -> bool:
-    """Whether trial drug-class TYPE matching reads the OMOP class-concept_id
-    columns (``omop_therapy_types_*``) instead of legacy CB category codes.
+    """Whether the OMOP drug-class TYPE match-path is engaged.
 
-    Off by default; gated by ``EXACT_OMOP_THERAPY_TYPES`` (promop ADR 0002, #285).
-    Requires ``EXACT_OMOP_THERAPY`` too — types ride on the OMOP profile, and the
-    patient's class concept_ids only flow in OMOP mode. Returns False (legacy types)
-    whenever OMOP therapy is off, so the flag alone can never divert the queryset /
-    matcher onto the OMOP-types path while the profile still names legacy columns.
+    Types are folded into the base OMOP profile (#285) — therapies, components and
+    types are one projection and flip together — so this is exactly ``EXACT_OMOP_THERAPY``.
+    Retained as the semantic gate for the OMOP-type code paths (the class-concept matcher
+    / queryset / patient class-id read); there is no separate ``EXACT_OMOP_THERAPY_TYPES``
+    toggle.
     """
-    return omop_therapy_enabled() and bool(getattr(settings, 'EXACT_OMOP_THERAPY_TYPES', False))
+    return omop_therapy_enabled()
 
 
 def get_therapy_match_profile() -> TherapyMatchProfile:
-    """Return the active profile for the current OMOP therapy settings."""
+    """Return the active profile for the current OMOP therapy setting."""
     if not omop_therapy_enabled():
         return LEGACY_THERAPY_MATCH_PROFILE
-    if omop_therapy_types_enabled():
-        return OMOP_THERAPY_WITH_TYPES_MATCH_PROFILE
     return OMOP_THERAPY_MATCH_PROFILE
 
 

--- a/tests/services/patient_info/test_promop_adapter_omop.py
+++ b/tests/services/patient_info/test_promop_adapter_omop.py
@@ -101,7 +101,7 @@ def test_therapy_release_id_preserved_by_normalize_flag_off():
     assert r['therapy_release_id'] == '7'      # untouched regardless of the OMOP flag
 
 
-@override_settings(EXACT_OMOP_THERAPY=True, EXACT_OMOP_THERAPY_TYPES=True)
+@override_settings(EXACT_OMOP_THERAPY=True)
 def test_therapy_release_id_reaches_getter_end_to_end():
     # Full forwarding chain: PROMOP row -> normalize -> build PatientInfo -> getter.
     # (The flags are prod-realistic context; neither normalize nor the getter reads

--- a/tests/services/test_omop_component_type_matching.py
+++ b/tests/services/test_omop_component_type_matching.py
@@ -1,20 +1,24 @@
-"""OMOP component + type matching under Phase P (#234).
+"""OMOP component matching under Phase P (#234).
 
 Under EXACT_OMOP_THERAPY:
 - regimen matches on OMOP concept_ids (omop_therapies_* columns);
 - component match-values are the consumer-supplied PRE-EXPANDED concept_ids
   (PatientInfo.therapy_component_ids), NOT reverse-mapped from the regimen via the
-  local CB graph;
-- type/category is NOT OMOP-mapped — resolved from the patient's component concept_ids
-  via the flat ComponentCategoryOmopLookup (CB category codes), matched against the
-  LEGACY therapy_types_* columns.
+  local CB graph.
+
+Drug-class TYPE matching is now folded into the base flag (#285) and matches the
+patient's pre-expanded class concept_ids against omop_therapy_types_* — covered by
+tests/services/test_omop_therapy_types_matching.py. The old mode-2 type path
+(component concept_ids -> ComponentCategoryOmopLookup CB category codes -> legacy
+therapy_types_* columns) is retired under OMOP; the type tests that exercised it were
+removed. Legacy (flag OFF) type matching via the CB M2M graph is unchanged.
 """
 import pytest
 from django.test import override_settings
 
 from trials.models import (
     Therapy, TherapyComponent, TherapyComponentCategory,
-    TherapyComponentConnection, TherapyComponentCategoryConnection, OmopConcept,
+    TherapyComponentConnection, TherapyComponentCategoryConnection,
 )
 from trials.services.omop.therapy_graph import derive_component_and_type_values
 from trials.services.omop.component_category_lookup import sync_component_category_lookup
@@ -36,10 +40,9 @@ def _graph():
     TherapyComponentConnection.objects.create(therapy=vrd, component=bort)
     TherapyComponentConnection.objects.create(therapy=vrd, component=lena)
     TherapyComponentCategoryConnection.objects.create(category=pi_cat, component=bort)
-    # Type resolution reads the flat ComponentCategoryOmopLookup (ADR 0001-A / #4502).
-    # Production has no live post_save sync — the loader/rebuild command populates it —
-    # so the test must sync after wiring the graph, or type_values come back empty.
-    sync_component_category_lookup()
+    # (pi_cat + the M2M connection are used only by the legacy — flag OFF — type path,
+    # which reads the CB M2M graph directly. The flat ComponentCategoryOmopLookup is no
+    # longer consulted for types under OMOP, #285.)
     return vrd, bort, lena, pi_cat
 
 
@@ -59,7 +62,8 @@ def test_derive_uses_consumer_supplied_component_ids_when_flag_on():
     # Phase P: components come from the pre-expanded ids, not the regimen.
     comps, types = derive_component_and_type_values([str(VRD_CID)], [str(BORT_CID), str(LEN_CID)])
     assert sorted(comps) == [str(BORT_CID), str(LEN_CID)]    # consumer-supplied concept_ids
-    assert types == ['zz_proteasome_inh']                    # types stay CB codes (flat lookup)
+    # types folded into the base flag (#285): with no class ids supplied -> unknown (None).
+    assert types is None
 
 
 @override_settings(EXACT_OMOP_THERAPY=True)
@@ -72,7 +76,8 @@ def test_derive_none_component_ids_is_unknown():
 @override_settings(EXACT_OMOP_THERAPY=True)
 def test_derive_empty_component_ids_is_known_empty():
     _graph()
-    assert derive_component_and_type_values([str(VRD_CID)], []) == ([], [])
+    # components known-empty; types unknown (no class ids supplied -> None, #285)
+    assert derive_component_and_type_values([str(VRD_CID)], []) == ([], None)
 
 
 @override_settings(EXACT_OMOP_THERAPY=True)
@@ -104,25 +109,9 @@ def test_component_excluded_blocks_via_concept_id():
     assert res == 'not_matched'
 
 
-# ── matcher: type level via the flat category lookup (legacy column) ──
-
-@override_settings(EXACT_OMOP_THERAPY=True)
-def test_type_required_matches_via_component_category_lookup():
-    _graph()
-    pi = PatientInfo(disease='multiple myeloma', therapy_component_ids=[BORT_CID])
-    # type column stays LEGACY (CB code) even under OMOP
-    trial = TrialFactory(disease='multiple myeloma', therapy_types_required=['zz_proteasome_inh'])
-    res = UserToTrialAttrMatcher(trial, pi)._match_therapy_related_things([str(VRD_CID)], False)
-    assert res == 'matched'
-
-
-@override_settings(EXACT_OMOP_THERAPY=True)
-def test_type_excluded_blocks_via_component_category_lookup():
-    _graph()
-    pi = PatientInfo(disease='multiple myeloma', therapy_component_ids=[BORT_CID])
-    trial = TrialFactory(disease='multiple myeloma', therapy_types_excluded=['zz_proteasome_inh'])
-    res = UserToTrialAttrMatcher(trial, pi)._match_therapy_related_things([str(VRD_CID)], False)
-    assert res == 'not_matched'
+# (Mode-2 type matching via the component→category lookup is retired under OMOP, #285.
+# Mode-3 type matching — patient class ids overlapped against omop_therapy_types_* — is
+# covered by tests/services/test_omop_therapy_types_matching.py.)
 
 
 # ── detail display (therapy_related_things_match_status) under OMOP ───
@@ -145,26 +134,6 @@ def test_display_component_excluded_status_via_concept_id():
     trial = TrialFactory(disease='multiple myeloma', omop_therapy_components_excluded=[str(BORT_CID)])
     out = UserToTrialAttrMatcher(trial, pi).therapy_related_things_match_status()
     assert out['therapyComponentsExcluded']['status'] == 'not_matched'
-
-
-@override_settings(EXACT_OMOP_THERAPY=True)
-def test_display_type_required_status_via_lookup():
-    _graph()
-    pi = PatientInfo(disease='multiple myeloma', first_line_therapy=str(VRD_CID),
-                     prior_therapy='One line', therapy_component_ids=[BORT_CID])
-    trial = TrialFactory(disease='multiple myeloma', therapy_types_required=['zz_proteasome_inh'])
-    out = UserToTrialAttrMatcher(trial, pi).therapy_related_things_match_status()
-    assert out['therapyTypesRequired']['status'] == 'matched'
-
-
-@override_settings(EXACT_OMOP_THERAPY=True)
-def test_display_type_excluded_status_via_lookup():
-    _graph()
-    pi = PatientInfo(disease='multiple myeloma', first_line_therapy=str(VRD_CID),
-                     prior_therapy='One line', therapy_component_ids=[BORT_CID])
-    trial = TrialFactory(disease='multiple myeloma', therapy_types_excluded=['zz_proteasome_inh'])
-    out = UserToTrialAttrMatcher(trial, pi).therapy_related_things_match_status()
-    assert out['therapyTypesExcluded']['status'] == 'not_matched'
 
 
 @override_settings(EXACT_OMOP_THERAPY=True)
@@ -222,8 +191,6 @@ def test_display_includes_omop_concepts_code_and_title():
     assert out['therapyComponentsRequired']['omopConcepts'] == [
         {'code': BORT_CID, 'title': 'bortezomib', 'vocab': 'RxNorm'}
     ]
-    # types are CB-coded (not OMOP) → no omopConcepts on the type criterion
-    assert 'omopConcepts' not in out['therapyTypesRequired']
 
 
 @override_settings(EXACT_OMOP_THERAPY=True)

--- a/tests/services/test_omop_therapy_types_matching.py
+++ b/tests/services/test_omop_therapy_types_matching.py
@@ -1,8 +1,8 @@
-"""OMOP-native drug-class TYPE matching under EXACT_OMOP_THERAPY_TYPES (#285).
+"""OMOP-native drug-class TYPE matching — folded into the base EXACT_OMOP_THERAPY flag (#285).
 
 promop ADR 0002 reverses "types are not OMOP-mapped": the patient now carries
-pre-expanded drug-class concept_ids (PatientInfo.therapy_type_ids,
-promop#370). With EXACT_OMOP_THERAPY + EXACT_OMOP_THERAPY_TYPES on:
+pre-expanded drug-class concept_ids (PatientInfo.therapy_type_ids, promop#370). Types
+are part of the one OMOP therapy projection (no separate flag). With EXACT_OMOP_THERAPY on:
 - the profile flips therapy_types_* -> omop_therapy_types_* (class concept_id columns);
 - derive returns the consumer's class concept_ids as type_values (no category lookup);
 - matching is class-concept_id overlap, FAIL-CLOSED on unknown/empty patient classes.
@@ -15,7 +15,7 @@ from django.test import override_settings
 from trials.models import Trial
 from trials.services.omop.therapy_graph import derive_component_and_type_values
 from trials.services.therapy_match_profile import (
-    get_therapy_match_profile, OMOP_THERAPY_WITH_TYPES_MATCH_PROFILE,
+    get_therapy_match_profile,
     OMOP_THERAPY_MATCH_PROFILE, LEGACY_THERAPY_MATCH_PROFILE,
 )
 from trials.services.user_to_trial_attr_matcher import UserToTrialAttrMatcher
@@ -34,7 +34,8 @@ INVALID_CLASS = '35800002'  # present in the mirror but invalidated (invalid_rea
 _RID = 1                    # the seeded active mirror release_id
 
 
-OMOP_TYPES = dict(EXACT_OMOP_THERAPY=True, EXACT_OMOP_THERAPY_TYPES=True)
+# Types are folded into the base flag (#285) — no separate EXACT_OMOP_THERAPY_TYPES.
+OMOP_TYPES = dict(EXACT_OMOP_THERAPY=True)
 
 
 def _mirror_concept(concept_id, invalid_reason=None):
@@ -71,17 +72,15 @@ def _active_mirror(db):
 # ── profile selection ────────────────────────────────────────────────
 
 def test_profile_selection_matrix():
-    with override_settings(EXACT_OMOP_THERAPY=False, EXACT_OMOP_THERAPY_TYPES=False):
+    # Types are folded into the base flag: base off -> legacy; base on -> the one OMOP
+    # profile, which now names the omop_therapy_types_* columns.
+    with override_settings(EXACT_OMOP_THERAPY=False):
         assert get_therapy_match_profile() is LEGACY_THERAPY_MATCH_PROFILE
-    with override_settings(EXACT_OMOP_THERAPY=True, EXACT_OMOP_THERAPY_TYPES=False):
-        assert get_therapy_match_profile() is OMOP_THERAPY_MATCH_PROFILE
-    with override_settings(**OMOP_TYPES):
+    with override_settings(EXACT_OMOP_THERAPY=True):
         p = get_therapy_match_profile()
-        assert p is OMOP_THERAPY_WITH_TYPES_MATCH_PROFILE
+        assert p is OMOP_THERAPY_MATCH_PROFILE
         assert p.therapy_types_required == 'omop_therapy_types_required'
-    # types flag ignored when OMOP therapy is off (types ride the OMOP profile)
-    with override_settings(EXACT_OMOP_THERAPY=False, EXACT_OMOP_THERAPY_TYPES=True):
-        assert get_therapy_match_profile() is LEGACY_THERAPY_MATCH_PROFILE
+        assert p.therapy_types_excluded == 'omop_therapy_types_excluded'
 
 
 # ── derive: types = the patient's class concept_ids ──────────────────
@@ -93,12 +92,17 @@ def test_derive_returns_patient_class_ids_as_types():
     assert types == [PI_CLASS]          # class concept_ids as-is, no category lookup
 
 
-def test_types_flag_ignored_without_omop_therapy():
-    # codex [P2]: the types flag alone must NOT divert onto the OMOP-types path
-    # (queryset/matcher) while the profile still names legacy columns.
-    from trials.services.therapy_match_profile import omop_therapy_types_enabled
-    with override_settings(EXACT_OMOP_THERAPY=False, EXACT_OMOP_THERAPY_TYPES=True):
+def test_types_enabled_tracks_base_flag():
+    # Types are folded into the base flag — the type path engages exactly when OMOP
+    # therapy is on (no separate toggle).
+    from trials.services.therapy_match_profile import (
+        omop_therapy_types_enabled, omop_therapy_enabled)
+    with override_settings(EXACT_OMOP_THERAPY=False):
         assert omop_therapy_types_enabled() is False
+        assert omop_therapy_types_enabled() == omop_therapy_enabled()
+    with override_settings(EXACT_OMOP_THERAPY=True):
+        assert omop_therapy_types_enabled() is True
+        assert omop_therapy_types_enabled() == omop_therapy_enabled()
 
 
 @override_settings(**OMOP_TYPES)
@@ -131,13 +135,6 @@ def test_derive_none_class_ids_is_unknown_types():
 def test_derive_empty_class_ids_is_known_empty_types():
     _, types = derive_component_and_type_values([REG], [BORT_CID], patient_class_ids=[])
     assert types == []
-
-
-@override_settings(EXACT_OMOP_THERAPY=True, EXACT_OMOP_THERAPY_TYPES=False)
-def test_derive_ignores_class_ids_when_types_flag_off():
-    # types flag off: class ids are ignored; legacy category-code path is used.
-    _, types = derive_component_and_type_values([REG], [BORT_CID], patient_class_ids=[PI_CLASS])
-    assert types == []                  # no category lookup rows -> [] (not the class ids)
 
 
 # ── matcher verdict (fail-closed) ────────────────────────────────────
@@ -185,6 +182,31 @@ def test_no_required_type_matches():
                      therapy_type_ids=[])
     trial = TrialFactory(disease='multiple myeloma', omop_therapy_types_required=[])
     assert _match(trial, pi) == 'matched'
+
+
+# ── exclusion + empty/unknown patient classes (documented flip-gate policy) ──
+# Required types are fail-CLOSED on unknown/empty patient classes (see the
+# test_type_required_* cases above). Excluded types are NOT: an empty (known-empty)
+# class set does not reject an excluded-type trial. This is INTENTIONAL and preserved
+# by the fold (#285) — it is a documented flip-gate decision, guarded by an ingestion
+# invariant: a therapy-bearing patient must never emit an EMPTY class list merely
+# because pre-expansion failed (that would silently weaken an exclusion). These tests
+# pin the current behavior so a future change is a conscious one.
+
+@override_settings(**OMOP_TYPES)
+def test_type_excluded_empty_classes_does_not_reject():
+    pi = PatientInfo(disease='multiple myeloma', therapy_component_ids=[int(BORT_CID)],
+                     therapy_type_ids=[])  # known-empty
+    trial = TrialFactory(disease='multiple myeloma', omop_therapy_types_excluded=[PI_CLASS])
+    assert _match(trial, pi) == 'matched'  # empty class set does NOT trip the exclusion
+
+
+@override_settings(**OMOP_TYPES)
+def test_queryset_empty_classes_keeps_excluded_type_trial():
+    excl = TrialFactory(disease='multiple myeloma', omop_therapy_types_excluded=[PI_CLASS])
+    # [] (known-empty) patient classes: the excluded-type trial is NOT dropped.
+    qs = Trial.objects.filter(id=excl.id).eligible_for_omop_therapy_types([])
+    assert set(qs.values_list('id', flat=True)) == {excl.id}
 
 
 # ── queryset fail-closed (parity with the matcher verdict) ───────────

--- a/tests/services/test_therapy_match_profile.py
+++ b/tests/services/test_therapy_match_profile.py
@@ -36,10 +36,10 @@ def test_active_profile_uses_omop_columns_when_flag_on():
     # supportive flips too (#228, dedicated path wired by #4449)
     assert THERAPY_MATCH_PROFILE.supportive_therapies_required == 'omop_supportive_therapies_required'
     assert THERAPY_MATCH_PROFILE.supportive_therapies_excluded == 'omop_supportive_therapies_excluded'
-    # types stay legacy even in OMOP mode (matched via CB category graph)
-    assert THERAPY_MATCH_PROFILE.therapy_types_required == 'therapy_types_required'
-    assert THERAPY_MATCH_PROFILE.therapy_types_excluded == 'therapy_types_excluded'
-    # planned stays legacy (76/85 codes unmappable — #230)
+    # types flip too — folded into the base OMOP flag (#285)
+    assert THERAPY_MATCH_PROFILE.therapy_types_required == 'omop_therapy_types_required'
+    assert THERAPY_MATCH_PROFILE.therapy_types_excluded == 'omop_therapy_types_excluded'
+    # only planned stays legacy (76/85 codes unmappable — #230)
     assert THERAPY_MATCH_PROFILE.planned_therapies_required == 'planned_therapies_required'
 
 
@@ -65,10 +65,10 @@ def test_active_profile_flips_mapped_levels_when_flag_on():
     assert THERAPY_MATCH_PROFILE.therapy_components_required == 'omop_therapy_components_required'
     assert THERAPY_MATCH_PROFILE.therapy_components_excluded == 'omop_therapy_components_excluded'
     assert THERAPY_MATCH_PROFILE.supportive_therapies_required == 'omop_supportive_therapies_required'
-    # ...but types stay LEGACY (not OMOP-mapped — matched via the CB category graph),
-    # as does planned (76/85 codes unmappable — #230).
-    assert THERAPY_MATCH_PROFILE.therapy_types_required == 'therapy_types_required'
-    assert THERAPY_MATCH_PROFILE.therapy_types_excluded == 'therapy_types_excluded'
+    # ...and types flip too (#285 folded them into the base flag); only planned stays
+    # legacy (76/85 codes unmappable — #230).
+    assert THERAPY_MATCH_PROFILE.therapy_types_required == 'omop_therapy_types_required'
+    assert THERAPY_MATCH_PROFILE.therapy_types_excluded == 'omop_therapy_types_excluded'
     assert THERAPY_MATCH_PROFILE.planned_therapies_required == 'planned_therapies_required'
 
 
@@ -97,9 +97,12 @@ def test_an_omop_profile_can_be_constructed():
         therapies_excluded='omop_therapies_excluded',
     )
     assert omop.therapies_required == 'omop_therapies_required'
-    # the shipped OMOP profile flips regimen + component + supportive; planned stays legacy
+    # the shipped OMOP profile flips regimen + component + supportive + TYPES (#285 folded
+    # types into the base flag); only planned stays legacy
     assert OMOP_THERAPY_MATCH_PROFILE.therapies_required == 'omop_therapies_required'
     assert OMOP_THERAPY_MATCH_PROFILE.supportive_therapies_required == 'omop_supportive_therapies_required'
+    assert OMOP_THERAPY_MATCH_PROFILE.therapy_types_required == 'omop_therapy_types_required'
+    assert OMOP_THERAPY_MATCH_PROFILE.therapy_types_excluded == 'omop_therapy_types_excluded'
     assert OMOP_THERAPY_MATCH_PROFILE.planned_therapies_required == 'planned_therapies_required'
 
 

--- a/tests/test_omop_real_concept_ids.py
+++ b/tests/test_omop_real_concept_ids.py
@@ -20,11 +20,11 @@ Component concept_ids (RxNorm):
     Dexamethasone 1518254
     Daratumumab   35605744
 
-Type codes (CB-internal, not OMOP):
-    proteasome_inhibitor
-    immunomodulatory_drug_(imid)
-    corticosteroid
-    monoclonal_antibody_(anti_cd38)
+Scope: regimen + component + queryset matching on OMOP concept_ids. Drug-class TYPE
+matching folded into the base flag (#285) is covered by
+tests/services/test_omop_therapy_types_matching.py; the old mode-2 type path (component
+concept_ids -> CB category codes -> legacy therapy_types_*) is retired under OMOP and its
+tests were removed here.
 """
 import pytest
 from django.test import override_settings
@@ -73,17 +73,10 @@ def omop_vocab(db):
     ]:
         TherapyComponent.objects.filter(code=code).update(omop_concept_id=cid)
 
-    # Populate the flat lookup table — derive_component_and_type_values reads
-    # ComponentCategoryOmopLookup in OMOP mode (not the M2M graph directly).
-    # The .update() calls above bypass signals, so we sync explicitly here.
-    from trials.services.omop.component_category_lookup import (
-        clear_lookup_cache,
-        sync_component_category_lookup,
-    )
-    sync_component_category_lookup()
-    # Flush the LRU cache so stale entries from other tests don't leak in.
+    # (Types are folded into the base flag, #285 — matched via the patient's pre-expanded
+    # class concept_ids, not the flat ComponentCategoryOmopLookup — so no lookup sync is
+    # needed here; these tests exercise regimen + component matching on omop_* columns.)
     yield
-    clear_lookup_cache()
 
 # ── real concept_ids (from local vocab — test will fail if mapping drifts) ──
 
@@ -101,12 +94,6 @@ CARF = '42873638'   # carfilzomib component
 DEX  = '1518254'    # dexamethasone component
 DARA = '35605744'   # daratumumab component
 
-PI_CAT_BORT = 'proteasome_inhibitor'
-PI_CAT_LEN  = 'immunomodulatory_drug_(imid)'
-PI_CAT_DEX  = 'corticosteroid'
-PI_CAT_DARA = 'monoclonal_antibody_(anti_cd38)'
-
-
 # ── Phase P: components are consumer-supplied (promop pre-expanded), not derived ──
 # Regimen → its component concept_ids, i.e. what promop pre-expands onto the patient.
 REGIMEN_COMPONENTS = {
@@ -120,12 +107,9 @@ REGIMEN_COMPONENTS = {
 }
 
 
-def test_derive_uses_supplied_components_and_maps_types():
-    comps, types = derive_component_and_type_values([VRD], REGIMEN_COMPONENTS[VRD])
-    assert sorted(comps) == sorted([BORT, LEN, DEX])
-    assert PI_CAT_BORT in types
-    assert PI_CAT_LEN in types
-    assert PI_CAT_DEX in types
+def test_derive_uses_supplied_components():
+    comps, _ = derive_component_and_type_values([VRD], REGIMEN_COMPONENTS[VRD])
+    assert sorted(comps) == sorted([BORT, LEN, DEX])  # consumer-supplied component ids
 
 
 def test_derive_none_component_ids_is_unknown():
@@ -224,67 +208,9 @@ def test_daratumumab_naive_trial_excludes_dara_vrd_patient():
     assert result == 'not_matched'
 
 
-# ── extra mapping: HemOnc component concept_id → CB category code ────────────
-# These pin the TherapyComponent.omop_concept_id → TherapyComponentCategory.code
-# path so a vocab-load error is caught at this level, not only end-to-end.
-
-def test_bortezomib_component_concept_id_maps_to_proteasome_inhibitor():
-    _, types = derive_component_and_type_values([BORT_MONO], [BORT])
-    assert PI_CAT_BORT in types
-
-
-def test_carfilzomib_component_concept_id_also_maps_to_proteasome_inhibitor():
-    _, types = derive_component_and_type_values([CARF_MONO], [CARF])
-    assert PI_CAT_BORT in types
-
-
-def test_lenalidomide_component_concept_id_maps_to_imid():
-    _, types = derive_component_and_type_values([LEN_MONO], [LEN])
-    assert PI_CAT_LEN in types
-
-
-def test_daratumumab_component_concept_id_maps_to_anti_cd38():
-    _, types = derive_component_and_type_values([DARA_MONO], [DARA])
-    assert PI_CAT_DARA in types
-
-
-# ── type-level matching (CB category codes, legacy column) ───────────────────
-
-def test_trial_requiring_proteasome_inhibitor_matches_vrd_patient():
-    trial = TrialFactory(disease='multiple myeloma', therapy_types_required=[PI_CAT_BORT])
-    pi = _mm_pi(VRD)
-    result = UserToTrialAttrMatcher(trial, pi)._match_therapy_related_things([VRD], False)
-    assert result == 'matched'
-
-
-def test_trial_excluding_imid_blocks_vrd_patient():
-    trial = TrialFactory(disease='multiple myeloma', therapy_types_excluded=[PI_CAT_LEN])
-    pi = _mm_pi(VRD)
-    result = UserToTrialAttrMatcher(trial, pi)._match_therapy_related_things([VRD], False)
-    assert result == 'not_matched'
-
-
-def test_trial_requiring_anti_cd38_not_matched_by_vrd_patient():
-    # VRd has no anti-CD38 component
-    trial = TrialFactory(disease='multiple myeloma', therapy_types_required=[PI_CAT_DARA])
-    pi = _mm_pi(VRD)
-    result = UserToTrialAttrMatcher(trial, pi)._match_therapy_related_things([VRD], False)
-    assert result == 'not_matched'
-
-
-def test_trial_requiring_anti_cd38_matches_dara_vrd_patient():
-    trial = TrialFactory(disease='multiple myeloma', therapy_types_required=[PI_CAT_DARA])
-    pi = _mm_pi(DARA_VRD)
-    result = UserToTrialAttrMatcher(trial, pi)._match_therapy_related_things([DARA_VRD], False)
-    assert result == 'matched'
-
-
-def test_trial_excluding_anti_cd38_allows_vrd_patient():
-    # VRd has no anti-CD38 → patient is eligible despite the exclusion
-    trial = TrialFactory(disease='multiple myeloma', therapy_types_excluded=[PI_CAT_DARA])
-    pi = _mm_pi(VRD)
-    result = UserToTrialAttrMatcher(trial, pi)._match_therapy_related_things([VRD], False)
-    assert result == 'matched'
+# (The component-concept_id→CB-category mapping tests and the type-level matching tests
+# exercised the retired mode-2 type path; drug-class type matching is now mode-3 and
+# covered by tests/services/test_omop_therapy_types_matching.py, #285.)
 
 
 def test_trial_requiring_carfilzomib_component_not_matched_by_vrd_patient():
@@ -411,11 +337,5 @@ def test_component_only_component_exclusion_filters():
     assert kept.id in ids           # patient never had carfilzomib
 
 
-def test_component_only_type_filter_via_lookup():
-    type_match = TrialFactory(disease='multiple myeloma', therapy_types_required=[PI_CAT_BORT])
-    type_other = TrialFactory(disease='multiple myeloma', therapy_types_required=[PI_CAT_DARA])
-    pi = PatientInfo(disease='multiple myeloma', prior_therapy='One line',
-                     therapy_component_ids=[BORT, LEN])
-    ids = set(Trial.objects.filter_by_patient_info(pi)[0].values_list('id', flat=True))
-    assert type_match.id in ids     # bortezomib → proteasome inhibitor
-    assert type_other.id not in ids # patient has no anti-CD38 component
+# (test_component_only_type_filter_via_lookup removed — mode-2 type filter is retired;
+# the component-only type filter under mode-3 is covered by the omop-therapy-types suite.)

--- a/trials/models.py
+++ b/trials/models.py
@@ -445,9 +445,9 @@ class Trial(TimeStampMixin):
     omop_therapies_excluded = models.JSONField(blank=True, null=False, default=list)
     # OMOP-mapped drug-class "types" (promop ADR 0002, reverses decision A/#4502):
     # the patient now carries pre-expanded class concept_ids (promop#370), so these
-    # class-concept-id columns CAN overlap. Filled upstream by CB (#4633); read by
-    # EXACT only when the OMOP TherapyMatchProfile + EXACT_OMOP_THERAPY_TYPES are
-    # active (#285). Mirrors CB (#4631).
+    # class-concept-id columns CAN overlap. Filled upstream by CB (#4633); read by EXACT
+    # under the OMOP TherapyMatchProfile (#285 folded types into the base flag). Mirrors
+    # CB (#4631).
     omop_therapy_types_required = models.JSONField(blank=True, null=False, default=list)
     omop_therapy_types_excluded = models.JSONField(blank=True, null=False, default=list)
     omop_therapy_components_required = models.JSONField(blank=True, null=False, default=list)

--- a/trials/services/omop/component_category_lookup.py
+++ b/trials/services/omop/component_category_lookup.py
@@ -37,12 +37,16 @@ _request_memo: contextvars.ContextVar = contextvars.ContextVar(
 def component_concept_ids_to_type_codes(concept_ids):
     """Patient component concept_ids → list of CB category codes for type matching.
 
-    Returns ``None`` when ``concept_ids`` is ``None`` (unknown → preserve
-    unknown semantics in the matcher). Returns ``[]`` when the lookup yields
-    nothing (known-empty → no types to match).
+    DEPRECATED / DEAD (#285): this was the "mode 2" type path — reverse-map the
+    patient's components to CB category codes and overlap against the legacy
+    ``therapy_types_*`` columns. Types are now folded into the base OMOP flag and
+    matched by the patient's PRE-EXPANDED class concept_ids against
+    ``omop_therapy_types_*`` (promop pre-expands component→class, ADR 0004), so no
+    production caller reaches this. Kept only until the ``ComponentCategoryOmopLookup``
+    table + its sync/loader integration are retired in a follow-up. Do NOT add callers.
 
-    Input order is ignored. Inside a :class:`component_lookup_request_cache`
-    block the same concept_id set is resolved once and reused for the request.
+    Returns ``None`` when ``concept_ids`` is ``None`` (unknown → preserve unknown
+    semantics). Returns ``[]`` when the lookup yields nothing (known-empty).
     """
     if concept_ids is None:
         return None

--- a/trials/services/omop/therapy_graph.py
+++ b/trials/services/omop/therapy_graph.py
@@ -20,7 +20,7 @@ Returns ``(component_values, type_values)``. ``(None, None)`` means unknown
 ``therapy_component_ids`` (``patient_component_ids is None``); legacy → the patient
 has no resolvable regimens. An empty list is a known-empty component set.
 """
-from trials.services.therapy_match_profile import omop_therapy_enabled, omop_therapy_types_enabled
+from trials.services.therapy_match_profile import omop_therapy_enabled
 
 
 def resolve_regimens(therapy_identifiers):
@@ -46,14 +46,12 @@ def derive_component_and_type_values(therapy_identifiers, patient_component_ids=
     sent nothing) → ``(None, None)``; ``[]`` = known-empty; a list → those component
     concept_ids.
 
-    Types (drug-class):
-    - OMOP-types mode (``EXACT_OMOP_THERAPY_TYPES`` on, promop ADR 0002 / #285):
-      types are the consumer-supplied pre-expanded class concept_ids
-      ``patient_class_ids`` — ``None`` = unknown (fail-closed downstream), ``[]`` =
-      known-empty, a list → those class concept_ids. Matched by overlap against
-      ``omop_therapy_types_*``.
-    - OMOP-types OFF: legacy — CB category codes from the components via the flat
-      category lookup (overlapped against legacy ``therapy_types_*``; #4502).
+    Types (drug-class) under OMOP (folded into the base flag, #285 / promop ADR 0002):
+    the consumer-supplied PRE-EXPANDED class concept_ids ``patient_class_ids`` — ``None``
+    = unknown (fail-closed downstream), ``[]`` = known-empty, a list → those class
+    concept_ids. Matched by overlap against ``omop_therapy_types_*``. (The old
+    component→CB-category lookup type path is retired under OMOP; promop pre-expands
+    component→class per ADR 0004.)
 
     ``therapy_identifiers`` is used only by the legacy path.
 
@@ -67,26 +65,25 @@ def derive_component_and_type_values(therapy_identifiers, patient_component_ids=
     the return value is identical either way.
     """
     if omop_therapy_enabled():
-        types_on = omop_therapy_types_enabled()
+        # Types are folded into the base OMOP flag (#285): drug-class types are the
+        # consumer's PRE-EXPANDED class concept_ids (patient_class_ids), matched against
+        # omop_therapy_types_*. The old component->CB-category lookup type path (mode 2)
+        # is retired under OMOP — promop pre-expands component->class (ADR 0004).
         if patient_component_ids is None:
             if measure and therapy_identifiers:
                 from trials.services.omop.phase_t_metrics import record_regimen_unresolved
                 record_regimen_unresolved(therapy_identifiers)
-            # Components unknown -> component_values None. Types are independent under
-            # OMOP-types mode: a class-only patient (class ids but no components — and
-            # the #224 fold routes such patients here) still derives its types from the
-            # supplied class ids, so a required-class trial isn't false-negatived.
-            if types_on and patient_class_ids is not None:
+            # Components unknown -> component_values None. Types are independent: a
+            # class-only patient (class ids but no components — the #224 fold routes such
+            # patients here) still derives its types from the class ids, so a
+            # required-class trial isn't false-negatived.
+            if patient_class_ids is not None:
                 return None, [str(cid) for cid in patient_class_ids]
             return None, None
         component_values = [str(cid) for cid in patient_component_ids]
-        if types_on:
-            # Types = the patient's pre-expanded class concept_ids as-is. Preserve
-            # None (consumer sent no class ids -> unknown -> fail-closed) vs [].
-            type_values = None if patient_class_ids is None else [str(cid) for cid in patient_class_ids]
-        else:
-            from trials.services.omop.component_category_lookup import component_concept_ids_to_type_codes
-            type_values = component_concept_ids_to_type_codes(component_values) or []
+        # Types = the patient's pre-expanded class concept_ids as-is. Preserve None
+        # (consumer sent no class ids -> unknown -> fail-closed) vs [] (known-empty).
+        type_values = None if patient_class_ids is None else [str(cid) for cid in patient_class_ids]
         return component_values, type_values
 
     # ── legacy (flag OFF): internal CB-graph expansion — byte-identical to CB ──

--- a/trials/services/patient_info/patient_info.py
+++ b/trials/services/patient_info/patient_info.py
@@ -91,11 +91,12 @@ _FIELDS = [
     _f(TextField, 'later_therapy'),
     _f(JSONField, 'later_therapies', default=list),
     # Component concept_ids supplied directly by PROMOP (promop#189) under OMOP mode.
-    # None when the consumer has not sent them; used by component_category_lookup for types.
+    # None when the consumer has not sent them; used for component matching.
     _f(JSONField, 'therapy_component_ids', default=None),
     # Drug-class "type" concept_ids pre-expanded by PROMOP (promop#370, ADR 0002).
     # None when the consumer has not sent them; consumed as the patient's type
-    # match-values once EXACT_OMOP_THERAPY_TYPES is on (#285). Inert until then.
+    # match-values once OMOP therapy is on (#285 folded types into the base flag). Inert
+    # until then.
     _f(JSONField, 'therapy_type_ids', default=None),
     # Aggregate therapy-vocab release the patient's therapy_type_ids were derived
     # against (promop VocabularyRelease pk as a decimal string; promop#394). One

--- a/trials/services/therapy_match_profile.py
+++ b/trials/services/therapy_match_profile.py
@@ -9,7 +9,6 @@ from exact_matching.therapy_match_profile import (  # noqa: F401
     TherapyMatchProfile,
     LEGACY_THERAPY_MATCH_PROFILE,
     OMOP_THERAPY_MATCH_PROFILE,
-    OMOP_THERAPY_WITH_TYPES_MATCH_PROFILE,
     omop_therapy_enabled,
     omop_therapy_types_enabled,
     get_therapy_match_profile,


### PR DESCRIPTION
Types are part of the one OMOP therapy projection (therapies + components + supportive + types) and flip together — there is no architectural reason for a separate toggle. **Removes the `EXACT_OMOP_THERAPY_TYPES` flag; types ride the base `EXACT_OMOP_THERAPY`.**

## What
- `therapy_match_profile.py`: `OMOP_THERAPY_MATCH_PROFILE` now names `omop_therapy_types_*`; removed the separate `OMOP_THERAPY_WITH_TYPES_MATCH_PROFILE`; `omop_therapy_types_enabled()` is now an alias of `omop_therapy_enabled()` (the semantic gate for the type path); `get_therapy_match_profile()` = legacy / the one OMOP profile.
- **Retires the "mode 2" type path under OMOP** (patient component concept_ids → `ComponentCategoryOmopLookup` CB categories → legacy `therapy_types_*`): removed the dead derive branch (`therapy_graph.py`) + dead display lookup (`data_port.py`); `component_concept_ids_to_type_codes` is deprecated/dead. Under OMOP, types match ONLY via the patient's pre-expanded class concept_ids (promop#370) overlapped against `omop_therapy_types_*` — "tell don't ask" (ADR 0004). **Legacy (flag OFF) matching is byte-identical.**
- Stale comments/docstrings that described the removed flag as a live toggle or claimed "types are CB-coded / not OMOP-mapped" updated to reality.

## Tests
Deleted the mode-2 type-via-lookup tests (duplicates of the mode-3 coverage in `test_omop_therapy_types_matching.py` — required match/miss/unknown-fail-closed, excluded hit/empty, queryset, display); kept all component/regimen/legacy tests; **added exclusion-empty tests** pinning current behavior (required types fail-closed on unknown/empty; excluded types NOT rejected on an empty patient class set — a documented flip-gate decision guarded by an ingestion invariant: a therapy-bearing patient must not emit an empty class list from a failed expansion). 555 relevant tests pass; `makemigrations --check` clean.

## Status — DORMANT
Base OMOP is off in every env, so this lands inert. **Enabling the flag still requires** a real per-type shadow-compare (#287, not built — the current comparator only covers regimen/component/supportive) split by required/excluded deltas, plus the exclusion policy. This change does NOT make it cutover-ready.

## Follow-ups (tracked, non-blocking)
- Retire the full `ComponentCategoryOmopLookup` table + its sync + loader integration (dead post-fold).
- Display parity: add `omopConcepts` to the type criteria in the detail map (types are now OMOP concepts; behavior unchanged from before the fold).

Adjudicated with `codex exec` (proceed-with-modifications) + `codex review` (clean) + fresh-context subagent (clean, no P1/P2 — verified fold correctness, dead-path removal completeness, coverage preservation, derive contract, exclusion-empty).

🤖 Generated with [Claude Code](https://claude.com/claude-code)