### PR TITLE
fix(matcher): blank bool_restriction is potential, not a hard reject (#4832)

### DIFF
--- a/matcher_app/exact_matching/matcher.py
+++ b/matcher_app/exact_matching/matcher.py
@@ -1060,6 +1060,14 @@ class UserToTrialAttrMatcher:
             return 'matched'
         elif under_user_control:
             return 'unknown'
+        elif ctx.is_blank:
+            # Blank/unresolved (e.g. a computed bool like meets_crab whose inputs
+            # aren't in yet) vs a trial that requires it: unknown, not a hard fail.
+            # The SQL path already treats this as potential (filter_by_patient_info
+            # skips blank attrs; potential_attrs_to_check counts them), and a
+            # definite False (not blank) still falls through to not_matched.
+            # (#4832 reconcile.)
+            return 'unknown'
         else:
             return 'not_matched'
 

--- a/tests/matching/test_meets_crab_blank_divergence.py
+++ b/tests/matching/test_meets_crab_blank_divergence.py
@@ -1,0 +1,96 @@
+"""#4832 first reconcile: blank computed bool_restriction (meets_crab) must be
+`unknown`/potential, not a hard `not_matched`.
+
+A trial that requires meets_crab=True, matched against a patient whose CRAB
+status is unresolved (blank), diverges today: the matcher hard-fails it
+(`not_matched` -> not_eligible) while the SQL path keeps it as `potential`.
+The clinically-correct verdict is `potential` (fill in the CRAB data), so the
+matcher is the side to fix.
+"""
+import pytest
+
+from trials.models import Trial
+from trials.services.patient_info.patient_info import PatientInfo
+from trials.services.patient_info.patient_info_attributes import PatientInfoAttributes
+from trials.services.user_to_trial_attr_matcher import UserToTrialAttrMatcher
+from trials.services.matching import status_equivalence as se
+from tests.factories import TrialFactory
+
+
+@pytest.mark.django_db
+def test_blank_meets_crab_precondition():
+    """The fix's precondition: for a bare MM patient, meets_crab is unresolved
+    (blank / None), which is the input that used to be coerced to False."""
+    pi = PatientInfo(disease='multiple myeloma', patient_age=65)
+    attrs = PatientInfoAttributes(pi)
+    assert attrs.get_value('meets_crab') is None
+    assert attrs.is_attr_blank('meets_crab') is True
+
+
+@pytest.mark.django_db
+def test_blank_meets_crab_is_potential_not_rejected():
+    """The reconcile: blank meets_crab vs a trial requiring it -> potential."""
+    trial = TrialFactory(disease='multiple myeloma', meets_crab=True)
+    pi = PatientInfo(disease='multiple myeloma', patient_age=65)
+
+    verdict = UserToTrialAttrMatcher(trial, pi).trial_match_status()
+    assert verdict == 'potential', (
+        f"blank meets_crab against a meets_crab=True trial should be potential, "
+        f"got {verdict!r}"
+    )
+
+
+@pytest.mark.django_db
+def test_no_sql_matcher_divergence_on_blank_meets_crab():
+    """The comparator (the #4832 contract) must see no divergence for this case."""
+    trial = TrialFactory(disease='multiple myeloma', meets_crab=True)
+    pi = PatientInfo(disease='multiple myeloma', patient_age=65)
+    base = Trial.objects.filter(id=trial.id)
+
+    divs = se.compare(base, pi)
+    assert divs == [], (
+        f"blank meets_crab still diverges: "
+        f"{[(d.direction, d.matcher_not_matched_attrs) for d in divs]}"
+    )
+
+
+@pytest.mark.django_db
+def test_blank_meets_crab_matched_when_trial_does_not_require():
+    """Guard against over-firing: a blank bool against a trial that does NOT
+    require it stays eligible (the value == trial short-circuit runs first)."""
+    trial = TrialFactory(disease='multiple myeloma', meets_crab=False)
+    pi = PatientInfo(disease='multiple myeloma', patient_age=65)
+
+    verdict = UserToTrialAttrMatcher(trial, pi).trial_match_status()
+    assert verdict == 'eligible', (
+        f"blank meets_crab vs a non-requiring trial should be eligible, got {verdict!r}"
+    )
+
+
+@pytest.mark.django_db
+def test_peer_bool_no_hiv_blank_is_potential_isnull_branch():
+    """Peer coverage: the fix applies to every bool_restriction, not just the
+    IS-NOT-TRUE class. `no_hiv_status` routes through the SQL `IS NULL` branch;
+    a blank value against a trial that requires it must reconcile to potential
+    (matcher) with no divergence."""
+    trial = TrialFactory(disease='multiple myeloma', no_hiv_required=True)
+    pi = PatientInfo(disease='multiple myeloma', patient_age=65, no_hiv_status=None)
+    base = Trial.objects.filter(id=trial.id)
+
+    verdict = UserToTrialAttrMatcher(trial, pi).trial_match_status()
+    assert verdict == 'potential', f"blank no_hiv_status vs a requiring trial, got {verdict!r}"
+    assert se.compare(base, pi) == []
+
+
+@pytest.mark.django_db
+def test_definite_false_meets_crab_still_rejected():
+    """Guard: an established negative (meets_crab computed False, not blank) must
+    still be not_eligible against a meets_crab=True trial — the fix only rescues
+    the BLANK case, not a real negative."""
+    trial = TrialFactory(disease='multiple myeloma', meets_crab=True)
+    pi = PatientInfo(disease='multiple myeloma', patient_age=65, meets_crab=False)
+
+    verdict = UserToTrialAttrMatcher(trial, pi).trial_match_status()
+    assert verdict == 'not_eligible', (
+        f"a definite meets_crab=False should stay not_eligible, got {verdict!r}"
+    )


### PR DESCRIPTION
First #4832 reconcile, verified with the differential-equivalence comparator (#381).

## Bug
`_match_type_bool_restriction` coerced a blank patient value (`None`) to `False` and, against a trial requiring the bool, returned `not_matched` → the trial went **not_eligible**. The SQL path treats the same case as **potential** (`filter_by_patient_info` skips blank attrs; `potential_attrs_to_check` counts them). So the SQL classifier and the matcher disagreed — a trial the matcher would reject sat in the potential tab.

Dominant real case: **`meets_crab`** (computed CRAB status, unresolved for a sparse patient) — 100% of the `potential→not_eligible` divergences the comparator found.

## Fix (one branch)
When the patient value is blank (`ctx.is_blank`) and earlier branches haven't resolved it, return `unknown` (potential). A definite `False` (not blank) still falls through to `not_matched`, so an established negative stays `not_eligible`.

## Verified with the comparator (exact_mm, 3114 MM trials, sparse patient)
- Divergences: **224 → 111** (7.19% → 3.56%).
- The entire **113-trial `potential→not_eligible` / meets_crab** class is gone.
- **Zero new divergences.** The remaining 111 are a separate, pre-existing `potential→eligible` class (SQL count vs its own attribution), untouched.

## Blast radius
Applies to every `bool_restriction` (~36 attrs), not just `meets_crab`. Confirmed correct for both SQL branches — the `IS NOT TRUE` class (meets_crab, tnbc_status, …) and the `IS NULL` class (`no_*` safety exclusions). `filter_by_patient_info` skips blank attrs, so no bool ever hard-excludes on a blank value → `unknown` is the correct verdict for all of them.

## Tests
`tests/matching/test_meets_crab_blank_divergence.py` (6): precondition (meets_crab blank), blank→potential, no divergence via the comparator, definite-False still rejected, blank-vs-non-requiring stays eligible, and a peer `no_hiv_status` (exercises the `IS NULL` SQL branch). 38 matcher-suite tests pass, no regressions.

## Review
- Fresh-context subagent: no P1 — verified the None-vs-False distinction, the blast radius over all bool_restrictions, and no new SQL-vs-matcher divergence; P3 test-coverage gaps applied.
- codex review: clean.

Note: two pre-existing 2omop test failures (`test_filter_by_patient_info`, `test_blank_list_attrs_not_in_traces`, about therapy JSON-list traces) fail on the base branch too — not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)