### PR TITLE
ci: invalidate a poisoned pythonLocation cache

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -21,10 +21,20 @@ jobs:
         key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}-v1
         restore-keys: |
           ${{ runner.os }}-pip-
+    # -v2 invalidates a poisoned generation of this cache. It snapshots the whole
+    # Python installation, site-packages/pip included, and actions/cache unpacks
+    # it *over* the directory without removing what is already there. When the
+    # snapshot's pip differs from the runner's preinstalled one, files present in
+    # both are overwritten and files only in the newer survive, leaving a mixture
+    # of two pip versions — which fails as
+    #   ImportError: cannot import name 'get_runnable_pip'
+    #                from 'pip._internal.utils.misc'
+    # on the very first `pip install`. It depends on which runner you land on, so
+    # it flaps: the same commit failed twice and passed on the third attempt.
     - uses: actions/cache@v4
       with:
         path: ${{ env.pythonLocation }}
-        key: ${{ runner.os }}-${{ env.pythonLocation }}-${{ hashFiles('requirements.txt') }}-v1
+        key: ${{ runner.os }}-${{ env.pythonLocation }}-${{ hashFiles('requirements.txt') }}-v2
     - name: Install system dependencies
       run: |
         sudo apt-get -qq update && \
@@ -64,10 +74,11 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: '3.12'
+    # Same cache, same reason as in `build` above — keep the suffixes in step.
     - uses: actions/cache@v4
       with:
         path: ${{ env.pythonLocation }}
-        key: ${{ runner.os }}-${{ env.pythonLocation }}-${{ hashFiles('requirements.txt') }}-v1
+        key: ${{ runner.os }}-${{ env.pythonLocation }}-${{ hashFiles('requirements.txt') }}-v2
     - name: Install system dependencies
       run: |
         sudo apt-get -qq update && \


### PR DESCRIPTION
`build` has been failing intermittently on the very first `pip install`, before pip reads `requirements.txt` at all:

```
ImportError: cannot import name 'get_runnable_pip' from 'pip._internal.utils.misc'
```

Not a dependency problem. Both jobs cache `${{ env.pythonLocation }}` — the entire Python installation, `site-packages/pip` included — and `actions/cache` unpacks the snapshot **over** that directory without removing what is already there. When the snapshot's pip differs from the runner's preinstalled one, files present in both are overwritten by the snapshot's and files only in the newer survive: `pip/_internal/build_env/installer.py` from the newer version, which imports `get_runnable_pip`, sitting next to `utils/misc.py` from the older, which does not have it. pip then cannot start.

Whether it breaks depends on which runner the job lands on, so it flaps rather than failing outright — which is what makes it expensive: it reads as a broken branch.

## Evidence

On #365, same code, same Python 3.12.13, same cache keys, same restored archives:

| attempt | result |
|---|---|
| run on `5caf008` | **fail** — pip ImportError, 32s |
| rerun of `5caf008` | **fail** — same, 32s |
| rerun of `caa9308` (the commit before), 2 min later | pass |
| third rerun of `5caf008` | pass, and all three test groups green |

I checked the logs of the failing and passing runs side by side: identical `Cache restored from key: Linux-/opt/hostedtoolcache/Python/3.12.13/x64-718c018…-v1` in both, identical 92 MB pip archive, same interpreter version. The only variable left is the runner's own preinstalled pip.

## What this does

Bumps the suffix on the `pythonLocation` cache in both jobs, discarding that generation. The key already contains `hashFiles('requirements.txt')`, so it was last rebuilt when #359 added `httpx`, `PyJWT` and `cryptography`, and has been layering over a moving runner pool ever since.

The `~/.cache/pip` entry is deliberately left at `-v1`: it holds only downloaded wheels, cannot produce this failure, and is worth ~90 MB of warm cache.

## Not fixed here

Caching `pythonLocation` at all is the underlying fragility — it is what makes the runner's own Python mutable, and this will recur the next time `requirements.txt` changes and a fresh snapshot meets a heterogeneous pool. Dropping the step and keeping only the wheel cache would cost a little install time and remove the failure mode permanently. Left as a separate decision rather than folded into a one-line unblock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)