### PR TITLE
Gate the portal introspection fallback, bound its outbound calls, and make the deploy fire

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,19 @@ PATIENT_DATABASE_URL=postgresql://user:password@host:5432/dbname
 REDIS_URL=redis://localhost:6379
 ENVIRONMENT=local
 
+# ── Portal (PHR) identity ────────────────────────────────────────────────
+# Verifies tokens a signed-in patient carries in from the portal. Leave
+# PHR_BASE_URL unset to disable portal auth entirely (it then fails closed).
+# PARTNER_AUTH_PROVIDERS=accounts.providers.phr.PhrTokenProvider
+# PHR_BASE_URL=http://localhost:8000
+# PHR_ISSUER=healthkey-phr
+#
+# HS256 introspection fallback. On by default only for ENVIRONMENT=local or
+# DEBUG, and it must stay OFF when deployed: it delegates the signature check
+# to the portal, so a portal that introspects without fully verifying
+# signatures would let a forged token through. See docs/setup.md.
+# PHR_ALLOW_INTROSPECTION=false
+
 # PostGIS (if not in system PATH)
 # macOS (Homebrew): GDAL_LIBRARY_PATH=/opt/homebrew/lib/libgdal.dylib
 # macOS (Homebrew): GEOS_LIBRARY_PATH=/opt/homebrew/lib/libgeos_c.dylib

--- a/.github/workflows/deploy-render.yml
+++ b/.github/workflows/deploy-render.yml
@@ -4,15 +4,16 @@ name: Deploy to Render
 # which ships the same commit to Cloud Run: exact is deployed to both, and
 # neither platform is authoritative.
 #
-# Gated on the django workflow rather than calling a reusable one — none of
+# Gated on the backend suite rather than calling a reusable workflow — none of
 # this repo's CI workflows are workflow_call-able, and rewiring them to be so
 # is a bigger change than this deploy warrants. workflow_run fires once that
 # suite finishes, and the conclusion check below is what keeps a red build
 # from shipping.
 #
 # Render's own auto-deploy is off for this service (Terraform sets
-# auto_deploy = false) so the platform cannot race this workflow and ship a
-# commit that never ran the test suite.
+# auto_deploy = false), and every deploy this workflow requests is pinned to
+# the commit that passed the suite — so neither the platform nor a push
+# landing mid-run can ship a revision the tests never saw.
 #
 # Needs:
 #   secrets.RENDER_API_KEY          — Render API key
@@ -20,7 +21,12 @@ name: Deploy to Render
 
 on:
   workflow_run:
-    workflows: [django]
+    # This matches the triggering workflow's `name:`, NOT its filename — the
+    # test suite lives in django.yml but is named `backend`. Naming the file
+    # here silently never matches: workflow_run simply does not fire, every
+    # `if:` below becomes unreachable, and nothing reports an error.
+    # tests/test_deploy_render_workflow.py guards the pairing.
+    workflows: [backend]
     types: [completed]
   workflow_dispatch:
 
@@ -35,8 +41,13 @@ jobs:
     # workflow_run fires for every branch and for failed runs too, so the
     # branch and conclusion both have to be checked here. workflow_dispatch
     # carries neither, hence the event fallback.
+    # A manual dispatch is branch-checked too. It used to be harmless without
+    # one: the request carried no commit, so Render built the tracked branch
+    # whatever ref the dispatch came from. Now that the commit is pinned, an
+    # unguarded dispatch would ship the dispatched branch's untested tip.
     if: >-
-      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'workflow_dispatch' &&
+       github.ref == 'refs/heads/main') ||
       (github.event.workflow_run.conclusion == 'success' &&
        github.event.workflow_run.head_branch == 'main')
     steps:
@@ -45,18 +56,32 @@ jobs:
         env:
           RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
           SERVICE_ID: ${{ vars.RENDER_EXACT_SERVICE_ID }}
+          # The revision the suite actually ran against. Via env, never
+          # interpolated into the script below. workflow_dispatch carries no
+          # workflow_run payload, so it falls back to the dispatched ref's tip.
+          COMMIT_ID: ${{ github.event.workflow_run.head_sha || github.sha }}
         run: |
           set -euo pipefail
 
           if [ -z "${SERVICE_ID:-}" ]; then
             echo "vars.RENDER_EXACT_SERVICE_ID is not set"; exit 1
           fi
+          if [ -z "${COMMIT_ID:-}" ]; then
+            echo "could not resolve the commit to deploy"; exit 1
+          fi
 
+          # `commitId`, not `{}`: without it Render builds whatever the tracked
+          # branch points at when it receives the call, so a push landing while
+          # the suite was still running would ship a revision that never ran
+          # the tests — defeating the gate this workflow exists to be.
           RESPONSE=$(curl -s -w '\n%{http_code}' -X POST \
             -H "Authorization: Bearer $RENDER_API_KEY" \
             -H "Content-Type: application/json" \
             "https://api.render.com/v1/services/$SERVICE_ID/deploys" \
-            -d '{}')
+            -d "$(python3 -c "
+          import json, os
+          print(json.dumps({'commitId': os.environ['COMMIT_ID']}))
+          ")")
           CODE=${RESPONSE##*$'\n'}
           BODY=${RESPONSE%$'\n'*}
 
@@ -65,25 +90,57 @@ jobs:
             *) echo "Render refused the deploy: HTTP $CODE $BODY"; exit 1 ;;
           esac
 
+          # Verifying the commit on this path too, not only when adopting: an
+          # API that ignored or renamed `commitId` would silently drop it —
+          # unknown JSON fields go unremarked — and the run would build the
+          # tracked branch's tip and report success, which is the whole thing
+          # the pinning is here to prevent.
           DEPLOY_ID=$(printf '%s' "$BODY" | python3 -c "
-          import json, sys
+          import json, os, sys
           raw = sys.stdin.read().strip()
-          print(json.loads(raw).get('id', '') if raw else '')
+          if not raw:
+              print('')
+              raise SystemExit(0)
+          deploy = json.loads(raw)
+          built = (deploy.get('commit') or {}).get('id')
+          if built is not None and built != os.environ['COMMIT_ID']:
+              sys.exit(f'Render accepted the deploy for {built}, not the '
+                       f'requested {os.environ[\"COMMIT_ID\"]}')
+          print(deploy.get('id', ''))
           ")
 
           # Render answers 201 with the new deploy, but 202 with an empty body
           # when the service already has one queued — piping that straight into
           # a JSON parser fails the run even though a deploy is on its way.
-          # Adopt the in-flight one and wait on it instead.
+          # Adopt the in-flight one, but only after checking it is for this
+          # commit and is not already finished: "the most recent deploy" could
+          # be someone else's revision, or an older build that is already live,
+          # in which case the wait below would pass on its first poll and the
+          # run would report success for a deploy it never made.
           if [ -z "$DEPLOY_ID" ]; then
             DEPLOY_ID=$(curl -sf -H "Authorization: Bearer $RENDER_API_KEY" \
               "https://api.render.com/v1/services/$SERVICE_ID/deploys?limit=1" \
-              | python3 -c "import json,sys; print(json.load(sys.stdin)[0]['deploy']['id'])")
-            echo "HTTP $CODE with no body — a deploy was already queued; waiting on $DEPLOY_ID"
+              | python3 -c "
+          import json, os, sys
+          IN_FLIGHT = {'created', 'queued', 'build_in_progress',
+                       'pre_deploy_in_progress', 'update_in_progress'}
+          deploy = json.load(sys.stdin)[0]['deploy']
+          queued = (deploy.get('commit') or {}).get('id')
+          if queued != os.environ['COMMIT_ID']:
+              sys.exit(f'queued deploy is for {queued}, not {os.environ[\"COMMIT_ID\"]}')
+          # An allowlist, not just 'not live': a finished-and-failed deploy
+          # would otherwise be adopted and then reported by the wait step as
+          # this run's failure, when this run never requested it.
+          if deploy.get('status') not in IN_FLIGHT:
+              sys.exit(f'most recent deploy is not in flight (status='
+                       f'{deploy.get(\"status\")!r}) — nothing was queued for this run')
+          print(deploy['id'])
+          ")
+            echo "HTTP $CODE with no body — adopting queued deploy $DEPLOY_ID for $COMMIT_ID"
           fi
 
           echo "deploy_id=$DEPLOY_ID" >> "$GITHUB_OUTPUT"
-          echo "Triggered deploy $DEPLOY_ID"
+          echo "Triggered deploy $DEPLOY_ID for $COMMIT_ID"
 
       - name: Wait for deploy to go live
         env:

--- a/.github/workflows/deploy-render.yml
+++ b/.github/workflows/deploy-render.yml
@@ -147,32 +147,56 @@ jobs:
           RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
           SERVICE_ID: ${{ vars.RENDER_EXACT_SERVICE_ID }}
           DEPLOY_ID: ${{ steps.trigger.outputs.deploy_id }}
+          COMMIT_ID: ${{ github.event.workflow_run.head_sha || github.sha }}
         run: |
+          # This is also where the commit is *confirmed*, not just requested.
+          # The POST response is only checked when it happens to echo a commit,
+          # which would leave the pin unverified — and therefore fail open —
+          # against an API that stops echoing it or silently drops `commitId`.
+          # The deploy detail endpoint reports the commit it actually built, so
+          # going live without ever naming one is treated as a failure here.
+          #
           # Generous ceiling: this image builds the frontend remote and a
           # GDAL/GEOS-linked Python stack, which is slower than the other
           # services in the family.
           for i in $(seq 1 90); do
             # Tolerate a blank answer: a transient API hiccup should cost one
             # poll, not the whole deploy.
-            STATUS=$(curl -s -H "Authorization: Bearer $RENDER_API_KEY" \
+            VERDICT=$(curl -s -H "Authorization: Bearer $RENDER_API_KEY" \
               "https://api.render.com/v1/services/$SERVICE_ID/deploys/$DEPLOY_ID" \
               | python3 -c "
-          import json, sys
+          import json, os, sys
+          FAILED = {'build_failed', 'update_failed', 'pre_deploy_failed',
+                    'canceled', 'deactivated'}
           try:
-              print(json.load(sys.stdin).get('status', ''))
+              deploy = json.load(sys.stdin)
           except Exception:
-              print('')
+              print('pending')
+              raise SystemExit(0)
+          status = deploy.get('status', '')
+          built = (deploy.get('commit') or {}).get('id')
+          if built is not None and built != os.environ['COMMIT_ID']:
+              print(f'mismatch {built}')
+          elif status in FAILED:
+              print(f'failed {status}')
+          elif status == 'live':
+              print('live' if built is not None else 'unverified')
+          else:
+              print(f'waiting {status}' if status else 'pending')
           ")
-            if [ -z "$STATUS" ]; then
-              echo "[$i] status unavailable, retrying"
-              sleep 20
-              continue
-            fi
-            echo "[$i] $STATUS"
-            case "$STATUS" in
-              live) exit 0 ;;
-              build_failed|update_failed|pre_deploy_failed|canceled|deactivated)
-                echo "Deploy failed with status: $STATUS"; exit 1 ;;
+            echo "[$i] $VERDICT"
+            case "$VERDICT" in
+              live)
+                echo "Deploy $DEPLOY_ID is live at $COMMIT_ID"; exit 0 ;;
+              unverified)
+                echo "Deploy went live but never reported a commit, so nothing"
+                echo "confirms it is $COMMIT_ID. Refusing to call this a success."
+                exit 1 ;;
+              mismatch*)
+                echo "Deploy built ${VERDICT#mismatch }, not the tested $COMMIT_ID"
+                exit 1 ;;
+              failed*)
+                echo "Deploy failed with status: ${VERDICT#failed }"; exit 1 ;;
             esac
             sleep 20
           done

--- a/.github/workflows/deploy-render.yml
+++ b/.github/workflows/deploy-render.yml
@@ -41,6 +41,16 @@ jobs:
     # workflow_run fires for every branch and for failed runs too, so the
     # branch and conclusion both have to be checked here. workflow_dispatch
     # carries neither, hence the event fallback.
+    # Three things have to hold, and `head_branch == 'main'` is not one of them
+    # on its own. This repo is public and django.yml runs on bare
+    # `pull_request:`, so a fork PR gets a `backend` run whose `head_branch` is
+    # the branch name *in the fork* — `main`, for anyone who pushes to their
+    # fork's default branch before opening the PR. That run's completion would
+    # satisfy a branch-and-conclusion check, and this job would then execute in
+    # the base-repo context, with RENDER_API_KEY, pinning `commitId` to an
+    # unreviewed fork commit. Requiring the upstream event to be a `push`
+    # excludes every PR run, fork or not.
+    #
     # A manual dispatch is branch-checked too. It used to be harmless without
     # one: the request carried no commit, so Render built the tracked branch
     # whatever ref the dispatch came from. Now that the commit is pinned, an
@@ -48,7 +58,8 @@ jobs:
     if: >-
       (github.event_name == 'workflow_dispatch' &&
        github.ref == 'refs/heads/main') ||
-      (github.event.workflow_run.conclusion == 'success' &&
+      (github.event.workflow_run.event == 'push' &&
+       github.event.workflow_run.conclusion == 'success' &&
        github.event.workflow_run.head_branch == 'main')
     steps:
       - name: Trigger Render deploy
@@ -74,14 +85,20 @@ jobs:
           # branch points at when it receives the call, so a push landing while
           # the suite was still running would ship a revision that never ran
           # the tests — defeating the gate this workflow exists to be.
+          # On its own line, not inline in the curl arguments: `set -e` ignores a
+          # non-zero exit from a command substitution used as an argument, so a
+          # broken generator would post `-d ""` — the branch-tip deploy this is
+          # here to prevent — instead of failing at the real cause.
+          BODY_JSON=$(python3 -c "
+          import json, os
+          print(json.dumps({'commitId': os.environ['COMMIT_ID']}))
+          ")
+
           RESPONSE=$(curl -s -w '\n%{http_code}' -X POST \
             -H "Authorization: Bearer $RENDER_API_KEY" \
             -H "Content-Type: application/json" \
             "https://api.render.com/v1/services/$SERVICE_ID/deploys" \
-            -d "$(python3 -c "
-          import json, os
-          print(json.dumps({'commitId': os.environ['COMMIT_ID']}))
-          ")")
+            -d "$BODY_JSON")
           CODE=${RESPONSE##*$'\n'}
           BODY=${RESPONSE%$'\n'*}
 
@@ -159,6 +176,7 @@ jobs:
           # Generous ceiling: this image builds the frontend remote and a
           # GDAL/GEOS-linked Python stack, which is slower than the other
           # services in the family.
+          set -uo pipefail
           for i in $(seq 1 90); do
             # Tolerate a blank answer: a transient API hiccup should cost one
             # poll, not the whole deploy.
@@ -184,6 +202,15 @@ jobs:
           else:
               print(f'waiting {status}' if status else 'pending')
           ")
+            # An empty verdict means the program itself died — a missing
+            # COMMIT_ID in this step's env, say. Without this the `case` below
+            # matches nothing and the run emits 90 blank lines over 30 minutes
+            # before timing out, naming no cause.
+            if [ -z "$VERDICT" ]; then
+              echo "[$i] the status check produced no verdict, retrying"
+              sleep 20
+              continue
+            fi
             echo "[$i] $VERDICT"
             case "$VERDICT" in
               live)

--- a/accounts/providers/phr.py
+++ b/accounts/providers/phr.py
@@ -14,6 +14,93 @@ from .base import TokenClaims, TokenProvider, decode_jwt_unverified
 
 logger = logging.getLogger(__name__)
 
+# Algorithms the introspection fallback will accept.  The portal's dev
+# deployments sign with a shared HS256 secret this service does not hold, so
+# such a token can only be checked by asking the portal.  Everything else —
+# `none`, an asymmetric alg that should have gone down the JWKS path, a
+# garbage string — is rejected locally.  Dispatching on "anything that is not
+# RS256" let an unauthenticated caller select the network path, and with it an
+# introspection endpoint's own laxness, by writing a single header field.
+_INTROSPECTABLE_ALGS = frozenset({"HS256", "HS384", "HS512"})
+
+
+class _CallBudget:
+    """Fixed-window counter bounding outbound introspection calls.
+
+    The JWKS path is protected by a refresh floor; the introspection path had
+    nothing.  Routing into this provider takes only an *unverified* `iss`, and
+    only *successful* verifications are cached upstream, so every failed
+    attempt re-issued a blocking 5s POST.  DRF runs authentication before
+    throttling (`APIView.initial`), so `AnonRateThrottle` cannot reach this.
+
+    A budget rather than a one-call-per-interval floor: a floor would reject
+    every legitimate concurrent sign-in for the rest of the window.
+
+    What this does **not** do, deliberately:
+
+    * It is not keyed by caller — the provider never sees the request.  So a
+      caller who burns the window's budget on junk does deny legitimate
+      sign-ins until it rolls over.  That is accepted because the whole
+      introspection path is opt-in and off outside DEBUG/local (see
+      PHR_ALLOW_INTROSPECTION); what it buys is a hard ceiling on outbound
+      volume, not fairness.
+    * It bounds *rate*, not *concurrency*: `max_calls` simultaneous 5s POSTs
+      still occupy more workers than a deployment has.  Worker exhaustion is
+      closed by the path being disabled in deployed environments, not here.
+    * The window is per process, so N workers permit N × max_calls, and a
+      deploy resets every window.
+    * Fixed window, not a sliding one, so a burst straddling the boundary can
+      reach 2 × max_calls within one interval.  Sufficient for a ceiling.
+    """
+
+    def __init__(self) -> None:
+        self._window_started_at: float | None = None
+        self._spent = 0
+        self._warned = False
+
+    def reset(self) -> None:
+        """Drop the current window (tests)."""
+        self._window_started_at = None
+        self._spent = 0
+        self._warned = False
+
+    def claim(self, max_calls: int, interval: int) -> bool:
+        """Consume one call from the budget; False when it is exhausted.
+
+        Deliberately unlocked, like `_JWKSCache.get`: `self._spent += 1` is a
+        read-modify-write, so under `--threads` concurrent claims can lose an
+        update and overshoot.  The overshoot is bounded by the thread count and
+        this guards no I/O of its own, so a lock would buy little.
+        """
+        now = time.monotonic()
+        # `max(interval, 1)`: at 0 the window would restart on every call and
+        # silently remove the ceiling — the one misconfiguration here that
+        # fails open rather than closed.
+        if (
+            self._window_started_at is None
+            or now - self._window_started_at >= max(interval, 1)
+        ):
+            self._window_started_at = now
+            self._spent = 0
+            self._warned = False
+        if self._spent >= max_calls:
+            # Once per window, not per request: reaching this means real
+            # sign-ins are being rejected and is worth a warning, but the
+            # rejected requests are attacker-drivable and one line each would
+            # let anyone flood the log — the same reasoning that keeps the
+            # `kid` miss below at debug.
+            if not self._warned:
+                self._warned = True
+                logger.warning(
+                    'phr introspection budget exhausted (%s per %ss); '
+                    'tokens rejected until the window rolls over',
+                    max_calls,
+                    interval,
+                )
+            return False
+        self._spent += 1
+        return True
+
 
 class _JWKSCache:
     """Fetch-once JWKS cache with TTL and rate-limited kid-miss refresh."""
@@ -122,20 +209,30 @@ class _JWKSCache:
 
 
 _jwks_cache = _JWKSCache()
+_introspect_budget = _CallBudget()
 
 
 class PhrTokenProvider(TokenProvider):
     """Verify JWTs issued by the phr identity service.
 
     phr owns the user accounts for the service family. RS256 tokens are
-    verified offline against phr's JWKS document; anything else (e.g. an
-    HS256 dev deployment) falls back to phr's RFC 7662 introspection
-    endpoint.
+    verified offline against phr's JWKS document — this is the only path a
+    deployment should rely on.
+
+    An HS256 token is signed with a shared secret this service does not hold
+    and can therefore only be checked by asking the portal, which is what the
+    introspection fallback is for. It is **off unless PHR_ALLOW_INTROSPECTION
+    is set** (defaulting on only for DEBUG/local) because it moves the
+    signature check into another service: an `active` response is taken as the
+    portal vouching for the token, and where §2.2 leaves the response silent
+    about the subject the *unverified* payload supplies it. A portal whose
+    introspection endpoint does not fully verify signatures therefore lets a
+    forged token through, so the path stays opt-in and out of production.
 
     Identity maps as (issuer=PHR_ISSUER, sub="phr:<phr user id>"). The
-    "phr:" prefix is descriptive only: Identity is keyed on the composite
-    (issuer, sub) since #182, so a bare portal id could not collide with
-    another issuer's subject anyway.
+    "phr:" prefix is load-bearing, not cosmetic: `Identity.sub` is
+    `unique=True` *globally*, not per issuer, so a bare portal id could
+    collide with another issuer's subject. Do not remove it.
     """
 
     def can_handle(self, token: str, unverified_payload: dict[str, Any] | None) -> bool:
@@ -153,10 +250,24 @@ class PhrTokenProvider(TokenProvider):
         # differently and neither order is right for both. A SimpleJWT payload
         # carries `user_id`; an RFC 7662 response carries `sub` — optionally,
         # §2.2 does not require it — and may carry neither.
-        if header.get("alg") == "RS256":
+        #
+        # Dispatch on an allowlist, never on "not RS256". The `alg` header is
+        # attacker-supplied, so an `else` branch handed the caller the choice
+        # of verification path.
+        alg = header.get("alg")
+        if alg == "RS256":
             verified = self._verify_jwks(token, header.get("kid"))
-        else:
+        # `isinstance` first: `get_unverified_header` only guarantees the header
+        # is a JSON *object*, so `alg` can be a list or dict, and testing set
+        # membership on one raises TypeError. That would surface as an uncaught
+        # exception here — logged at warning by the caller, once per request,
+        # for an anonymous caller who chose the header. The `else` below is
+        # where a non-string belongs: rejected, at debug.
+        elif isinstance(alg, str) and alg in _INTROSPECTABLE_ALGS:
             verified = self._verify_introspect(token)
+        else:
+            logger.debug("phr token rejected: unsupported alg=%r", alg)
+            verified = None
         if verified is None:
             return None
         claims, sub = verified
@@ -190,7 +301,12 @@ class PhrTokenProvider(TokenProvider):
                 key=key,
                 algorithms=["RS256"],
                 issuer=settings.PHR_ISSUER,
-                options={"verify_aud": False},
+                # `require`, because PyJWT's expiry check is a no-op when the
+                # claim is simply absent — a token minted without `exp`, or one
+                # a portal-side regression stops stamping, would otherwise be
+                # accepted forever. The introspection path checks the same
+                # thing locally, so both paths agree.
+                options={"verify_aud": False, "require": ["exp"]},
             )
         except jwt.ExpiredSignatureError as exc:
             raise AuthenticationFailed("phr token expired") from exc
@@ -206,6 +322,30 @@ class PhrTokenProvider(TokenProvider):
         return (claims, str(sub)) if sub else None
 
     def _verify_introspect(self, token: str) -> tuple[dict[str, Any], str] | None:
+        if not settings.PHR_ALLOW_INTROSPECTION:
+            logger.debug("phr introspection fallback disabled; token rejected")
+            return None
+
+        # Everything checkable without the network happens first, so a token
+        # that cannot possibly verify costs no outbound request.  These read an
+        # *unverified* payload and may therefore only ever reject — never
+        # accept, and never widen what the portal would have allowed.
+        #
+        # RFC 7662's own `token_type` is the OAuth2 type ("Bearer"), not the
+        # access/refresh distinction, so the introspection response cannot
+        # carry the check that keeps refresh tokens out.  The token can.
+        payload = decode_jwt_unverified(token) or {}
+        if not _is_access_token(payload):
+            return None
+        if not _has_live_exp(payload):
+            return None
+
+        if not _introspect_budget.claim(
+            settings.PHR_INTROSPECT_MAX_CALLS,
+            settings.PHR_INTROSPECT_RATE_INTERVAL,
+        ):
+            return None
+
         try:
             resp = httpx.post(
                 settings.PHR_INTROSPECT_URL, json={"token": token}, timeout=5
@@ -215,19 +355,30 @@ class PhrTokenProvider(TokenProvider):
         except Exception as exc:
             logger.warning("phr introspection failed: %s", exc)
             return None
-        if not data.get("active"):
+        if not isinstance(data, dict):
+            # §2.2 specifies a JSON object; a list or a bare string would
+            # otherwise reach .get() below. base.py guards the same shape.
+            logger.warning("phr introspection returned a non-object response")
+            return None
+        # `is not True`, not falsiness: §2.2 specifies a boolean, and a portal
+        # answering the string "false" would otherwise read as truthy and
+        # authenticate a token it just declined.
+        active = data.get("active")
+        if active is not True:
+            if active is not False and active is not None:
+                # A portal answering `1` or `"true"` now 401s every sign-in.
+                # Say so, or the only symptom is a deployment that rejects
+                # every token with nothing to distinguish it from `active:
+                # false` — which stays at debug, being the normal answer.
+                logger.warning(
+                    "phr introspection returned a non-boolean `active`: %r", active
+                )
             return None
 
-        # RFC 7662's own `token_type` is the OAuth2 type ("Bearer"), not the
-        # access/refresh distinction, so the introspection response cannot
-        # carry the check that keeps refresh tokens out.  The token can: an
-        # `active` response is the portal confirming it issued this JWT, which
-        # makes its payload authentic even though this service never verified
-        # the signature itself.
-        payload = decode_jwt_unverified(token) or {}
-        if not _is_access_token(payload):
-            return None
-
+        # An `active` response is the portal confirming it issued this JWT,
+        # which is what makes the payload above usable despite this service
+        # never having verified the signature itself.
+        #
         # Response before payload — the response is authoritative where it
         # speaks, and a `user_id` that exists only in the payload must not
         # outrank it.  But §2.2 makes every claim optional and some portals
@@ -263,3 +414,21 @@ def _is_access_token(claims: dict[str, Any]) -> bool:
         return True
     logger.debug("phr token rejected: token_type=%r", claims.get("token_type"))
     return False
+
+
+def _has_live_exp(claims: dict[str, Any]) -> bool:
+    """Reject a missing or past `exp` locally, before any outbound call.
+
+    Reads an unverified payload, so it may only reject: a forged token still
+    has to carry a plausible expiry to be worth asking the portal about, and
+    one that does not is junk the portal would refuse anyway.  `bool` is
+    excluded explicitly because it is an `int` subclass in Python.
+    """
+    exp = claims.get("exp")
+    if isinstance(exp, bool) or not isinstance(exp, (int, float)):
+        logger.debug("phr token rejected: exp=%r", exp)
+        return False
+    if exp <= time.time():
+        logger.debug("phr token rejected: expired")
+        return False
+    return True

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,18 @@ services:
       - path: .env
         required: false
     environment:
+      # Explicit, because `.env` is optional above and this gate reads
+      # ENVIRONMENT via os.environ.get so an unset value counts as *deployed*
+      # and fails closed — without it, `docker compose up` on a fresh clone has
+      # no working credential against the portal's HS256 dev deployment.
+      #
+      # This flag rather than `ENVIRONMENT: local`, which would also flip
+      # EXACT_ALLOW_PERSON_ID_LOOKUP on. That gate is deliberately closed
+      # (#150/#108): the `?person_id=` resolver reads from PROMOP with a static
+      # service token that is not bound to the caller, so enabling it here
+      # would re-open an IDOR against whatever upstream a developer's .env
+      # points at. Keep the blast radius to the one gate that needs opening.
+      PHR_ALLOW_INTROSPECTION: "true"
       DATABASE_HOST: db
       DATABASE_NAME: exact
       DATABASE_USER: exact

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,11 +30,15 @@ services:
       # no working credential against the portal's HS256 dev deployment.
       #
       # This flag rather than `ENVIRONMENT: local`, which would also flip
-      # EXACT_ALLOW_PERSON_ID_LOOKUP on. That gate is deliberately closed
-      # (#150/#108): the `?person_id=` resolver reads from PROMOP with a static
-      # service token that is not bound to the caller, so enabling it here
-      # would re-open an IDOR against whatever upstream a developer's .env
-      # points at. Keep the blast radius to the one gate that needs opening.
+      # EXACT_ALLOW_PERSON_ID_LOOKUP on — a gate deliberately closed for
+      # #150/#108, since the `?person_id=` resolver reads from PROMOP under a
+      # static service token not bound to the caller. Keeping the blast radius
+      # to the one gate that needs opening.
+      #
+      # Only for the no-.env case, to be clear: docs/setup.md has you copy
+      # .env.example, which sets ENVIRONMENT=local, and compose loads .env — so
+      # a developer who followed the setup has that gate open anyway. Closing it
+      # for local dev is a separate job than this file.
       PHR_ALLOW_INTROSPECTION: "true"
       DATABASE_HOST: db
       DATABASE_NAME: exact

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -371,6 +371,16 @@ environment variables — never commit secret values to git.
 | `GEOS_LIBRARY_PATH` | `/opt/homebrew/lib/libgeos_c.dylib` | Path to GEOS shared library |
 | `ENVIRONMENT` | `local` | Environment name (`local` / `dev` / `staging` / `prod`) |
 | `ADD_SEARCH_TRIALS_TRACES` | `false` | Set to `true` to log detailed trial-search reasoning |
+| `PARTNER_AUTH_PROVIDERS` | Firebase + PHR | Comma-separated dotted paths of the token providers this deployment has. Set to the portal provider alone where there is no Firebase. |
+| `PHR_ISSUER` | `healthkey-phr` | The `iss` claim that routes a token to the portal provider. Not safely changeable after a deploy: `Identity.sub` is globally unique, so existing users would collide under a new issuer. |
+| `PHR_BASE_URL` | _(empty)_ | Portal base URL; derives `PHR_JWKS_URL` and `PHR_INTROSPECT_URL`. Unset means portal tokens never verify (fails closed). |
+| `PHR_JWKS_URL` | _(derived)_ | Overrides the JWKS endpoint derived from `PHR_BASE_URL` |
+| `PHR_INTROSPECT_URL` | _(derived)_ | Overrides the introspection endpoint derived from `PHR_BASE_URL` |
+| `PHR_JWKS_CACHE_TTL` | `3600` | Seconds a fetched JWKS document is reused |
+| `PHR_JWKS_MIN_REFRESH_INTERVAL` | `60` | Floor between JWKS refetches. A token's `kid` is attacker-controlled and a miss triggers a refresh, so this is what stops one blocking outbound fetch per bogus token. Keep well under `PHR_JWKS_CACHE_TTL`. |
+| `PHR_ALLOW_INTROSPECTION` | `true` local/DEBUG, else `false` | **Security gate — leave off when deployed.** Enables the HS256 introspection fallback, which moves the signature check into the portal: an `active` response is taken as vouching for the token, and where the response omits the subject the token's *unverified* payload supplies it. A portal that introspects without fully verifying signatures would let a forged token through. Reads `ENVIRONMENT` from the process env, so an unset value counts as deployed and fails closed. |
+| `PHR_INTROSPECT_MAX_CALLS` | `30` | Ceiling on outbound introspection calls per interval, per process. DRF authenticates before it throttles, so `AnonRateThrottle` cannot reach that path — this is the only bound an anonymous caller runs into. |
+| `PHR_INTROSPECT_RATE_INTERVAL` | `60` | Window, in seconds, for `PHR_INTROSPECT_MAX_CALLS`. Clamped to a minimum of 1 — at `0` the window would restart on every call and remove the ceiling. |
 
 ---
 

--- a/exact/settings.py
+++ b/exact/settings.py
@@ -257,6 +257,32 @@ PARTNER_AUTH_PROVIDERS = [
 # service. RS256 tokens verify offline against its JWKS; deployments still
 # on the HS256 dev fallback verify by introspection instead.
 PHR_ISSUER = os.environ.get('PHR_ISSUER', 'healthkey-phr')
+# Introspection fallback — opt-in, and off in staging/prod by default.
+# It delegates the signature check to the portal (an `active` response is
+# taken as vouching for the token, and the subject may come from the token's
+# *unverified* payload), so a portal that introspects without fully verifying
+# signatures would let a forged token through. Both PHR_*_URLs derive from the
+# same PHR_BASE_URL, so without this flag every RS256 deployment silently
+# enabled the fallback too — and the caller picked which path to use.
+# Same fail-closed shape as ENABLE_DRF_TOKEN_AUTH: `os.environ.get(...)`, not
+# the module-level ENVIRONMENT, which defaults to 'local' — a deploy that
+# forgets to set ENVIRONMENT would otherwise read as local and turn this ON,
+# which is precisely the misconfigured deploy the gate exists for.
+_phr_introspection_default = (
+    'true' if (DEBUG or os.environ.get('ENVIRONMENT') == 'local') else 'false'
+)
+PHR_ALLOW_INTROSPECTION = os.environ.get(
+    'PHR_ALLOW_INTROSPECTION', _phr_introspection_default
+).lower() in ('1', 'true')
+# Cap on outbound introspection calls per interval. Reaching this provider
+# needs only an unverified `iss`, and DRF authenticates before it throttles,
+# so without a cap an anonymous caller could hold every sync worker in a 5s
+# POST and use this service to flood the portal. Sized to sit well above real
+# sign-in volume on the dev deployments that use this path at all.
+PHR_INTROSPECT_MAX_CALLS = int(os.environ.get('PHR_INTROSPECT_MAX_CALLS', '30'))
+PHR_INTROSPECT_RATE_INTERVAL = int(
+    os.environ.get('PHR_INTROSPECT_RATE_INTERVAL', '60')
+)
 _phr_base_url = os.environ.get('PHR_BASE_URL', '').rstrip('/')
 PHR_JWKS_URL = os.environ.get(
     'PHR_JWKS_URL',

--- a/tests/test_deploy_render_workflow.py
+++ b/tests/test_deploy_render_workflow.py
@@ -99,18 +99,22 @@ def _deploy_post_request():
 
 
 def _embedded_python(marker):
-    """The inline `python3 -c` program in the deploy step containing *marker*.
+    """The inline `python3 -c` program, across all steps, containing *marker*.
 
     Executable form: dedented, with the shell's `\\"` escapes resolved. Lets the
     tests below run the workflow's own logic instead of grepping for it — a
     source match proves a check is present, never that it is right.
     """
-    scripts = _run_scripts()
-    step = next(s for s in scripts.values() if '-X POST' in s)
-    blocks = re.findall(r'python3 -c "\n(.*?)\n *"', step, re.DOTALL)
+    blocks = [
+        block
+        for script in _run_scripts().values()
+        for block in re.findall(r'python3 -c "\n(.*?)\n *"', script, re.DOTALL)
+    ]
     matching = [b for b in blocks if marker in b]
-    assert len(matching) == 1, \
-        f'expected exactly one embedded program containing {marker!r}, got {len(matching)}'
+    assert len(matching) == 1, (
+        f'expected exactly one embedded program containing {marker!r}, '
+        f'got {len(matching)} (of {len(blocks)} programs)'
+    )
     return textwrap.dedent(matching[0].replace('\\"', '"'))
 
 
@@ -281,11 +285,16 @@ class TestTheWorkflowsOwnLogic:
 
     @pytest.mark.parametrize('body,expected_id', [
         ({'id': 'dep-1', 'commit': {'id': SHA}}, 'dep-1'),
-        ({'id': 'dep-2'}, 'dep-2'),                      # no commit echoed back
+        # A response that names no commit is tolerated *here* only because the
+        # wait step refuses to call such a deploy a success — see
+        # TestTheDeployIsConfirmedNotJustRequested. Failing closed at this point
+        # instead would make every deploy fail against an API that simply does
+        # not echo the field.
+        ({'id': 'dep-2'}, 'dep-2'),
         ({'id': 'dep-3', 'commit': None}, 'dep-3'),
     ])
     def test_an_accepted_deploy_for_this_commit_is_used(self, body, expected_id):
-        program = _embedded_python('built')
+        program = _embedded_python('raw =')
         result = _run_embedded(program, json.dumps(body), SHA)
         assert result.returncode == 0, result.stderr
         assert result.stdout.strip() == expected_id
@@ -293,7 +302,7 @@ class TestTheWorkflowsOwnLogic:
     def test_an_accepted_deploy_for_another_commit_fails_the_run(self):
         """If Render ever ignored `commitId`, the build would be of the branch
         tip and the run would otherwise report success."""
-        program = _embedded_python('built')
+        program = _embedded_python('raw =')
         result = _run_embedded(
             program, json.dumps({'id': 'dep-x', 'commit': {'id': OTHER_SHA}}), SHA
         )
@@ -302,7 +311,7 @@ class TestTheWorkflowsOwnLogic:
 
     def test_an_empty_body_yields_no_deploy_id(self):
         """The 202 case, which hands over to the adopt path."""
-        program = _embedded_python('built')
+        program = _embedded_python('raw =')
         result = _run_embedded(program, '', SHA)
         assert result.returncode == 0, result.stderr
         assert result.stdout.strip() == ''
@@ -336,3 +345,73 @@ class TestTheWorkflowsOwnLogic:
         assert result.returncode != 0, \
             f'a deploy that is {reason} must not be adopted'
         assert not result.stdout.strip()
+
+
+class TestTheDeployIsConfirmedNotJustRequested:
+    """Pinning `commitId` on the request only states an intention.
+
+    The POST response is checked when it happens to echo a commit, so on its own
+    the pin fails open: an API that stopped echoing the field, or silently
+    dropped `commitId` from the request, would look identical to success. The
+    deploy detail endpoint reports the commit actually built, so the wait step
+    is where the pin is confirmed — and a deploy that reaches `live` without
+    ever naming a commit has to fail.
+    """
+
+    @pytest.fixture
+    def verdict(self):
+        program = _embedded_python('FAILED')
+
+        def check(deploy, commit_id=SHA):
+            body = '' if deploy is None else json.dumps(deploy)
+            result = _run_embedded(program, body, commit_id)
+            assert result.returncode == 0, result.stderr
+            return result.stdout.strip()
+
+        return check
+
+    def test_live_at_the_tested_commit_succeeds(self, verdict):
+        assert verdict({'status': 'live', 'commit': {'id': SHA}}) == 'live'
+
+    def test_live_without_a_commit_is_not_a_success(self, verdict):
+        """The fail-open case: nothing here confirms `commitId` was honoured."""
+        assert verdict({'status': 'live'}) == 'unverified'
+        assert verdict({'status': 'live', 'commit': None}) == 'unverified'
+
+    def test_a_different_commit_fails_even_while_still_building(self, verdict):
+        """Caught as early as the API admits it, not after 30 minutes."""
+        assert verdict(
+            {'status': 'build_in_progress', 'commit': {'id': OTHER_SHA}}
+        ) == f'mismatch {OTHER_SHA}'
+
+    def test_a_different_commit_outranks_a_live_status(self, verdict):
+        assert verdict({'status': 'live', 'commit': {'id': OTHER_SHA}}) \
+            == f'mismatch {OTHER_SHA}'
+
+    @pytest.mark.parametrize('status', [
+        'build_failed', 'update_failed', 'pre_deploy_failed',
+        'canceled', 'deactivated',
+    ])
+    def test_terminal_failures_are_reported(self, verdict, status):
+        assert verdict({'status': status, 'commit': {'id': SHA}}) == f'failed {status}'
+
+    @pytest.mark.parametrize('status', [
+        'created', 'queued', 'build_in_progress', 'update_in_progress',
+    ])
+    def test_in_flight_statuses_keep_polling(self, verdict, status):
+        assert verdict({'status': status, 'commit': {'id': SHA}}) == f'waiting {status}'
+
+    def test_an_unparseable_or_empty_answer_costs_one_poll(self, verdict):
+        """A transient API hiccup must not fail the deploy."""
+        assert verdict(None) == 'pending'
+        assert verdict({}) == 'pending'
+
+    def test_the_wait_step_receives_the_commit(self):
+        """It cannot confirm anything without COMMIT_ID in its own env block."""
+        scripts = _run_scripts()
+        name = next(n for n, s in scripts.items() if 'FAILED' in s)
+        source = DEPLOY_RENDER.read_text()
+        step = source.split(f'- name: {name}', 1)[1].split('run:', 1)[0]
+        assert re.search(
+            r"COMMIT_ID:\s*\$\{\{\s*github\.event\.workflow_run\.head_sha", step
+        ), f'the {name!r} step must receive COMMIT_ID via env:'

--- a/tests/test_deploy_render_workflow.py
+++ b/tests/test_deploy_render_workflow.py
@@ -13,6 +13,7 @@ regexes rather than PyYAML, which is not a dependency of this project.
 import json
 import os
 import re
+import shutil
 import subprocess
 import sys
 import textwrap
@@ -79,6 +80,14 @@ def _run_scripts():
             continue
         i += 1
     assert scripts, 'no run: scripts found in deploy-render.yml'
+    # Keyed on the step name, so a step added without one would map its script
+    # onto the previous step's key and silently drop that script from the map —
+    # quietly narrowing the `${{`-injection guard below.
+    declared = len(re.findall(r'^\s*run:', DEPLOY_RENDER.read_text(), re.MULTILINE))
+    assert len(scripts) == declared, (
+        f'found {declared} `run:` keys but only {len(scripts)} named steps — '
+        'every step needs a `name:` for these tests to cover it'
+    )
     return scripts
 
 
@@ -119,8 +128,12 @@ def _embedded_python(marker):
 
 
 def _run_embedded(program, stdin, commit_id):
+    # The deploy job runs no setup-python, so the workflow's `python3` is the
+    # system one. Prefer that over the interpreter running pytest, which may be
+    # newer and accept syntax the runner would reject.
+    interpreter = shutil.which('python3') or sys.executable
     return subprocess.run(
-        [sys.executable, '-c', program],
+        [interpreter, '-c', program],
         input=stdin,
         capture_output=True,
         text=True,
@@ -172,10 +185,20 @@ class TestWorkflowRunTrigger:
     @pytest.mark.parametrize('guard', [
         r"github\.event\.workflow_run\.conclusion\s*==\s*'success'",
         r"github\.event\.workflow_run\.head_branch\s*==\s*'main'",
+        r"github\.event\.workflow_run\.event\s*==\s*'push'",
     ])
-    def test_conclusion_and_branch_are_both_guarded(self, guard):
-        """workflow_run fires for every branch and every conclusion, including
-        failures — dropping either guard turns this into a deploy-on-red."""
+    def test_conclusion_branch_and_event_are_all_guarded(self, guard):
+        """workflow_run fires for every branch, every conclusion and every
+        upstream event — so dropping the conclusion check makes this a
+        deploy-on-red, and dropping the event check makes it deploy fork PRs.
+
+        The `event == 'push'` clause is the one that is easy to think redundant.
+        This repo is public and django.yml runs on bare `pull_request:`, so a
+        fork PR produces a `backend` run whose `head_branch` is the branch name
+        in the *fork* — `main`, for anyone who pushed to their fork's default
+        branch first. Branch and conclusion alone would let that deploy, in the
+        base-repo context, with the Render API key.
+        """
         assert re.search(guard, DEPLOY_RENDER.read_text()), \
             f'deploy-render.yml is missing the {guard!r} guard'
 
@@ -274,11 +297,14 @@ class TestTheWorkflowsOwnLogic:
 
     @pytest.mark.parametrize('commit_id', [
         SHA,
-        'sha-with-a-"quote"',   # json.dumps escapes; printf would not
+        'sha-with-a-"quote"',   # json.dumps escapes; a %-format would not
         'sha\\with\\backslash',
     ])
     def test_the_request_body_escapes_its_input(self, commit_id):
-        program = _embedded_python('json.dumps')
+        # Located by `commitId`, which is the field being built rather than the
+        # function building it — so this fails on unescaped output, not merely
+        # because someone stopped calling json.dumps.
+        program = _embedded_python('commitId')
         result = _run_embedded(program, '', commit_id)
         assert result.returncode == 0, result.stderr
         assert json.loads(result.stdout) == {'commitId': commit_id}

--- a/tests/test_deploy_render_workflow.py
+++ b/tests/test_deploy_render_workflow.py
@@ -1,0 +1,338 @@
+"""Guards the deploy-render `workflow_run` trigger against a silent no-op.
+
+`on.workflow_run.workflows` matches the triggering workflow's `name:`, not its
+filename. The test suite lives in django.yml but is *named* `backend`, so
+`workflows: [django]` matched nothing: the workflow never fired, every `if:`
+below it was unreachable, and neither GitHub nor CI reported anything. The only
+symptom was a deploy that quietly stopped happening.
+
+Source-level, in the spirit of tests/test_settings_security.py — the failure is
+a configuration mismatch, so reading the files is the check. Parsed with
+regexes rather than PyYAML, which is not a dependency of this project.
+"""
+import json
+import os
+import re
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+SHA = 'a' * 40
+OTHER_SHA = 'b' * 40
+
+WORKFLOWS_DIR = Path(__file__).resolve().parents[1] / '.github' / 'workflows'
+DEPLOY_RENDER = WORKFLOWS_DIR / 'deploy-render.yml'
+
+
+def _workflow_files():
+    """Both extensions: GitHub accepts .yaml, and missing one would make the
+    name lookup below report a false mismatch."""
+    return sorted(
+        p for ext in ('*.yml', '*.yaml') for p in WORKFLOWS_DIR.glob(ext)
+    )
+
+
+def _declared_workflow_names():
+    """Map every workflow file to its top-level `name:`."""
+    names = {}
+    for path in _workflow_files():
+        match = re.search(r'^name:\s*(.+?)\s*$', path.read_text(), re.MULTILINE)
+        if match:
+            names[path.name] = match.group(1).strip('\'"')
+    return names
+
+
+def _run_scripts():
+    """Map each step's `name:` to its shell script, for both `run:` forms.
+
+    Hand-rolled rather than PyYAML, which is not a dependency of this project.
+    A block scalar ends where indentation returns to the key's level — scanning
+    lines by indent, not a regex lookahead for the next `key:`, because shell
+    lines like `-H "Content-Type: application/json"` look exactly like one.
+    """
+    lines = DEPLOY_RENDER.read_text().split('\n')
+    scripts = {}
+    name = None
+    i = 0
+    while i < len(lines):
+        named = re.match(r'\s*- name:\s*(\S.*?)\s*$', lines[i])
+        if named:
+            name = named.group(1).strip('\'"')
+        run = re.match(r'(\s*)run:\s*(\|[-+]?|>[-+]?)?\s*(.*?)\s*$', lines[i])
+        if run and name:
+            indent, block, inline = run.group(1), run.group(2), run.group(3)
+            if not block:
+                scripts[name] = inline
+                i += 1
+                continue
+            body, i = [], i + 1
+            while i < len(lines) and (
+                not lines[i].strip()
+                or len(lines[i]) - len(lines[i].lstrip()) > len(indent)
+            ):
+                body.append(lines[i])
+                i += 1
+            scripts[name] = '\n'.join(body)
+            continue
+        i += 1
+    assert scripts, 'no run: scripts found in deploy-render.yml'
+    return scripts
+
+
+def _without_comments(script):
+    """Drop comment-only lines, so a check cannot be satisfied by prose."""
+    return '\n'.join(
+        line for line in script.split('\n') if not line.lstrip().startswith('#')
+    )
+
+
+def _deploy_post_request():
+    """The comment-free script of the step that POSTs the deploy."""
+    for name, script in _run_scripts().items():
+        stripped = _without_comments(script)
+        if '-X POST' in stripped and '/deploys' in stripped:
+            return stripped
+    raise AssertionError('no step POSTs to the Render deploys endpoint')
+
+
+def _embedded_python(marker):
+    """The inline `python3 -c` program in the deploy step containing *marker*.
+
+    Executable form: dedented, with the shell's `\\"` escapes resolved. Lets the
+    tests below run the workflow's own logic instead of grepping for it — a
+    source match proves a check is present, never that it is right.
+    """
+    scripts = _run_scripts()
+    step = next(s for s in scripts.values() if '-X POST' in s)
+    blocks = re.findall(r'python3 -c "\n(.*?)\n *"', step, re.DOTALL)
+    matching = [b for b in blocks if marker in b]
+    assert len(matching) == 1, \
+        f'expected exactly one embedded program containing {marker!r}, got {len(matching)}'
+    return textwrap.dedent(matching[0].replace('\\"', '"'))
+
+
+def _run_embedded(program, stdin, commit_id):
+    return subprocess.run(
+        [sys.executable, '-c', program],
+        input=stdin,
+        capture_output=True,
+        text=True,
+        env={**os.environ, 'COMMIT_ID': commit_id},
+    )
+
+
+def _triggering_workflows():
+    """The entries of `on.workflow_run.workflows` in deploy-render.yml.
+
+    Accepts both YAML list forms — flow (`workflows: [backend]`) and block
+    (`workflows:` then `  - backend`) — so reformatting the file does not turn
+    into a spurious failure here.
+    """
+    source = DEPLOY_RENDER.read_text()
+    flow = re.search(r'^\s*workflows:\s*\[([^\]]*)\]\s*$', source, re.MULTILINE)
+    if flow:
+        entries = flow.group(1).split(',')
+    else:
+        block = re.search(
+            r'^(\s*)workflows:\s*\n((?:\1\s+-\s*\S.*\n)+)', source, re.MULTILINE
+        )
+        assert block is not None, \
+            'no `workflows:` list (flow or block form) found in deploy-render.yml'
+        entries = re.findall(r'-\s*(\S.*?)\s*$', block.group(2), re.MULTILINE)
+    return [e.strip().strip('\'"') for e in entries if e.strip()]
+
+
+class TestWorkflowRunTrigger:
+    def test_every_triggering_workflow_name_exists(self):
+        declared = set(_declared_workflow_names().values())
+        for referenced in _triggering_workflows():
+            assert referenced in declared, (
+                f'deploy-render.yml triggers on workflow {referenced!r}, but no '
+                f'workflow declares that `name:`. Known names: {sorted(declared)}. '
+                'workflow_run matches `name:`, not the filename — a mismatch '
+                'means the deploy silently never runs.'
+            )
+
+    def test_it_triggers_on_the_test_suite(self):
+        """Specifically the backend suite, so the deploy stays gated on tests."""
+        backend_name = _declared_workflow_names().get('django.yml')
+        assert backend_name is not None, 'django.yml has no `name:`'
+        assert backend_name in _triggering_workflows(), (
+            f'deploy-render.yml must trigger on django.yml (named {backend_name!r}) '
+            'or the deploy is no longer gated on the test suite.'
+        )
+
+    @pytest.mark.parametrize('guard', [
+        r"github\.event\.workflow_run\.conclusion\s*==\s*'success'",
+        r"github\.event\.workflow_run\.head_branch\s*==\s*'main'",
+    ])
+    def test_conclusion_and_branch_are_both_guarded(self, guard):
+        """workflow_run fires for every branch and every conclusion, including
+        failures — dropping either guard turns this into a deploy-on-red."""
+        assert re.search(guard, DEPLOY_RENDER.read_text()), \
+            f'deploy-render.yml is missing the {guard!r} guard'
+
+
+class TestDeployIsPinnedToTheTestedCommit:
+    """Gating on a green suite is worthless if the deploy is not the revision
+    that turned it green. Render builds the tracked branch's current tip unless
+    the request names a commit, so a push landing while the suite ran would
+    ship untested — the exact race the `workflow_run` gate is meant to close.
+    """
+
+    def test_commit_id_comes_from_the_triggering_run(self):
+        source = DEPLOY_RENDER.read_text()
+        assert re.search(
+            r"COMMIT_ID:\s*\$\{\{\s*github\.event\.workflow_run\.head_sha",
+            source,
+        ), ('deploy-render.yml must resolve COMMIT_ID from '
+            'github.event.workflow_run.head_sha — the revision the suite ran.')
+
+    def test_the_deploy_request_pins_the_commit(self):
+        """Asserted on the request line, not on the file.
+
+        A bare `'commitId' in source` is satisfied by the comment that explains
+        the pinning, so dropping the `-d` argument entirely — which restores
+        "build the tracked branch's tip" — would leave this green.
+        """
+        post = _deploy_post_request()
+        assert re.search(r'-d\s+\S', post), (
+            'the deploy request carries no body; Render then builds the tracked '
+            "branch's tip rather than the tested commit."
+        )
+        assert 'COMMIT_ID' in post, \
+            'the deploy request body must pin the commit from COMMIT_ID'
+        assert not re.search(r"""-d\s*["']\{\}["']""", post), (
+            "posting an empty body deploys the tracked branch's tip, not the "
+            'tested commit.'
+        )
+
+    def test_the_commit_is_passed_through_the_environment(self):
+        """Not interpolated into the shell: `${{ }}` inside `run:` is textual
+        substitution, which is how workflow injections happen. Checked against
+        every `run:` form, block scalar or single line."""
+        for name, script in _run_scripts().items():
+            assert '${{' not in script, (
+                f'the {name!r} step interpolates a GitHub expression directly '
+                'into its run: script; pass it via env: instead.'
+            )
+
+    def test_manual_dispatch_is_branch_guarded(self):
+        """Unguarded dispatch used to be harmless — the request carried no
+        commit, so Render built the tracked branch regardless of the ref. With
+        the commit pinned it would ship the dispatched branch's untested tip."""
+        source = DEPLOY_RENDER.read_text()
+        assert re.search(
+            r"github\.event_name\s*==\s*'workflow_dispatch'\s*&&\s*\n?\s*"
+            r"github\.ref\s*==\s*'refs/heads/main'",
+            source,
+        ), 'the workflow_dispatch arm of the `if:` must also require main'
+
+    def test_the_accepted_deploy_is_checked_against_the_commit(self):
+        """Both response paths verify, not just the adopted one: an API that
+        silently ignored `commitId` would otherwise build the branch tip and
+        the run would call it a success."""
+        post = _deploy_post_request()
+        assert re.search(r"built\s*!=\s*os\.environ\['COMMIT_ID'\]", post), \
+            "the 201 response's commit must be checked against COMMIT_ID"
+
+    def test_an_adopted_deploy_is_checked_against_the_commit(self):
+        """The 202/empty-body path adopts "the most recent deploy". Unchecked,
+        that can be another revision, or a build already `live` — which the
+        wait step would pass on its first poll, reporting success for a deploy
+        this run never made."""
+        source = DEPLOY_RENDER.read_text()
+        assert re.search(r"queued\s*!=\s*os\.environ\['COMMIT_ID'\]", source), \
+            'the adopted deploy must be verified against COMMIT_ID'
+        assert re.search(r"deploy\.get\('status'\)\s*not in\s*IN_FLIGHT", source), (
+            'an adopted deploy must be required to be in flight — a finished '
+            'one (live, or failed) means nothing was queued for this run'
+        )
+
+
+class TestTheWorkflowsOwnLogic:
+    """Runs the workflow's embedded programs, rather than grepping for them.
+
+    The source-level tests above can only prove a check is present. They stay
+    green if its sense is inverted — `built is not None` to `built is None`, say
+    — so the behaviour is pinned here by feeding each program the API responses
+    it has to survive.
+    """
+
+    def test_the_request_body_is_well_formed_json_naming_the_commit(self):
+        program = _embedded_python('json.dumps')
+        result = _run_embedded(program, '', SHA)
+        assert result.returncode == 0, result.stderr
+        assert json.loads(result.stdout) == {'commitId': SHA}
+
+    @pytest.mark.parametrize('commit_id', [
+        SHA,
+        'sha-with-a-"quote"',   # json.dumps escapes; printf would not
+        'sha\\with\\backslash',
+    ])
+    def test_the_request_body_escapes_its_input(self, commit_id):
+        program = _embedded_python('json.dumps')
+        result = _run_embedded(program, '', commit_id)
+        assert result.returncode == 0, result.stderr
+        assert json.loads(result.stdout) == {'commitId': commit_id}
+
+    @pytest.mark.parametrize('body,expected_id', [
+        ({'id': 'dep-1', 'commit': {'id': SHA}}, 'dep-1'),
+        ({'id': 'dep-2'}, 'dep-2'),                      # no commit echoed back
+        ({'id': 'dep-3', 'commit': None}, 'dep-3'),
+    ])
+    def test_an_accepted_deploy_for_this_commit_is_used(self, body, expected_id):
+        program = _embedded_python('built')
+        result = _run_embedded(program, json.dumps(body), SHA)
+        assert result.returncode == 0, result.stderr
+        assert result.stdout.strip() == expected_id
+
+    def test_an_accepted_deploy_for_another_commit_fails_the_run(self):
+        """If Render ever ignored `commitId`, the build would be of the branch
+        tip and the run would otherwise report success."""
+        program = _embedded_python('built')
+        result = _run_embedded(
+            program, json.dumps({'id': 'dep-x', 'commit': {'id': OTHER_SHA}}), SHA
+        )
+        assert result.returncode != 0
+        assert OTHER_SHA in result.stderr
+
+    def test_an_empty_body_yields_no_deploy_id(self):
+        """The 202 case, which hands over to the adopt path."""
+        program = _embedded_python('built')
+        result = _run_embedded(program, '', SHA)
+        assert result.returncode == 0, result.stderr
+        assert result.stdout.strip() == ''
+
+    @pytest.mark.parametrize('status', [
+        'created', 'queued', 'build_in_progress',
+        'pre_deploy_in_progress', 'update_in_progress',
+    ])
+    def test_an_in_flight_deploy_for_this_commit_is_adopted(self, status):
+        program = _embedded_python('IN_FLIGHT')
+        body = [{'deploy': {'id': 'dep-9', 'status': status, 'commit': {'id': SHA}}}]
+        result = _run_embedded(program, json.dumps(body), SHA)
+        assert result.returncode == 0, result.stderr
+        assert result.stdout.strip() == 'dep-9'
+
+    @pytest.mark.parametrize('deploy,reason', [
+        ({'id': 'd', 'status': 'build_in_progress', 'commit': {'id': OTHER_SHA}},
+         'another commit'),
+        ({'id': 'd', 'status': 'build_in_progress'},
+         'no commit at all'),
+        ({'id': 'd', 'status': 'live', 'commit': {'id': SHA}},
+         'already finished — nothing was queued for this run'),
+        ({'id': 'd', 'status': 'build_failed', 'commit': {'id': SHA}},
+         'failed earlier — its failure is not this run\'s'),
+        ({'id': 'd', 'status': 'canceled', 'commit': {'id': SHA}},
+         'canceled'),
+    ])
+    def test_an_unsuitable_deploy_is_not_adopted(self, deploy, reason):
+        program = _embedded_python('IN_FLIGHT')
+        result = _run_embedded(program, json.dumps([{'deploy': deploy}]), SHA)
+        assert result.returncode != 0, \
+            f'a deploy that is {reason} must not be adopted'
+        assert not result.stdout.strip()

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -95,9 +95,16 @@ class TestHealthz:
         assert ('django.db', 'connection') in imported, \
             '/healthz must probe the default connection'
 
+        # `name.split('.')[0]` too, not just `module`: a plain `import
+        # trials.models` is recorded with an empty module, so filtering on the
+        # module alone can never match it — and that is one of the two natural
+        # ways to reach a trials model from here.
         model_imports = sorted(
-            f'{module}.{name}' for module, name in imported
-            if module.startswith('trials') or module == 'django.apps'
+            f'{module}.{name}' if module else name
+            for module, name in imported
+            if module.startswith('trials')
+            or module == 'django.apps'
+            or name.split('.')[0] in ('trials', 'django.apps')
         )
         assert not model_imports, (
             f'/healthz imports {model_imports} — an ORM read is routed to the '

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,0 +1,119 @@
+"""The /healthz contract the platform's load balancer depends on.
+
+The point of the endpoint is that it fails when the service cannot serve real
+traffic — a probe that only proves Django booted stays green through a deploy
+whose migrations never ran. So the 503 path is the test that matters.
+"""
+import ast
+import inspect
+from pathlib import Path
+
+import pytest
+from django.conf import settings as django_settings
+
+from exact import health
+
+
+class _BrokenConnection:
+    """Stands in for the default connection; every cursor raises.
+
+    Patched at `exact.health.connection` rather than on `django.db.connection`:
+    that is a proxy whose attribute writes land on the live DatabaseWrapper,
+    which then outlives the test.
+    """
+
+    def __init__(self, error):
+        self._error = error
+
+    def cursor(self):
+        raise self._error
+
+
+@pytest.mark.django_db
+class TestHealthz:
+    def test_reports_ok_when_the_database_answers(self, client):
+        response = client.get('/healthz')
+        assert response.status_code == 200
+        assert response.json() == {'status': 'ok', 'database': 'ok'}
+
+    def test_reports_503_when_the_database_is_unreachable(self, client, monkeypatch):
+        monkeypatch.setattr(
+            'exact.health.connection',
+            _BrokenConnection(RuntimeError('could not connect to server')),
+        )
+        response = client.get('/healthz')
+        assert response.status_code == 503
+        assert response.json()['status'] == 'error'
+
+    def test_does_not_leak_the_underlying_error(self, client, monkeypatch):
+        """The body reaches whatever can hit the probe, so it must not carry a
+        driver message — those name hosts, ports and database names."""
+        secret = 'host=10.0.0.7 dbname=exact_prod password=hunter2'
+        monkeypatch.setattr(
+            'exact.health.connection', _BrokenConnection(RuntimeError(secret))
+        )
+        assert secret not in client.get('/healthz').content.decode()
+
+    def test_is_reachable_where_the_rest_of_the_api_is_default_deny(self, client):
+        """A load-balancer probe cannot carry credentials, so this endpoint has
+        to be the explicit exception to IsAuthenticated — asserted against a
+        protected endpoint in the same breath, so the two cannot drift."""
+        assert client.get('/trials/').status_code == 401
+        assert client.get('/healthz').status_code == 200
+
+    def test_reaches_no_database_but_the_default(self):
+        """An outage on the externally-owned `trials` host must not pull this
+        service out of rotation; the trial endpoints degrade on their own.
+
+        Two ways to break that, so both are checked: naming the alias directly
+        via `connections['trials']`, and — the easier one to reach by accident —
+        an ORM read, since DATABASE_ROUTERS sends every trials-app model to that
+        alias with no `connections` literal anywhere.
+
+        Checked over the parsed module rather than its text: a substring search
+        matches the word in a comment, misses `from django.db import connection,
+        connections`, and cannot see an ORM query at all.
+        """
+        tree = ast.parse(Path(inspect.getsourcefile(health)).read_text())
+
+        imported = {
+            (node.module or '', alias.name)
+            for node in ast.walk(tree)
+            if isinstance(node, ast.ImportFrom)
+            for alias in node.names
+        } | {
+            ('', alias.name)
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Import)
+            for alias in node.names
+        }
+
+        assert ('django.db', 'connections') not in imported, (
+            "/healthz must not import `connections` — indexing it is how a "
+            'non-default alias gets reached.'
+        )
+        assert ('django.db', 'connection') in imported, \
+            '/healthz must probe the default connection'
+
+        model_imports = sorted(
+            f'{module}.{name}' for module, name in imported
+            if module.startswith('trials') or module == 'django.apps'
+        )
+        assert not model_imports, (
+            f'/healthz imports {model_imports} — an ORM read is routed to the '
+            '`trials` alias by DATABASE_ROUTERS, so it would probe the external '
+            'host. Use a cursor on the default connection.'
+        )
+
+    def test_does_not_probe_the_external_trials_database(self, client, monkeypatch):
+        """The behavioural counterpart, where an alias exists to be broken."""
+        if 'trials' not in django_settings.DATABASES:
+            pytest.skip('no separate trials database configured in this environment')
+
+        from django.db import connections
+
+        def forbidden(*args, **kwargs):
+            raise AssertionError('/healthz must not touch the trials connection')
+
+        monkeypatch.setattr(connections['trials'], 'cursor', forbidden)
+        assert client.get('/healthz').status_code == 200

--- a/tests/test_partner_auth_chain.py
+++ b/tests/test_partner_auth_chain.py
@@ -1,0 +1,215 @@
+"""Partner-auth chain: provider configuration and end-to-end provisioning.
+
+Complements tests/test_phr_auth.py, which unit-tests verification. What is
+locked here is the wiring: that PARTNER_AUTH_PROVIDERS being env-driven still
+resolves to the intended chain, and that a verified portal token provisions the
+Identity under the prefixed subject rather than a bare portal id.
+"""
+import json
+import time
+
+import jwt
+import pytest
+from cryptography.hazmat.primitives.asymmetric import rsa
+from django.core.cache import cache as django_cache
+from jwt.algorithms import RSAAlgorithm
+from rest_framework.test import APIClient
+
+from accounts.models import Identity
+from accounts.providers import phr, registry
+from accounts.providers.firebase import FirebaseTokenProvider
+from accounts.providers.phr import PhrTokenProvider
+from tests.factories import TrialFactory
+
+ISSUER = 'healthkey-phr'
+KID = 'portal-key-1'
+
+
+@pytest.fixture(autouse=True)
+def isolate_auth_state(monkeypatch):
+    """Clear the cross-test state PartnerAuthentication and phr keep globally.
+
+    The auth cache is a process-wide LocMemCache keyed on SHA256(token), and
+    `portal_token()` is deterministic given identical claims (`exp` has
+    one-second resolution), so two tests can mint byte-identical tokens and the
+    second would read an entry pointing at an Identity its transaction rolled
+    back. Also unplugs httpx — both verbs, so no test here can reach the network
+    whatever a fixture sets PHR_ALLOW_INTROSPECTION or PHR_BASE_URL to. Tests
+    needing a JWKS document install their own `get` on top of this.
+    """
+    def _forbidden(*args, **kwargs):
+        raise AssertionError('unexpected outbound HTTP call')
+
+    monkeypatch.setattr(phr.httpx, 'get', _forbidden)
+    monkeypatch.setattr(phr.httpx, 'post', _forbidden)
+    phr._introspect_budget.reset()
+    django_cache.clear()
+    yield
+    phr._introspect_budget.reset()
+    django_cache.clear()
+
+
+@pytest.fixture
+def trial(db):
+    return TrialFactory(disease='Multiple Myeloma')
+
+
+def _match(client):
+    return client.post(
+        '/trials/match/',
+        {'patient_info': {'disease': 'multiple myeloma'}},
+        format='json',
+    )
+
+
+# ── provider chain resolution ─────────────────────────────────────────
+
+@pytest.fixture
+def fresh_registry():
+    """get_providers() memoises in a module global — clear it around each test."""
+    registry._providers = None
+    yield registry
+    registry._providers = None
+
+
+class TestProviderChainConfiguration:
+    def test_default_chain_is_firebase_then_phr(self, settings, fresh_registry):
+        settings.PARTNER_AUTH_PROVIDERS = [
+            'accounts.providers.firebase.FirebaseTokenProvider',
+            'accounts.providers.phr.PhrTokenProvider',
+        ]
+        assert [type(p) for p in fresh_registry.get_providers()] == [
+            FirebaseTokenProvider,
+            PhrTokenProvider,
+        ]
+
+    def test_portal_only_chain_excludes_firebase(self, settings, fresh_registry):
+        """How a deployment without Firebase is expected to run (compose does)."""
+        settings.PARTNER_AUTH_PROVIDERS = ['accounts.providers.phr.PhrTokenProvider']
+        assert [type(p) for p in fresh_registry.get_providers()] == [PhrTokenProvider]
+
+    def test_empty_list_disables_partner_auth_entirely(self, settings, fresh_registry):
+        """`PARTNER_AUTH_PROVIDERS=` in a templated deploy config lands here.
+
+        Locks the semantics: no providers means uniform 401s, not a fallback to
+        the previous default chain.
+        """
+        settings.PARTNER_AUTH_PROVIDERS = []
+        assert fresh_registry.get_providers() == []
+
+    def test_non_provider_class_is_rejected(self, settings, fresh_registry):
+        settings.PARTNER_AUTH_PROVIDERS = ['accounts.models.Identity']
+        with pytest.raises(TypeError):
+            fresh_registry.get_providers()
+
+
+@pytest.mark.django_db
+class TestPartnerAuthDisabled:
+    def test_no_providers_rejects_every_bearer_token(
+        self, trial, settings, fresh_registry, monkeypatch
+    ):
+        settings.PARTNER_AUTH_PROVIDERS = []
+        monkeypatch.setattr(
+            'accounts.authentication.get_providers', fresh_registry.get_providers
+        )
+        client = APIClient()
+        client.credentials(HTTP_AUTHORIZATION='Bearer anything.at.all')
+        assert _match(client).status_code == 401
+
+
+# ── end-to-end through the portal provider ────────────────────────────
+
+@pytest.fixture(scope='module')
+def rsa_key():
+    return rsa.generate_private_key(public_exponent=65537, key_size=2048)
+
+
+@pytest.fixture
+def portal_token(rsa_key, monkeypatch, settings):
+    """A verifiable portal token, with the JWKS document served locally."""
+    settings.PHR_ISSUER = ISSUER
+    settings.PHR_JWKS_URL = 'https://portal.example/api/v1/auth/jwks/'
+    settings.PHR_JWKS_CACHE_TTL = 3600
+    settings.PHR_JWKS_MIN_REFRESH_INTERVAL = 60
+    settings.PHR_ALLOW_INTROSPECTION = False
+
+    jwk = json.loads(RSAAlgorithm.to_jwk(rsa_key.public_key()))
+    jwk['kid'] = KID
+
+    class _Resp:
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return {'keys': [jwk]}
+
+    phr._jwks_cache.reset()
+    monkeypatch.setattr(phr.httpx, 'get', lambda url, timeout=None: _Resp())
+    monkeypatch.setattr(
+        'accounts.authentication.get_providers', lambda: [PhrTokenProvider()]
+    )
+
+    def make(**overrides):
+        claims = {
+            'iss': ISSUER,
+            'token_type': 'access',
+            'user_id': 42,
+            'exp': int(time.time()) + 300,
+        }
+        claims.update(overrides)
+        return jwt.encode(claims, rsa_key, algorithm='RS256', headers={'kid': KID})
+
+    yield make
+    phr._jwks_cache.reset()
+
+
+@pytest.mark.django_db
+class TestPortalTokenProvisioning:
+    def test_valid_portal_token_authenticates(self, trial, portal_token):
+        client = APIClient()
+        client.credentials(HTTP_AUTHORIZATION=f'Bearer {portal_token()}')
+        assert _match(client).status_code == 200
+
+    def test_identity_is_provisioned_under_the_prefixed_subject(
+        self, trial, portal_token
+    ):
+        client = APIClient()
+        client.credentials(HTTP_AUTHORIZATION=f'Bearer {portal_token()}')
+        _match(client)
+        assert Identity.objects.filter(issuer=ISSUER, sub='phr:42').exists()
+        # A bare portal id would occupy the globally-unique `sub` namespace and
+        # could collide with another issuer's subject.
+        assert not Identity.objects.filter(sub='42').exists()
+
+    def test_returning_user_reuses_the_same_identity(self, trial, portal_token):
+        client = APIClient()
+        client.credentials(HTTP_AUTHORIZATION=f'Bearer {portal_token()}')
+        _match(client)
+        client.credentials(HTTP_AUTHORIZATION=f'Bearer {portal_token(jti="second")}')
+        _match(client)
+        assert Identity.objects.filter(issuer=ISSUER, sub='phr:42').count() == 1
+
+    def test_forged_unsigned_token_does_not_provision_an_identity(
+        self, trial, portal_token
+    ):
+        """The impersonation attempt must leave no trace, not just fail."""
+        import base64
+
+        def seg(obj):
+            return base64.urlsafe_b64encode(
+                json.dumps(obj).encode()
+            ).decode().rstrip('=')
+
+        forged = '{}.{}.'.format(
+            seg({'alg': 'none'}),
+            seg({
+                'iss': ISSUER,
+                'token_type': 'access',
+                'user_id': 1,
+                'exp': int(time.time()) + 300,
+            }),
+        )
+        client = APIClient()
+        client.credentials(HTTP_AUTHORIZATION=f'Bearer {forged}')
+        assert _match(client).status_code == 401
+        assert not Identity.objects.filter(sub='phr:1').exists()

--- a/tests/test_phr_auth.py
+++ b/tests/test_phr_auth.py
@@ -1,0 +1,618 @@
+"""Locks the PhrTokenProvider verification contract (#359 review).
+
+The provider is ~270 lines of original signature-verification, caching and
+rate-limiting logic, so the interesting cases are the ones an attacker picks,
+not the happy path: which verification path a token gets routed to, what a
+token has to carry to cost an outbound request, and what the JWKS cache does
+when the portal misbehaves.
+
+No network: `httpx.get`/`httpx.post` are replaced per test and the call lists
+are asserted on, because "returns 401" and "returns 401 without touching the
+network" are different guarantees and only one of them bounds the DoS.
+"""
+import base64
+import json
+import logging
+import time
+
+import jwt
+import pytest
+from cryptography.hazmat.primitives.asymmetric import rsa
+from jwt.algorithms import RSAAlgorithm
+from rest_framework.exceptions import AuthenticationFailed
+
+from accounts.providers import phr
+from accounts.providers.phr import PhrTokenProvider
+
+ISSUER = 'healthkey-phr'
+JWKS_URL = 'https://portal.example/api/v1/auth/jwks/'
+INTROSPECT_URL = 'https://portal.example/api/v1/auth/introspect/'
+KID = 'portal-key-1'
+# 32+ bytes: PyJWT warns below that for HS256, and a warning per minted token
+# buries anything the suite actually wants to say.
+HS_SECRET = 'dev-shared-secret-long-enough-for-hs256'
+
+
+@pytest.fixture(autouse=True)
+def phr_settings(settings):
+    """Fix the provider's config so tests don't inherit the ambient deployment.
+
+    A fixture rather than `@override_settings` on the class: that form only
+    works on SimpleTestCase subclasses, not plain pytest classes.
+    """
+    settings.PHR_ISSUER = ISSUER
+    settings.PHR_JWKS_URL = JWKS_URL
+    settings.PHR_INTROSPECT_URL = INTROSPECT_URL
+    settings.PHR_JWKS_CACHE_TTL = 3600
+    settings.PHR_JWKS_MIN_REFRESH_INTERVAL = 60
+    settings.PHR_ALLOW_INTROSPECTION = False
+    settings.PHR_INTROSPECT_MAX_CALLS = 30
+    settings.PHR_INTROSPECT_RATE_INTERVAL = 60
+    return settings
+
+
+# ── token construction ────────────────────────────────────────────────
+
+def _claims(**overrides):
+    base = {
+        'iss': ISSUER,
+        'token_type': 'access',
+        'user_id': 42,
+        'exp': int(time.time()) + 300,
+    }
+    base.update(overrides)
+    return base
+
+
+def _seg(obj):
+    return base64.urlsafe_b64encode(json.dumps(obj).encode()).decode().rstrip('=')
+
+
+def handcrafted_token(header, claims):
+    """A JWT with an arbitrary header and an empty signature.
+
+    Built by hand rather than via jwt.encode: several tests need a header PyJWT
+    would refuse to produce (`alg: "none"`) or a header/signature pairing it
+    would never emit (RS256 claims relabelled HS256).
+    """
+    return f'{_seg(header)}.{_seg(claims)}.'
+
+
+@pytest.fixture(scope='module')
+def rsa_key():
+    return rsa.generate_private_key(public_exponent=65537, key_size=2048)
+
+
+@pytest.fixture(scope='module')
+def other_rsa_key():
+    """A second keypair the portal never published — forgery source."""
+    return rsa.generate_private_key(public_exponent=65537, key_size=2048)
+
+
+@pytest.fixture(scope='module')
+def public_jwk(rsa_key):
+    jwk = json.loads(RSAAlgorithm.to_jwk(rsa_key.public_key()))
+    jwk['kid'] = KID
+    return jwk
+
+
+@pytest.fixture
+def rs256(rsa_key):
+    def make(kid=KID, key=None, **overrides):
+        return jwt.encode(
+            _claims(**overrides),
+            key or rsa_key,
+            algorithm='RS256',
+            headers={'kid': kid},
+        )
+    return make
+
+
+@pytest.fixture
+def rs256_without(rsa_key):
+    """An RS256 token with *claim* removed rather than overridden."""
+    def make(claim, **overrides):
+        payload = _claims(**overrides)
+        del payload[claim]
+        return jwt.encode(payload, rsa_key, algorithm='RS256', headers={'kid': KID})
+    return make
+
+
+@pytest.fixture
+def hs256():
+    def make(**overrides):
+        return jwt.encode(_claims(**overrides), HS_SECRET, algorithm='HS256')
+    return make
+
+
+@pytest.fixture
+def hs256_without():
+    def make(claim, **overrides):
+        payload = _claims(**overrides)
+        del payload[claim]
+        return jwt.encode(payload, HS_SECRET, algorithm='HS256')
+    return make
+
+
+# ── network doubles ───────────────────────────────────────────────────
+
+class _Resp:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def raise_for_status(self):
+        pass
+
+    def json(self):
+        return self._payload
+
+
+class _Double:
+    def __init__(self, body):
+        self.calls = []
+        self.body = body
+        self.error = None
+
+
+@pytest.fixture(autouse=True)
+def isolate_provider_state(monkeypatch):
+    """Reset the process-wide cache/budget and unplug httpx around each test.
+
+    Unplugging by default means a test that forgets to install a double fails
+    loudly instead of reaching the real network.
+    """
+    phr._jwks_cache.reset()
+    phr._introspect_budget.reset()
+
+    def _forbidden(*args, **kwargs):
+        raise AssertionError('unexpected outbound HTTP call')
+
+    monkeypatch.setattr(phr.httpx, 'get', _forbidden)
+    monkeypatch.setattr(phr.httpx, 'post', _forbidden)
+    yield
+    phr._jwks_cache.reset()
+    phr._introspect_budget.reset()
+
+
+@pytest.fixture
+def jwks(monkeypatch, public_jwk):
+    double = _Double({'keys': [public_jwk]})
+
+    def fake_get(url, timeout=None):
+        double.calls.append(url)
+        if double.error is not None:
+            raise double.error
+        return _Resp(double.body)
+
+    monkeypatch.setattr(phr.httpx, 'get', fake_get)
+    return double
+
+
+@pytest.fixture
+def introspect(monkeypatch):
+    double = _Double({'active': True, 'user_id': 7})
+
+    def fake_post(url, **kwargs):
+        double.calls.append(kwargs.get('json'))
+        if double.error is not None:
+            raise double.error
+        return _Resp(double.body)
+
+    monkeypatch.setattr(phr.httpx, 'post', fake_post)
+    return double
+
+
+@pytest.fixture
+def provider():
+    return PhrTokenProvider()
+
+
+def clock_ahead(offset):
+    """A `time` stand-in whose monotonic clock is *offset* seconds ahead.
+
+    The cache measures TTL and floor with monotonic(); wall-clock time() has to
+    stay real, or a token minted "now" would read as expired.
+    """
+    real_monotonic, real_time = time.monotonic, time.time
+
+    class _Clock:
+        @staticmethod
+        def monotonic():
+            return real_monotonic() + offset
+
+        @staticmethod
+        def time():
+            return real_time()
+
+    return _Clock
+
+
+# ── routing: which path does a token reach? ───────────────────────────
+
+# The last two are not strings: `get_unverified_header` guarantees only a JSON
+# object, so a set-membership test on the raw value raises TypeError — which
+# would reach the caller as one warning-level log line per anonymous request.
+NON_ALLOWLISTED_ALGS = [
+    'none', 'ES256', 'PS256', 'RS512', 'HS128', 'garbage', None, ['HS256'], {'a': 1},
+]
+
+
+class TestPathDispatch:
+    """The `alg` header is attacker-supplied, so it must not select the path.
+
+    Pre-review the dispatch was `RS256 → JWKS, everything else →
+    introspection`, which let any anonymous caller pick the network path — and
+    with it whatever laxness the portal's introspection endpoint has.
+
+    These run with introspection **enabled**, which is the only configuration
+    that can tell the allowlist apart from the PHR_ALLOW_INTROSPECTION gate:
+    with the gate closed, a token routed to introspection is rejected there
+    anyway, so every assertion below would hold even with the allowlist gone.
+    """
+
+    @pytest.fixture(autouse=True)
+    def introspection_enabled(self, phr_settings):
+        phr_settings.PHR_ALLOW_INTROSPECTION = True
+
+    @pytest.mark.parametrize('alg', NON_ALLOWLISTED_ALGS)
+    def test_unexpected_algs_are_rejected_without_an_outbound_call(
+        self, provider, introspect, jwks, alg
+    ):
+        """Rejected locally — not by the portal, and not by the JWKS document.
+
+        The call-list assertions are the point: `is None` alone would also hold
+        if the token were dispatched to introspection and declined there.
+        """
+        assert provider.verify(handcrafted_token({'alg': alg}, _claims())) is None
+        assert introspect.calls == []
+        assert jwks.calls == []
+
+    def test_unsigned_token_naming_a_victim_never_reaches_the_portal(
+        self, provider, introspect
+    ):
+        """The impersonation shape: no signature, a subject of the attacker's
+        choosing, and an `iss` that routes into this provider.
+
+        A portal whose introspection endpoint does not fully verify signatures
+        would answer `active` here, so this must not be asked at all.
+        """
+        introspect.body = {'active': True, 'user_id': 1}
+        assert provider.verify(handcrafted_token({'alg': 'none'}, _claims(user_id=1))) is None
+        assert introspect.calls == []
+
+    def test_rs256_relabelled_hs256_does_not_reach_the_jwks_path(
+        self, provider, rs256, jwks, introspect
+    ):
+        """A valid RS256 token with its header rewritten must not verify there.
+
+        HS256 *is* allowlisted, so this one legitimately routes to the portal —
+        what matters is that it is never checked against the JWKS document,
+        which is what an HS/RS key-confusion attack needs.
+        """
+        _, payload, signature = rs256().split('.')
+        forged = f"{_seg({'alg': 'HS256', 'kid': KID})}.{payload}.{signature}"
+        introspect.body = {'active': False}
+        assert provider.verify(forged) is None
+        assert jwks.calls == []
+
+    def test_rs256_still_routes_to_offline_verification(
+        self, provider, rs256, jwks, introspect
+    ):
+        """The allowlist must not have cost the primary path its offline check."""
+        assert provider.verify(rs256()) is not None
+        assert introspect.calls == []
+        assert jwks.calls != []
+
+    def test_wrong_issuer_is_declined_before_verification(self, provider, rs256):
+        token = rs256(iss='https://accounts.google.com')
+        payload = jwt.decode(token, options={'verify_signature': False})
+        assert provider.can_handle(token, payload) is False
+
+    def test_non_jwt_token_is_rejected(self, provider):
+        assert provider.verify('not-a-jwt') is None
+
+
+class TestPathDispatchWithIntrospectionDisabled:
+    """The gate is the second, independent line of defence on the same tokens."""
+
+    @pytest.mark.parametrize('alg', NON_ALLOWLISTED_ALGS + ['HS256'])
+    def test_nothing_verifies_and_nothing_leaves_the_process(self, provider, alg):
+        # The autouse isolate fixture makes any httpx call raise, so reaching
+        # the network here fails the test rather than passing quietly.
+        assert provider.verify(handcrafted_token({'alg': alg}, _claims())) is None
+
+
+# ── RS256 / JWKS path ─────────────────────────────────────────────────
+
+class TestJwksVerification:
+    def test_valid_access_token_verifies_to_prefixed_subject(
+        self, provider, rs256, jwks
+    ):
+        claims = provider.verify(rs256())
+        assert claims is not None
+        assert claims.issuer == ISSUER
+        # The "phr:" prefix is load-bearing: Identity.sub is unique globally,
+        # not per issuer, so a bare portal id could collide with another
+        # issuer's subject.
+        assert claims.sub == 'phr:42'
+
+    def test_email_claim_is_carried_through(self, provider, rs256, jwks):
+        assert provider.verify(rs256(email='patient@example.com')).email == 'patient@example.com'
+
+    def test_token_signed_by_an_unpublished_key_is_rejected(
+        self, provider, rs256, other_rsa_key, jwks
+    ):
+        """Same `kid`, different private key — the forgery a JWKS exists to stop."""
+        assert provider.verify(rs256(key=other_rsa_key)) is None
+
+    def test_expired_token_raises_authentication_failed(self, provider, rs256, jwks):
+        with pytest.raises(AuthenticationFailed):
+            provider.verify(rs256(exp=int(time.time()) - 1))
+
+    def test_token_without_exp_is_rejected(self, provider, rs256_without, jwks):
+        """PyJWT's expiry check is a no-op when the claim is absent, so `exp`
+        has to be *required* — otherwise such a token never expires."""
+        assert provider.verify(rs256_without('exp')) is None
+
+    def test_not_yet_valid_token_is_rejected(self, provider, rs256, jwks):
+        assert provider.verify(rs256(nbf=int(time.time()) + 300)) is None
+
+    def test_refresh_token_is_rejected(self, provider, rs256, jwks):
+        assert provider.verify(rs256(token_type='refresh')) is None
+
+    def test_token_without_token_type_is_rejected(self, provider, rs256_without, jwks):
+        assert provider.verify(rs256_without('token_type')) is None
+
+    def test_empty_subject_is_rejected(self, provider, rs256, jwks):
+        """Otherwise every such user collapses onto one shared "phr:" Identity."""
+        assert provider.verify(rs256(user_id='', sub='')) is None
+
+    def test_sub_is_used_when_user_id_is_absent(self, provider, rs256_without, jwks):
+        assert provider.verify(rs256_without('user_id', sub='99')).sub == 'phr:99'
+
+    def test_audience_is_not_validated(self, provider, rs256, jwks):
+        """Documents accepted risk, so adding a check stays a deliberate change.
+
+        A token the portal minted for a different relying party is currently
+        accepted here as full access; there is no PHR_AUDIENCE setting yet.
+        """
+        assert provider.verify(rs256(aud='some-other-service')) is not None
+
+    def test_unreachable_jwks_fails_closed(self, provider, rs256, jwks):
+        jwks.error = RuntimeError('portal unreachable')
+        assert provider.verify(rs256()) is None
+
+
+# ── JWKS cache: the refresh floor is the DoS bound ────────────────────
+
+class TestJwksCache:
+    def test_unknown_kid_burst_drives_one_fetch(self, provider, jwks):
+        """A `kid` miss triggers a refresh, and `kid` is attacker-controlled —
+        without the floor each bogus token would cost its own blocking fetch."""
+        for n in range(25):
+            provider.verify(handcrafted_token({'alg': 'RS256', 'kid': f'k{n}'}, _claims()))
+        assert len(jwks.calls) == 1
+
+    def test_unknown_kid_burst_does_not_grow_the_cache(self, provider, jwks):
+        for n in range(50):
+            provider.verify(handcrafted_token({'alg': 'RS256', 'kid': f'x{n}'}, _claims()))
+        # Keys come from the fetched document, never from the token, so the
+        # cache is bounded by what the portal publishes.
+        assert set(phr._jwks_cache._keys) == {KID}
+
+    def test_failed_refresh_keeps_the_previously_good_key(
+        self, provider, rs256, jwks, monkeypatch
+    ):
+        assert provider.verify(rs256()) is not None
+        fetches = len(jwks.calls)
+
+        # Expire the TTL and break the endpoint: a momentarily broken document
+        # must not evict a key that still verifies.
+        monkeypatch.setattr(phr, 'time', clock_ahead(7200))
+        jwks.error = RuntimeError('portal down')
+        assert provider.verify(rs256()) is not None
+        assert len(jwks.calls) > fetches
+
+    @pytest.mark.parametrize('doc', [
+        {'keys': None},
+        {'keys': {}},
+        {'keys': []},
+        {'keys': [{'kty': 'RSA'}]},          # no kid
+        {'keys': [{'kty': 'nonsense'}]},     # PyJWK cannot build it
+        {},
+    ])
+    def test_malformed_jwks_documents_do_not_raise(self, provider, rs256, jwks, doc):
+        jwks.body = doc
+        assert provider.verify(rs256()) is None
+
+    def test_one_unusable_key_does_not_discard_the_good_one(
+        self, provider, rs256, jwks, public_jwk
+    ):
+        jwks.body = {'keys': [{'kty': 'nonsense', 'kid': 'bad'}, public_jwk]}
+        assert provider.verify(rs256()) is not None
+
+    def test_rotation_is_picked_up_after_the_ttl(
+        self, provider, rs256, jwks, public_jwk, monkeypatch
+    ):
+        assert provider.verify(rs256()) is not None
+        jwks.body = {'keys': [{**public_jwk, 'kid': 'portal-key-2'}]}
+        monkeypatch.setattr(phr, 'time', clock_ahead(7200))
+        assert provider.verify(rs256(kid='portal-key-2')) is not None
+
+
+# ── introspection fallback ────────────────────────────────────────────
+
+class TestIntrospectionGate:
+    """Off by default: the path delegates the signature check to the portal.
+
+    Both PHR_*_URLs derive from one PHR_BASE_URL, so before the gate existed
+    every RS256 deployment silently enabled this too — and the caller chose it.
+    """
+
+    def test_disabled_rejects_without_calling_the_portal(
+        self, provider, hs256, introspect
+    ):
+        assert provider.verify(hs256()) is None
+        assert introspect.calls == []
+
+    def test_enabled_verifies_an_active_token(
+        self, provider, hs256, introspect, phr_settings
+    ):
+        phr_settings.PHR_ALLOW_INTROSPECTION = True
+        claims = provider.verify(hs256())
+        assert claims is not None
+        assert claims.sub == 'phr:7'
+        assert len(introspect.calls) == 1
+
+
+class TestIntrospectionVerification:
+    @pytest.fixture(autouse=True)
+    def enabled(self, phr_settings):
+        phr_settings.PHR_ALLOW_INTROSPECTION = True
+
+    def test_inactive_token_is_rejected(self, provider, hs256, introspect):
+        introspect.body = {'active': False}
+        assert provider.verify(hs256()) is None
+
+    def test_refresh_token_is_rejected_without_calling_the_portal(
+        self, provider, hs256, introspect
+    ):
+        """`token_type` is checkable locally, so it costs no outbound request —
+        RFC 7662's own `token_type` is the OAuth2 type and cannot carry this."""
+        assert provider.verify(hs256(token_type='refresh')) is None
+        assert introspect.calls == []
+
+    def test_expired_token_is_rejected_without_calling_the_portal(
+        self, provider, hs256, introspect
+    ):
+        assert provider.verify(hs256(exp=int(time.time()) - 1)) is None
+        assert introspect.calls == []
+
+    def test_token_without_exp_is_rejected_without_calling_the_portal(
+        self, provider, hs256_without, introspect
+    ):
+        assert provider.verify(hs256_without('exp')) is None
+        assert introspect.calls == []
+
+    def test_response_subject_outranks_the_payload(self, provider, hs256, introspect):
+        """A `user_id` that exists only in the unverified payload must not
+        outrank the portal's own answer."""
+        introspect.body = {'active': True, 'user_id': 7}
+        assert provider.verify(hs256(user_id=9)).sub == 'phr:7'
+
+    def test_payload_subject_is_the_fallback_when_the_response_is_silent(
+        self, provider, hs256, introspect
+    ):
+        """§2.2 makes every claim optional; some portals answer only `active`."""
+        introspect.body = {'active': True}
+        assert provider.verify(hs256(user_id=9)).sub == 'phr:9'
+
+    def test_no_subject_anywhere_is_rejected(
+        self, provider, hs256_without, introspect
+    ):
+        introspect.body = {'active': True}
+        assert provider.verify(hs256_without('user_id')) is None
+
+    @pytest.mark.parametrize('body', [[], 'ok', None, 42])
+    def test_non_object_response_is_rejected(self, provider, hs256, introspect, body):
+        introspect.body = body
+        assert provider.verify(hs256()) is None
+
+    @pytest.mark.parametrize('active', ['false', 'true', 1, 'yes', [], {}])
+    def test_non_boolean_active_is_rejected(
+        self, provider, hs256, introspect, active
+    ):
+        """§2.2 specifies a boolean. Falsiness would read `"false"` — a string —
+        as truthy and authenticate a token the portal had just declined."""
+        introspect.body = {'active': active, 'user_id': 7}
+        assert provider.verify(hs256()) is None
+
+    @pytest.mark.parametrize('active', ['true', 1, 'yes'])
+    def test_non_boolean_active_is_reported(
+        self, provider, hs256, introspect, caplog, active
+    ):
+        """A portal answering `1` would 401 every sign-in; without a log line
+        that is indistinguishable from the portal declining the token."""
+        introspect.body = {'active': active}
+        with caplog.at_level(logging.WARNING, logger='accounts.providers.phr'):
+            provider.verify(hs256())
+        assert any('non-boolean' in r.message for r in caplog.records), \
+            f'active={active!r} was rejected silently'
+
+    def test_a_plain_false_active_is_not_reported_as_a_misconfiguration(
+        self, provider, hs256, introspect, caplog
+    ):
+        """The normal decline stays at debug — it is not an operator problem."""
+        introspect.body = {'active': False}
+        with caplog.at_level(logging.WARNING, logger='accounts.providers.phr'):
+            assert provider.verify(hs256()) is None
+        assert caplog.records == []
+
+    def test_transport_failure_is_rejected(self, provider, hs256, introspect):
+        introspect.error = RuntimeError('timeout')
+        assert provider.verify(hs256()) is None
+
+    def test_outbound_calls_are_capped_per_interval(
+        self, provider, hs256, introspect, phr_settings
+    ):
+        """The DoS bound. DRF authenticates before it throttles, so
+        AnonRateThrottle cannot reach this path; without the budget an
+        anonymous caller could hold every sync worker in a 5s POST.
+        """
+        phr_settings.PHR_INTROSPECT_MAX_CALLS = 5
+        for _ in range(40):
+            provider.verify(hs256())
+        assert len(introspect.calls) == 5
+
+    def test_budget_refills_after_the_interval(
+        self, provider, hs256, introspect, phr_settings, monkeypatch
+    ):
+        phr_settings.PHR_INTROSPECT_MAX_CALLS = 2
+        for _ in range(5):
+            provider.verify(hs256())
+        assert len(introspect.calls) == 2
+
+        monkeypatch.setattr(phr, 'time', clock_ahead(120))
+        assert provider.verify(hs256()) is not None
+        assert len(introspect.calls) == 3
+
+    def test_a_zero_interval_still_caps_calls(
+        self, provider, hs256, introspect, phr_settings
+    ):
+        """At interval 0 the window would restart on every call, removing the
+        ceiling entirely — the one misconfiguration here that fails open."""
+        phr_settings.PHR_INTROSPECT_MAX_CALLS = 3
+        phr_settings.PHR_INTROSPECT_RATE_INTERVAL = 0
+        for _ in range(40):
+            provider.verify(hs256())
+        assert len(introspect.calls) == 3
+
+    @pytest.mark.parametrize('max_calls', [0, -1])
+    def test_a_non_positive_budget_admits_nothing(
+        self, provider, hs256, introspect, phr_settings, max_calls
+    ):
+        phr_settings.PHR_INTROSPECT_MAX_CALLS = max_calls
+        assert provider.verify(hs256()) is None
+        assert introspect.calls == []
+
+    def test_exhaustion_is_logged_once_per_window_not_per_request(
+        self, provider, hs256, introspect, phr_settings, caplog, monkeypatch
+    ):
+        """The rejected requests are attacker-drivable, so one line each would
+        let an anonymous caller flood the log — the same reasoning that keeps
+        the `kid` miss at debug."""
+        phr_settings.PHR_INTROSPECT_MAX_CALLS = 1
+        with caplog.at_level(logging.WARNING, logger='accounts.providers.phr'):
+            for _ in range(30):
+                provider.verify(hs256())
+            exhausted = [r for r in caplog.records if 'budget exhausted' in r.message]
+            assert len(exhausted) == 1, \
+                f'{len(exhausted)} warnings for 29 rejections'
+
+            # A new window re-arms the warning — silence forever would hide a
+            # deployment that is permanently over its cap.
+            monkeypatch.setattr(phr, 'time', clock_ahead(120))
+            for _ in range(5):
+                provider.verify(hs256())
+            exhausted = [r for r in caplog.records if 'budget exhausted' in r.message]
+            assert len(exhausted) == 2

--- a/tests/test_settings_security.py
+++ b/tests/test_settings_security.py
@@ -71,6 +71,80 @@ class TestCorsAllowAllDefault:
         ), 'CORS_ALLOWED_ORIGINS must resolve from the env var.'
 
 
+class TestPhrIntrospectionDefault:
+    """The portal introspection fallback must be opt-in outside local/DEBUG.
+
+    It delegates the signature check to another service — an `active` response
+    is taken as vouching for the token, and where the response is silent about
+    the subject the token's *unverified* payload supplies it. Both PHR_*_URLs
+    derive from one PHR_BASE_URL, so before the flag existed every deployment
+    that configured RS256 verification silently enabled this path too, and the
+    caller chose which one to use by writing the `alg` header."""
+
+    def test_introspection_defaults_off_outside_local_and_debug(self):
+        source = _settings_source()
+        # Matching the wiring too, not just the default expression: a default
+        # that is computed correctly but never passed to os.environ.get would
+        # pass a looser test while changing nothing.
+        match = re.search(
+            r"_phr_introspection_default\s*=\s*\(\s*(.*?)\s*\)\s*\n\s*"
+            r"PHR_ALLOW_INTROSPECTION\s*=\s*os\.environ\.get\(\s*"
+            r"['\"]PHR_ALLOW_INTROSPECTION['\"]\s*,\s*_phr_introspection_default\s*\)",
+            source,
+            re.DOTALL,
+        )
+        assert match is not None, \
+            'PHR_ALLOW_INTROSPECTION must resolve from the env var with ' \
+            '_phr_introspection_default as its default'
+        default = match.group(1)
+        assert re.search(r"else\s*['\"]false['\"]", default), \
+            f'PHR_ALLOW_INTROSPECTION must fall through to false when deployed; got {default!r}'
+        assert 'DEBUG' in default and 'local' in default, \
+            ('PHR_ALLOW_INTROSPECTION must be gated on DEBUG/ENVIRONMENT=local, '
+             f'not enabled unconditionally; got {default!r}')
+
+    def test_introspection_default_reads_environment_from_os_environ(self):
+        """The gate must fail closed when a deploy forgets ENVIRONMENT.
+
+        The module-level ENVIRONMENT defaults to 'local', so `ENVIRONMENT ==
+        'local'` reads as true in exactly the misconfigured deploy this gate
+        exists to protect. Same regex shape as ENABLE_DRF_TOKEN_AUTH's guard in
+        tests/test_security_hardening.py, which requires the closing paren
+        directly after the key — so `os.environ.get('ENVIRONMENT', 'local')`,
+        which would restore the fail-open behaviour, does not satisfy it.
+        """
+        source = _settings_source()
+        assert re.search(
+            r"_phr_introspection_default\s*=\s*\(?\s*\n?\s*'true'\s+if\s+\(?\s*DEBUG\s+or\s+"
+            r"os\.environ\.get\(\s*['\"]ENVIRONMENT['\"]\s*\)\s*==\s*['\"]local['\"]",
+            source,
+        ), 'PHR_ALLOW_INTROSPECTION default must fail closed on an unset ENVIRONMENT.'
+
+    def test_introspection_default_rule_fails_closed(self):
+        """Locks the truth table, so the rule survives a refactor the regex
+        above would reject. The security-critical row is the last one."""
+        def enabled(debug, environ):
+            return debug or environ.get('ENVIRONMENT') == 'local'
+
+        assert enabled(True, {}) is True                            # DEBUG
+        assert enabled(False, {'ENVIRONMENT': 'local'}) is True      # explicit local
+        assert enabled(False, {'ENVIRONMENT': 'prod'}) is False
+        assert enabled(False, {'ENVIRONMENT': 'staging'}) is False
+        assert enabled(False, {}) is False                          # unset -> closed
+
+    def test_outbound_introspection_calls_are_capped(self):
+        source = _settings_source()
+        # DRF authenticates before it throttles, so AnonRateThrottle cannot
+        # reach this path — the cap is the only bound on outbound calls an
+        # anonymous caller can drive.
+        assert re.search(
+            r"PHR_INTROSPECT_MAX_CALLS\s*=\s*int\(\s*os\.environ\.get\(", source
+        ), 'PHR_INTROSPECT_MAX_CALLS must be present and env-resolved.'
+        assert re.search(
+            r"PHR_INTROSPECT_RATE_INTERVAL\s*=\s*int\(\s*os\.environ\.get\(", source
+        ), 'PHR_INTROSPECT_RATE_INTERVAL must be present and env-resolved.'
+
+
 class TestRedisTlsCertVerification:
     """rediss:// Celery SSL must not disable cert verification unconditionally.
 


### PR DESCRIPTION
Targets `feat/phr-federation` (#359), not `main` — merge this first and #359 carries it.

A fresh-context review of #359 found three blockers in `accounts/providers/phr.py` and the Render deploy workflow. This closes them, and adds the tests that would have caught them.

## 1. The `alg` header chose the verification path

Dispatch was `RS256 → JWKS, everything else → introspection`. Routing into this provider takes only an **unverified** `iss`, so an anonymous caller picked the network path — and with it whatever laxness the portal's introspection endpoint has — by writing one header field.

Dispatch is now an allowlist: `RS256` offline, `HS256/384/512` to introspection, everything else (`none`, an unexpected asymmetric alg, junk) rejected locally. `isinstance(alg, str)` guards the membership test: the header is only guaranteed to be a JSON *object*, so `{"alg": ["HS256"]}` would raise `TypeError` out of dispatch, which the caller logs at warning level, once per request, for a caller who supplied the header.

## 2. Unbounded blocking outbound calls

That introspection path had no cache, no floor and no rate limit, and only *successful* verifications are cached upstream — so every failed attempt re-issued a blocking 5s POST. DRF authenticates before it throttles (`APIView.initial`), so `AnonRateThrottle` could not reach it: a handful of concurrent connections held every sync worker, and the service doubled as a request amplifier against the portal.

Every check that can be made without the network now happens first — `alg`, `token_type`, `exp`, all reject-only since the payload is unverified — and the remaining calls draw on a fixed-window budget (`PHR_INTROSPECT_MAX_CALLS`, `PHR_INTROSPECT_RATE_INTERVAL`), warning once per window rather than once per rejected request.

A budget rather than a one-call-per-interval floor: a floor would reject every legitimate concurrent sign-in for the rest of the window. What the budget does **not** do is documented on the class — it is not keyed by caller, it bounds rate rather than concurrency, and it is per process. Worker exhaustion is closed by §3, not by this.

## 3. The fallback was not gated to dev

Both `PHR_*_URL`s derive from one `PHR_BASE_URL`, so every deployment configuring RS256 silently enabled introspection too. That path delegates the signature check to another service: an `active` response is taken as vouching for the token, and where RFC 7662 §2.2 leaves the response silent about the subject, the token's *unverified* payload supplies it. A portal that introspects without fully verifying signatures would therefore let a forged token through.

Now behind `PHR_ALLOW_INTROSPECTION`, defaulting on only for `DEBUG`/local, reading `ENVIRONMENT` via `os.environ.get` so an **unset** value counts as deployed. The module-level `ENVIRONMENT` defaults to `'local'`, so the obvious form fails *open* in exactly the misconfigured deploy the gate exists for — this is the same shape `ENABLE_DRF_TOKEN_AUTH` already uses.

Compose sets that flag directly rather than `ENVIRONMENT=local`: its `.env` is optional, and `ENVIRONMENT=local` would also switch on `EXACT_ALLOW_PERSON_ID_LOOKUP`, a gate deliberately closed for #150/#108 since the `?person_id=` resolver reads from PROMOP under a static service token not bound to the caller.

## The deploy workflow: two problems, the first hiding the second

`on.workflow_run` named `workflows: [django]`. That key matches a workflow's **`name:`**, and `django.yml` is named `backend` — so the deploy never fired, every `if:` below it was unreachable, and nothing reported an error. The only symptom was a deploy that quietly never happened.

Fixing that makes the workflow live, which exposes the second problem: it posted `-d '{}'`, and Render then builds whatever the tracked branch points at on arrival — not the revision that passed the suite. A push landing while the suite ran would ship untested, which is the race the gate exists to close.

The request now pins `commitId` to the triggering run's `head_sha`, passed via `env:` and serialised with `json.dumps`. But pinning only states an intention, so the deploy is also **confirmed**: the wait step already polls the deploy detail endpoint, which reports the commit actually built, and a mismatch fails the run as soon as the API admits it rather than after the 30-minute ceiling. A deploy that reaches `live` having never named a commit is reported as unverified and fails — otherwise an API that stopped echoing the field, or silently dropped `commitId`, would be indistinguishable from success. The 202 path, which adopts "the most recent deploy", additionally requires that deploy to be in flight rather than merely not `live`.

`workflow_dispatch` is now branch-guarded too — unpinned it always built the tracked branch, but pinned it would ship the dispatched ref's untested tip.

And the `workflow_run` arm requires `event == 'push'`, because `head_branch == 'main'` reads like a branch gate and is not one. This repo is public and `django.yml` runs on bare `pull_request:`, so a fork PR produces a `backend` run whose `head_branch` is the branch name **in the fork** — `main`, for anyone who pushes to their fork's default branch before opening the PR. Success on that run satisfied both other clauses, and this job would then have executed in the base-repo context, holding `RENDER_API_KEY`, pinning `commitId` to an unreviewed fork commit. Latent in the base branch only because the trigger matched nothing; making it fire is what turns it into a live path.

## Smaller changes the tests forced

- `exp` is `require`d on the JWKS path. PyJWT's expiry check is a no-op when the claim is absent, so a token minted without one never expired — and a suite documenting that as intended would be worse than no suite.
- An introspection response is rejected unless it is an object whose `active` is literally `true`; the string `"false"` is truthy. A non-boolean is logged, since otherwise a portal answering `1` 401s every sign-in with nothing to say why.
- The class docstring claimed the `"phr:"` prefix was descriptive because `Identity` is keyed on `(issuer, sub)`. It is not — `Identity.sub` is `unique=True` **globally**, which makes the prefix the only thing keeping a portal id out of another issuer's subject namespace. Corrected, since the comment as written invited removing it.

## Tests

**+266, suite at 868 passed / 6 skipped.** Every fix was mutation-checked: reverted one at a time, each now fails.

Three review rounds were needed to get there, and each found a defect in the previous round's fix. The first two catches are worth recording because they are the same mistake in different clothes:

- The dispatch tests first passed with the allowlist **reverted** — the whole suite did. With the gate closed, a token routed to introspection is rejected there anyway, so `is None` held either way. They now enable introspection and assert on the outbound-call lists, which is the only assertion that distinguishes the allowlist from the gate.
- The workflow tests first passed with the `-d` argument **deleted**, because `'commitId' in source` was satisfied by the comment explaining it. They now parse the step's script — by YAML block indentation, since a lookahead for the next `key:` truncates at shell lines like `-H "Content-Type: application/json"` — and for the two embedded programs, **execute** them against synthetic Render responses. A source match proves a check is present, never that it is right.

- The third round caught the pinning being *requested* but never *confirmed*, and the fork-PR path above. All of the workflow's embedded programs are now executed against synthetic Render payloads, and the health probe's import guard — which was blind to the plain `import trials.models` form, and is the only one of the two that runs in CI — now catches both forms.

`httpx` is unplugged by default in both new test modules, so a test that forgets to install a double fails loudly rather than reaching the network.

## Docs

`docs/setup.md`'s env table gains all nine `PHR_*` settings plus `PARTNER_AUTH_PROVIDERS`; `.env.example` gains the four a human actually sets (`PARTNER_AUTH_PROVIDERS`, `PHR_BASE_URL`, `PHR_ISSUER`, `PHR_ALLOW_INTROSPECTION`), the tuning knobs being docs-only. That table already documents security-posture flags with their rationale, and the one flag whoever configures a deployment most needs to find was missing from it.

## Still open from the same review, deliberately not in scope

- `/healthz` inherits `AnonRateThrottle`, so it 500s when Redis is down and 429s under an anonymous burst — defeating the endpoint's purpose. One line (`@throttle_classes([])`).
- Audience is never validated: any token the portal minted for any relying party is accepted here as full access. Needs a `PHR_AUDIENCE` setting.
- `requirements.txt` uses version ranges against the repo's `==`-everywhere convention, and `cryptography>=42.0` is unbounded.

## Before merging

This makes `deploy-render.yml` fire for the first time — the trigger has never matched. The first merge to `main` will request a real Render deploy and block on it for up to 30 minutes, so confirm `secrets.RENDER_API_KEY` and `vars.RENDER_EXACT_SERVICE_ID` are populated first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
