### PR TITLE
fix(promop): always call the v1 patient endpoint, whatever the credential (#387)

### DIFF
--- a/tests/services/patient_info/test_promop_client.py
+++ b/tests/services/patient_info/test_promop_client.py
@@ -39,7 +39,7 @@ class TestPromopClientFetch:
         assert result == {'person_id': 9001, 'disease': 'MM'}
         # Trailing slash on base_url should be stripped.
         call_args = mock_get.call_args
-        assert call_args.args[0] == 'https://promop.example.com/api/patient-info/9001/'
+        assert call_args.args[0] == 'https://promop.example.com/api/v1/patient-records/9001/'
         # Bearer auth attached.
         assert call_args.kwargs['headers']['Authorization'] == 'Bearer tk'
         assert call_args.kwargs['headers']['Accept'] == 'application/json'
@@ -125,7 +125,7 @@ class TestPromopClientFetch:
         ) as mock_get:
             assert client.fetch_patient('9001') == {'person_id': 9001}
         # URL has the validated integer, not the raw string.
-        assert mock_get.call_args.args[0] == 'https://promop.example.com/api/patient-info/9001/'
+        assert mock_get.call_args.args[0] == 'https://promop.example.com/api/v1/patient-records/9001/'
 
     def test_unwraps_patient_info_envelope(self):
         """The HTTP endpoint wraps the row in `{"patient_info": {...}}`; the
@@ -251,13 +251,16 @@ class TestOAuthV1:
         with patch(_POST, return_value=_token_response()), patch(_GET, return_value=_ok_response(body)):
             assert client.fetch_patient(9005) == {'person_id': 9005, 'disease': 'MM'}
 
-    def test_legacy_mode_uses_v0_url_and_static_token(self):
+    def test_static_token_mode_still_uses_the_v1_url(self):
+        """No OAuth config must not mean the legacy prefix (#387): promop routes
+        both prefixes to one viewset, so the static service token authenticates
+        against v1 too. Only the credential differs, never the URL."""
         client = PromopClient(base_url='https://promop.example.com', token='static')
         assert client.use_oauth is False
         with patch(_POST) as mpost, patch(_GET, return_value=_ok_response({'person_id': 1})) as mget:
             client.fetch_patient(9001)
         mpost.assert_not_called()
-        assert mget.call_args.args[0] == 'https://promop.example.com/api/patient-info/9001/'
+        assert mget.call_args.args[0] == 'https://promop.example.com/api/v1/patient-records/9001/'
         assert mget.call_args.kwargs['headers']['Authorization'] == 'Bearer static'
 
     def test_token_url_defaults_to_base_o_token(self):
@@ -307,16 +310,17 @@ class TestOAuthV1:
             client.fetch_patient(9001)
         assert mpost.call_args.kwargs['allow_redirects'] is False
 
-    def test_partial_oauth_config_is_legacy(self):
+    def test_partial_oauth_config_falls_back_to_the_static_token(self):
         """Only client_id (no secret) must not enable OAuth — it falls back to
-        the legacy static-token transport rather than half-authenticating."""
+        the static-token credential rather than half-authenticating. The URL
+        stays on v1 either way (#387)."""
         client = PromopClient(base_url='https://promop.example.com', token='static',
                               oauth_client_id='cid')  # secret missing
         assert client.use_oauth is False
         with patch(_POST) as mpost, patch(_GET, return_value=_ok_response({'person_id': 1})) as mget:
             client.fetch_patient(9001)
         mpost.assert_not_called()
-        assert mget.call_args.args[0] == 'https://promop.example.com/api/patient-info/9001/'
+        assert mget.call_args.args[0] == 'https://promop.example.com/api/v1/patient-records/9001/'
         assert mget.call_args.kwargs['headers']['Authorization'] == 'Bearer static'
 
     def test_settings_drive_oauth_config(self, settings):

--- a/trials/services/patient_info/promop_client.py
+++ b/trials/services/patient_info/promop_client.py
@@ -3,13 +3,14 @@
 Used by `resolve_patient_info` when a request carries `?person_id=` (or a body
 field `person_id`) instead of an inline `patient_info` payload.
 
-Two transport modes, chosen by configuration (#237):
-- **v1 + OAuth2** (preferred): when `PROMOP_OAUTH_CLIENT_ID` / `_SECRET` are set,
-  the client authenticates via OAuth2 `client_credentials` against promop
-  `/o/token/` (scope `patient/*.read`) and reads
-  `GET /api/v1/patient-records/{person_id}/`.
-- **legacy** (deprecated, sunsets 2026-09-01): otherwise it falls back to the
-  static `PROMOP_SERVICE_TOKEN` and `GET /api/patient-info/{person_id}/`.
+Always reads `GET /api/v1/patient-records/{person_id}/` (#387). Only the
+credential differs, chosen by configuration (#237):
+- **OAuth2** (preferred): when `PROMOP_OAUTH_CLIENT_ID` / `_SECRET` are set, the
+  client authenticates via OAuth2 `client_credentials` against promop `/o/token/`
+  (scope `patient/*.read`).
+- **static service token**: otherwise it sends `PROMOP_SERVICE_TOKEN` as a bearer.
+  promop accepts it on v1 as well, so this mode is no longer a reason to fall back
+  to the deprecated, sunsetting `/api/patient-info/` prefix.
 
 Either way `fetch_patient(person_id)` returns the flat row dict (the shape
 `normalize_promop_row` expects) or `None` on any error path (network failure,
@@ -138,9 +139,13 @@ class PromopClient:
         return bool(self.oauth_client_id and self.oauth_client_secret)
 
     def _patient_url(self, person_id_int: int) -> str:
-        if self.use_oauth:
-            return f'{self.base_url}/api/v1/patient-records/{person_id_int}/'
-        return f'{self.base_url}/api/patient-info/{person_id_int}/'
+        # Always v1. The URL is deliberately NOT tied to `use_oauth` (#387):
+        # promop routes both prefixes to the same DRF viewset, so
+        # `ScopedTokenPermission` short-circuits on the static service token and
+        # authenticates it against v1 exactly as against the legacy path. Picking
+        # the URL off the auth mode left every OAuth-less deployment talking to a
+        # sunsetting endpoint for no reason.
+        return f'{self.base_url}/api/v1/patient-records/{person_id_int}/'
 
     def _authorization(self) -> str | None:
         """Bearer header value, or None when it can't be built (caller fails closed)."""
@@ -155,9 +160,9 @@ class PromopClient:
     def fetch_patient(self, person_id) -> dict | None:
         """Fetch the patient row and return the flat JSON row (or None on any error).
 
-        v1 (`/api/v1/patient-records/{id}/`) and legacy (`/api/patient-info/{id}/`)
-        both wrap the row in a `{"patient_info": {...}}` envelope; v1 additionally
-        carries a sibling `user` block and drops `patient_info_id`. This method
+        The response wraps the row in a `{"patient_info": {...}}` envelope with a
+        sibling `user` block (identical on the legacy prefix this used to call —
+        the two share one viewset). This method
         unwraps the `patient_info` envelope (ignoring siblings), so callers always
         receive a flat row matching `normalize_promop_row` — without unwrapping,
         every real field would be nested one level too deep and silently dropped


### PR DESCRIPTION
Closes #387.

`_patient_url` chose the **URL** based on the **auth mode**:

```python
def _patient_url(self, person_id_int: int) -> str:
    if self.use_oauth:
        return f'{self.base_url}/api/v1/patient-records/{person_id_int}/'
    return f'{self.base_url}/api/patient-info/{person_id_int}/'
```

`use_oauth` is just "are `PROMOP_OAUTH_CLIENT_ID` and `_SECRET` both set", so every deployment without OAuth kept talking to promop's deprecated `/api/patient-info/` prefix — the one that returns `Deprecation: true` / `Sunset`.

## The coupling was never needed

Verified on the promop side:

- Both prefixes register **the same viewset**: `patient_portal/api/urls.py:35` and `patient_portal/api/v1_urls.py:44` → `PatientRecordViewSet`.
- `permission_classes = [ScopedTokenPermission, PatientSelfScopePermission]` therefore apply identically, and `ScopedTokenPermission.has_permission` short-circuits on `token == SERVICE_TOKEN` → full access before any scope check. The static `PROMOP_SERVICE_TOKEN` authenticates against v1 exactly as against legacy.
- `retrieve` builds one envelope for both (`views.py:462-464`), so `fetch_patient`'s unwrapping is unaffected.

The URL is now always v1; `use_oauth` decides only which bearer goes in the header. OAuth2 client_credentials remains worth doing, on its own schedule, for its own reasons.

## Tests

Four assertions pinned the legacy URL under a static token — they pin v1 now. Two test names encoded the old behaviour and would have become lies:

- `test_legacy_mode_uses_v0_url_and_static_token` → `test_static_token_mode_still_uses_the_v1_url`
- `test_partial_oauth_config_is_legacy` → `test_partial_oauth_config_falls_back_to_the_static_token`

Both now state what they actually pin: the credential varies, the URL does not.

`.venv/bin/python -m pytest tests/ -q` → **1279 passed, 5 skipped**.

## Why this targets `2omop` and not `dev`

`promop_client.py` only exists here. `dev` and `main` still carry `ctomop_client.py`, whose `:85` hardcodes the legacy URL with no v1 path at all — #237 landed on this branch, not on `dev`. So EXACT's real cutover off the deprecated prefix is gated on #223 / #226 (`2omop` → `dev`), and this PR makes sure that when #226 lands, the cutover is already complete rather than needing a follow-up. I corrected #387's body accordingly.

## Context

promop's sunset moved 2026-09-01 → 2026-12-01 (healthkey-ai/promop#667) because promop's own SPA is still on the legacy prefix (healthkey-ai/promop#666). Sibling consumer changes: healthkey-ai/soc#273 (merged), HealthTree/ht-phr#100 (open).

Self-review: fresh-context Claude review → no findings; `codex review --base origin/2omop` → no discrete regressions.
