### PR TITLE
fix(matching): wire albumin unit conversion + sane_range guard (#4840/#4855)

### DIFF
--- a/matcher_app/exact_matching/patient_info/configs.py
+++ b/matcher_app/exact_matching/patient_info/configs.py
@@ -1061,6 +1061,14 @@ USER_TO_TRIAL_ATTRS_MAPPING = {
         "type": "min_max_value",
         "searchable": True,
         "attr": "albumin",
+        # Previously unconvertible: no units_convertor, so a patient who entered
+        # G/L was compared raw against g/dL thresholds. Wire the convertor + the
+        # canonical unit, and guard the bi-scaled thresholds (14 rows are g/L
+        # magnitudes on the g/dL column). (cancerbot#4840/#4847/#4855.)
+        "units_convertor": BaseConvertor,
+        "default_unit": "g/dL",
+        "user_input_units_attr": "albumin_level_units",
+        "sane_range": (1, 7),
     },
     "serum_bilirubin_level_total": {
         "type": "min_max_value",

--- a/tests/matching/test_lab_sane_range_symmetry.py
+++ b/tests/matching/test_lab_sane_range_symmetry.py
@@ -42,6 +42,35 @@ def test_creatinine_decimal_band_out_of_band_no_divergence():
 
 
 @pytest.mark.django_db
+def test_albumin_out_of_band_threshold_no_divergence():
+    # albumin gains a units_convertor + (1,7) g/dL guard. A g/L mislabel (25 on
+    # the g/dL column) is out-of-band -> ignored on both sides, no divergence.
+    trial = TrialFactory(disease='multiple myeloma', albumin_min=25)
+    pi = PatientInfo(disease='multiple myeloma', patient_age=65,
+                     albumin_level=4.0, albumin_level_units='G/DL')
+    base = Trial.objects.filter(id=trial.id)
+    divs = se.compare(base, pi)
+    assert divs == [], f"albumin out-of-band diverges: {[(d.direction, d.matcher_not_matched_attrs) for d in divs]}"
+
+
+@pytest.mark.django_db
+def test_albumin_g_per_l_input_is_converted():
+    # The new units_convertor: a patient who entered G/L must be converted to
+    # g/dL before comparison. Discriminating case — 45 G/L = 4.5 g/dL fails a
+    # 5 g/dL minimum (not_eligible), whereas the raw 45 would wrongly clear it.
+    # (5 is in-band, so sane_range keeps it a real constraint.)
+    trial = TrialFactory(disease='multiple myeloma', albumin_min=5)
+    pi = PatientInfo(disease='multiple myeloma', patient_age=65,
+                     albumin_level=45, albumin_level_units='G/L')
+
+    verdict = UserToTrialAttrMatcher(trial, pi).trial_match_status()
+    assert verdict == 'not_eligible', (
+        f"45 G/L (=4.5 g/dL) vs a 5 g/dL min should be not_eligible; "
+        f"got {verdict} (raw 45 would wrongly match — convertor not applied?)"
+    )
+
+
+@pytest.mark.django_db
 def test_in_band_hemoglobin_threshold_still_excludes():
     # Guard: an IN-band threshold the patient genuinely fails must still exclude
     # (sane_range only skips out-of-band thresholds, not real ones).


### PR DESCRIPTION
Completes the albumin field deferred from #385, mirroring **cancerbot#4855**.

## Bug
The package `albumin_level` config was bare (`{type, searchable, attr}`) — **no `units_convertor`** — so a patient who entered albumin in **G/L** was compared raw against g/dL trial thresholds (wrong scale, "right by accident"). Thresholds are also bi-scaled (g/L magnitudes on the g/dL column).

## Fix (config-only)
`albumin_level`: `units_convertor=BaseConvertor`, `default_unit="g/dL"`, `user_input_units_attr="albumin_level_units"`, `sane_range=(1,7)`.

**Not blocked after all:** the package is duck-typed (owns no PatientInfo — a deliberate design), and both real patient sources (the EXACT-app `_f()` PatientInfo and CB's) already define `albumin_level` + `albumin_level_units`, so `getattr` never raises. The earlier "defer" looked in the package for a PatientInfo that lives in the host.

## Safety
- `BaseConvertor` makes `G/DL → g/dL` an **exact identity** (from==to, no float cast) → the default path is byte-for-byte unchanged; `G/L → g/dL` is ÷10.
- `sane_range (1,7)` sits in the clean gap (real thresholds ~2.5-3.5, g/L mislabels ~25-50).
- Comparator (#381): **0 divergences** on exact_mm; the matcher already honors sane_range symmetrically with the SQL filter (#385).

## Tests
`tests/matching/test_lab_sane_range_symmetry.py`: albumin out-of-band reconciles (no SQL/matcher divergence), and a **discriminating** G/L conversion case — 45 G/L = 4.5 g/dL fails a 5 g/dL min, which the raw 45 would wrongly clear — so the test fails if the convertor is unwired. 58 matcher/mapper/queryset tests pass.

## Review
- Fresh-context subagent: no P1 — verified G/DL identity (no default-path change), G/L ÷10, the (1,7) band, and SQL/matcher symmetry; flagged an initially-vacuous G/L test, now discriminating.
- codex: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)