### PR TITLE
ci: gate the :latest image tag on pushes to main only

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -20,7 +20,13 @@ jobs:
           type=sha,format=long
           type=ref,event=branch
           type=ref,event=tag
-          type=raw,value=latest,enable={{is_default_branch}}
+          # NOT `{{is_default_branch}}`: metadata-action counts a tag push as
+          # coming from the default branch, so tagging any line other than main
+          # moves :latest onto it. This bit us with harvard-2026-08-14, a tag
+          # cut from a deployment branch that is never merged into main — the
+          # tag build republished :latest pointing at that build.
+          # :latest must mean "current main" and nothing else.
+          type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
 
     - name: Login to Docker Registry
       uses: docker/login-action@v3


### PR DESCRIPTION
One line plus a comment.

`docker.yml` tagged `:latest` with `enable={{is_default_branch}}`, which docker/metadata-action also evaluates as true for **tag pushes**. That was fine while every tag came off `main`. It stopped being fine when a tag was cut from a deployment line that is deliberately never merged into `main`.

Concretely, `harvard-2026-08-14` (cut from `harvard/catalog-schema-fix`) republished `:latest` onto the Harvard build — an image with `?therapy_id=` removed, CB's marker models in place of ours, and three unused models dropped. Anything pulling `:latest` from Docker Hub would have silently switched to it. `:latest` has since been restored by re-running main's docker build (`sha-7a367b3b1f0494ec0d22da7aef9d54b0a6da8434`).

After this, `:latest` moves only on a push to `main`. Tags still publish their own immutable tag and the long-sha tag, which is what deployments should pin.

Same fix already landed on `harvard/catalog-schema-fix` (87889bc); `dev` still carries the old condition, so a tag cut from `dev` can still move `:latest` — worth the same change there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)