### PR TITLE
fix(matching): sane_range guards for hemoglobin/calcium/creatinine/bilirubin (#4840)

### DIFF
--- a/matcher_app/exact_matching/matcher.py
+++ b/matcher_app/exact_matching/matcher.py
@@ -97,17 +97,35 @@ def min_max_match(
     max_val: Optional[Any],
     value: Any,
     value_is_blank: bool,
+    sane_range: Optional[tuple] = None,
 ) -> Optional[AttrMatchStatus]:
     """Return `None` when both bounds are absent (no constraint), otherwise
     the standard per-attr match outcome. `min_val`/`max_val`/`value` are
     annotated `Any` because callers pass mixed numeric types (ints, floats,
     Decimals) plus date/datetime objects depending on the attr — uniform
     comparison via `<` / `>` is the only contract.
+
+    `sane_range=(low, high)`: a stored threshold outside the attribute's canonical
+    band is treated as no constraint (mid-migration bi-scaled thresholds), so the
+    matcher agrees with the queryset's sane_range guard instead of labelling an
+    admitted trial not_matched. (#4840.)
     """
     if min_val is None and max_val is None:
         return None
-    elif value_is_blank:
+    # Blank must be handled BEFORE the sane_range nullification below: otherwise an
+    # out-of-band threshold collapses both bounds to None and wrongly reports
+    # matched/no-constraint, disagreeing with the SQL classification (a blank attr
+    # against a constraint is 'potential').
+    if value_is_blank:
         return 'unknown'
+    if sane_range is not None:
+        low, high = sane_range
+        if min_val is not None and not (low <= min_val <= high):
+            min_val = None
+        if max_val is not None and not (low <= max_val <= high):
+            max_val = None
+    if min_val is None and max_val is None:
+        return None
     elif min_val is not None and value < min_val:
         return 'not_matched'
     elif max_val is not None and value > max_val:
@@ -1138,7 +1156,7 @@ class UserToTrialAttrMatcher:
         trial_attr_value_min = getattr(self.trial, attr_min_name)
         trial_attr_value_max = getattr(self.trial, attr_max_name)
 
-        abs_vals_match_res = min_max_match(trial_attr_value_min, trial_attr_value_max, ctx.value, ctx.is_blank)
+        abs_vals_match_res = min_max_match(trial_attr_value_min, trial_attr_value_max, ctx.value, ctx.is_blank, sane_range=ctx.meta.get("sane_range"))
         if "uln_attr_min" in ctx.meta and "uln_attr_max" in ctx.meta:
             trial_attr_value_uln_min = getattr(self.trial, ctx.meta["uln_attr_min"])
             trial_attr_value_uln_max = getattr(self.trial, ctx.meta["uln_attr_max"])

--- a/matcher_app/exact_matching/patient_info/configs.py
+++ b/matcher_app/exact_matching/patient_info/configs.py
@@ -1,3 +1,5 @@
+from decimal import Decimal
+
 from exact_matching.patient_info.convertors.alp_uln_calculator import AlpUlnCalculator
 from exact_matching.patient_info.convertors.alt_uln_calculator import AltUlnCalculator
 from exact_matching.patient_info.convertors.ast_uln_calculator import AstUlnCalculator
@@ -977,6 +979,9 @@ USER_TO_TRIAL_ATTRS_MAPPING = {
         "units_convertor": SerumCalciumConvertor,
         "default_unit": "mg/dL",
         "user_input_units_attr": "serum_calcium_level_units",
+        # Canonical mg/dL; bi-scaled trial thresholds self-heal via sane_range
+        # (out-of-band threshold skips the filter). (cancerbot#4840/#4845.)
+        "sane_range": (6, 20),
     },
     "creatinine_clearance_rate": {
         "type": "min_max_value",
@@ -994,6 +999,9 @@ USER_TO_TRIAL_ATTRS_MAPPING = {
         "uln_calculator": ScrUlnCalculator,
         "uln_attr_min": "serum_creatinine_level_uln_min",
         "uln_attr_max": "serum_creatinine_level_uln_max",
+        # Canonical mg/dL; sane_range applies only to the abs min/max (the ULN
+        # path takes no sane_range, matching CB). (cancerbot#4840/#4845.)
+        "sane_range": (Decimal('0.1'), 25),
     },
     "hemoglobin_level": {
         "type": "min_max_value",
@@ -1002,6 +1010,11 @@ USER_TO_TRIAL_ATTRS_MAPPING = {
         "units_convertor": BaseConvertor,
         "default_unit": "g/dL",
         "user_input_units_attr": "hemoglobin_level_units",
+        # Canonical is g/dL. Some trial thresholds are bi-scaled (g/L magnitudes
+        # wearing the g/dL label); sane_range skips the min/max filter for any
+        # threshold outside the g/dL band so a mislabelled g/L threshold does not
+        # silently exclude a patient. (cancerbot#4840/#4843.)
+        "sane_range": (2, 25),
     },
     "meets_crab": {
         "type": "bool_restriction",
@@ -1059,6 +1072,9 @@ USER_TO_TRIAL_ATTRS_MAPPING = {
         "uln_calculator": BiliTUlnCalculator,
         "uln_attr_min": "serum_bilirubin_total_level_uln_min",
         "uln_attr_max": "serum_bilirubin_total_level_uln_max",
+        # Canonical mg/dL; sane_range applies to the abs min/max only.
+        # Direct bilirubin deliberately gets no guard. (cancerbot#4840/#4852.)
+        "sane_range": (Decimal('0.05'), 7.5),
     },
     "serum_bilirubin_level_direct": {
         "type": "min_max_value",

--- a/tests/matching/test_lab_sane_range_symmetry.py
+++ b/tests/matching/test_lab_sane_range_symmetry.py
@@ -1,0 +1,53 @@
+"""#4840 port: lab sane_range guards must keep the SQL filter and the matcher in
+agreement for a patient who actually carries a value against an out-of-band
+(bi-scaled) trial threshold. If sane_range only reaches one side, they diverge.
+"""
+import pytest
+
+from trials.models import Trial
+from trials.services.patient_info.patient_info import PatientInfo
+from trials.services.user_to_trial_attr_matcher import UserToTrialAttrMatcher
+from trials.services.matching import status_equivalence as se
+from tests.factories import TrialFactory
+
+
+@pytest.mark.django_db
+def test_hemoglobin_out_of_band_threshold_no_sql_matcher_divergence():
+    # Patient 9.0 g/dL; trial requires hemoglobin_min=95 (a g/L magnitude wearing
+    # the g/dL label — outside the (2,25) band). sane_range should make BOTH the
+    # SQL filter and the matcher ignore the threshold, so no divergence.
+    trial = TrialFactory(disease='multiple myeloma', hemoglobin_level_min=95)
+    pi = PatientInfo(disease='multiple myeloma', patient_age=65,
+                     hemoglobin_level=9.0, hemoglobin_level_units='g/dL')
+    base = Trial.objects.filter(id=trial.id)
+
+    verdict = UserToTrialAttrMatcher(trial, pi).trial_match_status()
+    sql = se.sql_status_map(base, pi)
+    print(f"\nmatcher={verdict} sql={sql[trial.id]}")
+    assert se.compare(base, pi) == [], (
+        f"out-of-band hemoglobin threshold diverges: matcher={verdict} sql={sql[trial.id]}"
+    )
+
+
+@pytest.mark.django_db
+def test_creatinine_decimal_band_out_of_band_no_divergence():
+    # Exercises the Decimal sane_range band (0.1, 25): patient 1.0 mg/dL vs an
+    # out-of-band creatinine_abs_min of 88 (a µmol/L magnitude on the mg/dL col).
+    trial = TrialFactory(disease='multiple myeloma', serum_creatinine_level_abs_min=88)
+    pi = PatientInfo(disease='multiple myeloma', patient_age=65,
+                     serum_creatinine_level=1.0, serum_creatinine_level_units='mg/dL')
+    base = Trial.objects.filter(id=trial.id)
+    divs = se.compare(base, pi)
+    assert divs == [], f"creatinine Decimal-band diverges: {[(d.direction, d.matcher_not_matched_attrs) for d in divs]}"
+
+
+@pytest.mark.django_db
+def test_in_band_hemoglobin_threshold_still_excludes():
+    # Guard: an IN-band threshold the patient genuinely fails must still exclude
+    # (sane_range only skips out-of-band thresholds, not real ones).
+    trial = TrialFactory(disease='multiple myeloma', hemoglobin_level_min=12)
+    pi = PatientInfo(disease='multiple myeloma', patient_age=65,
+                     hemoglobin_level=9.0, hemoglobin_level_units='g/dL')
+
+    verdict = UserToTrialAttrMatcher(trial, pi).trial_match_status()
+    assert verdict == 'not_eligible', f"9.0 g/dL vs a 12 g/dL min should be not_eligible, got {verdict}"


### PR DESCRIPTION
Ports CancerBot's **cancerbot#4840** lab-threshold guards into the `exact_matching` package (2omop-canonical), so the package matcher and CB stay in sync.

## Bug
Trial thresholds for these labs are **bi-scaled** — some rows carry a different unit magnitude (g/L on a g/dL column, µmol/L on a mg/dL column) wearing the canonical label. A mislabelled threshold silently excludes patients (e.g. a g/L hemoglobin minimum of 95 excludes a real 9.5 g/dL patient). `sane_range=(low,high)` treats a threshold outside the canonical band as no-constraint so it self-heals.

## The deeper find (why this isn't config-only)
The package's `min_max_match` did **not** honor `sane_range` — only the SQL filter (`eligible_for_min_max_value`) did. A config-only guard would make the filter skip an out-of-band threshold (→ eligible) while the matcher still applied it (→ not_eligible): a **new SQL-vs-matcher divergence**. So this ports CB's matcher-side `sane_range` into `min_max_match` (nullify out-of-band bounds, after the blank check, before the comparison), making both sides agree. abs path only; ULN unchanged (matches CB + the SQL side).

## Bands (verified against the MM corpus)
| field | band | canonical | out-of-band caught |
|---|---|---|---|
| hemoglobin_level | (2, 25) | g/dL | 37 g/L mislabels |
| serum_calcium_level | (6, 20) | mg/dL | 5 |
| serum_creatinine_level | (0.1, 25) | mg/dL | 2 (µmol/L) |
| serum_bilirubin_level_total | (0.05, 7.5) | mg/dL | 20 (µmol/L; real max ≤6, clean gap to 17) |

## Verification
- Differential-equivalence comparator (#381): **0 divergences** on exact_mm (both patient profiles) — this change does not introduce any.
- New `tests/matching/test_lab_sane_range_symmetry.py`: an out-of-band threshold reconciles (SQL == matcher), a Decimal-band (creatinine) case, and an in-band threshold still excludes. 191 matcher/mapper/queryset tests pass.

## Deferred
**albumin** — CB's #4855 fix adds `units_convertor` + `default_unit` + `user_input_units_attr` + `sane_range`, but the package `PatientInfo` has **no albumin field**, so `getattr(patient_info, 'albumin_level_units')` would crash. Needs PatientInfo field work first (separate).

## Review
- Fresh-context subagent: no P1 — verified bound-by-bound SQL/matcher symmetry (inclusive band both sides), blank-first ordering, ULN consistency, Decimal type-safety, and the band values.
- codex review: clean.

Refs: cancerbot#4840 (source cluster: #4843 hemoglobin, #4845 creatinine/calcium, #4852 bilirubin, #4855 albumin-deferred).

🤖 Generated with [Claude Code](https://claude.com/claude-code)