### PR TITLE
fix(matching): read equal-bounds ULN pairs as a ceiling (cb#4863)

### DIFF
--- a/matcher_app/exact_matching/matcher.py
+++ b/matcher_app/exact_matching/matcher.py
@@ -98,6 +98,7 @@ def min_max_match(
     value: Any,
     value_is_blank: bool,
     sane_range: Optional[tuple] = None,
+    equal_bounds_are_ceiling: bool = False,
 ) -> Optional[AttrMatchStatus]:
     """Return `None` when both bounds are absent (no constraint), otherwise
     the standard per-attr match outcome. `min_val`/`max_val`/`value` are
@@ -109,7 +110,18 @@ def min_max_match(
     band is treated as no constraint (mid-migration bi-scaled thresholds), so the
     matcher agrees with the queryset's sane_range guard instead of labelling an
     admitted trial not_matched. (#4840.)
+
+    `equal_bounds_are_ceiling` (cb#4863): when a pair holds the SAME number in both
+    columns, extraction wrote a one-sided ceiling twice, so read it as a ceiling and
+    drop the vacuous floor rather than demanding an exact match. Must stay in step
+    with `eligible_for_min_max_value`'s flag on the search side, or search and trial
+    details disagree about the same trial. Passed for ULN pairs only; default False =
+    no-op. Ported from CB (the wider guarded/not_evaluated reporting there is a
+    separate divergence not carried here).
     """
+    if (equal_bounds_are_ceiling
+            and min_val is not None and max_val is not None and min_val == max_val):
+        min_val = None
     if min_val is None and max_val is None:
         return None
     # Blank must be handled BEFORE the sane_range nullification below: otherwise an
@@ -1162,7 +1174,9 @@ class UserToTrialAttrMatcher:
             trial_attr_value_uln_max = getattr(self.trial, ctx.meta["uln_attr_max"])
             user_attr_value_uln = self.patient_info_attr.get_uln_value(ctx.name)
             user_attr_value_uln_is_blank = ctx.is_blank or user_attr_value_uln is None
-            uln_vals_match_res = min_max_match(trial_attr_value_uln_min, trial_attr_value_uln_max, user_attr_value_uln, user_attr_value_uln_is_blank)
+            # ULN is the only pair read with equal-bounds as a ceiling (cb#4863) —
+            # keep in step with the search-side flag; the absolute pair above does not.
+            uln_vals_match_res = min_max_match(trial_attr_value_uln_min, trial_attr_value_uln_max, user_attr_value_uln, user_attr_value_uln_is_blank, equal_bounds_are_ceiling=True)
             if abs_vals_match_res is None and uln_vals_match_res is None:
                 return 'matched'
             elif abs_vals_match_res == 'not_matched' or uln_vals_match_res == 'not_matched':

--- a/matcher_app/exact_matching/querysets/trial.py
+++ b/matcher_app/exact_matching/querysets/trial.py
@@ -954,7 +954,8 @@ class TrialQuerySet(models.QuerySet):
             goodness_score=score_expr,
         )
 
-    def eligible_for_min_max_value(self, attr_min_name, attr_max_name, value, skip_blank=True, sane_range=None):
+    def eligible_for_min_max_value(self, attr_min_name, attr_max_name, value, skip_blank=True,
+                                   sane_range=None, equal_bounds_are_ceiling=False):
         if value is None:
             return self
         if skip_blank and value == 0:
@@ -972,11 +973,24 @@ class TrialQuerySet(models.QuerySet):
             low, high = sane_range
             return Q(**{f'{attr_name}__lt': low}) | Q(**{f'{attr_name}__gt': high})
 
+        # equal_bounds_are_ceiling=True (cb#4863): a pair holding the SAME number in
+        # both columns is a one-sided ceiling that extraction wrote twice, so the floor
+        # is vacuous rather than demanding an exact match. Structurally the same move as
+        # out_of_band above — one more way for the floor to not apply — and it must stay
+        # in step with min_max_match in the detailed matcher, or search and trial details
+        # disagree about the same trial. Passed for ULN pairs only; the absolute pairs
+        # split by analyte (a hemoglobin floor vs a bilirubin ceiling), so the rule
+        # cannot be applied to them wholesale. Ported from CB; default False = no-op.
+        def bounds_are_equal(min_name, max_name):
+            return Q(**{f'{min_name}__exact': F(max_name)})
+
         scope = self
         if attr_min_name is not None:
             cond = Q(**{f'{attr_min_name}__lte': value}) | Q(**{f'{attr_min_name}__isnull': True})
             if sane_range is not None:
                 cond |= out_of_band(attr_min_name)
+            if equal_bounds_are_ceiling and attr_max_name is not None:
+                cond |= bounds_are_equal(attr_min_name, attr_max_name)
             scope = scope.filter(cond)
         if attr_max_name is not None:
             cond = Q(**{f'{attr_max_name}__gte': value}) | Q(**{f'{attr_max_name}__isnull': True})
@@ -1750,7 +1764,11 @@ class TrialQuerySet(models.QuerySet):
                 if user_attr_value_uln:
                     uln_attr_min_name = trial_attr_meta["uln_attr_min"]
                     uln_attr_max_name = trial_attr_meta["uln_attr_max"]
-                    scope = scope.eligible_for_min_max_value(uln_attr_min_name, uln_attr_max_name, user_attr_value_uln)
+                    # The only call site that passes it (cb#4863) — see the note on
+                    # min_max_match. The absolute pair a few lines up deliberately does not.
+                    scope = scope.eligible_for_min_max_value(
+                        uln_attr_min_name, uln_attr_max_name, user_attr_value_uln,
+                        equal_bounds_are_ceiling=True)
 
             else:
                 raise Exception(f'type "{trial_attr_meta["type"]}" is not supported')


### PR DESCRIPTION
Ports **cb#4863** into the `exact_matching` package so 2omop's package-dispatch search path (`QUERYSET_USE_PACKAGE_DISPATCH=True`) matches CB/promop behaviour.

## Problem
Extraction writes a one-sided ULN ceiling into BOTH `*_uln_min` and `*_uln_max`, so `min == max` demanded an *exact* ratio match and filtered ~1,454 production trials out of search entirely (search says "no match" while the detail page could say matched).

## Fix (both sides, must agree)
- `eligible_for_min_max_value` (search): `equal_bounds_are_ceiling` flag → equal-bounds pair relaxes the vacuous floor (`bounds_are_equal`) instead of exact match. Passed for ULN pairs only from `filter_by_patient_info`.
- `min_max_match` (detail matcher): same equal-bounds nullification, passed `True` at the ULN call site.

Both default `False` = exact no-op for every other caller. The wider guarded/not_evaluated reporting CB carries on `min_max_match` is a separate divergence, deliberately **not** ported here.

## Validation (against CB `2omop` re-pinned to this SHA)
- 2 cb#4863 tests (direct helper + search-path wiring): green
- queryset + search-integration suites: 165 passed
- matcher / shadow-compare / seam suites: 188 passed

Two-part self-review (codex + Claude fresh-context): both clean, no findings.

Ported verbatim from CB/promop per `docs/porting-from-cancerbot.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)