### PR TITLE
fix(matching): an out-of-domain progression value is unanswered, not a rejection (cb#5026)

### DIFF
--- a/matcher_app/exact_matching/matcher.py
+++ b/matcher_app/exact_matching/matcher.py
@@ -695,8 +695,12 @@ class UserToTrialAttrMatcher:
         if trial_attr_active_required is not True and trial_attr_smoldering_required is not True:
             return 'matched'
 
-        # "Unknown" is sent from the UI as an empty string (see ValueOptions.progressions)
-        if ctx.value is None or ctx.value == '':
+        # "Unknown" is sent from the UI as an empty string (see
+        # ValueOptions.progressions). `is_blank` also covers a value outside the
+        # closed domain (#5026) — an unrecognised value is not an answer, and the
+        # SQL filter already treats it as one it cannot act on, so returning
+        # 'not_matched' for it manufactured false negatives.
+        if ctx.is_blank:
             return 'unknown'
 
         if ctx.value == 'active' and trial_attr_smoldering_required is not True:

--- a/matcher_app/exact_matching/patient_info/configs.py
+++ b/matcher_app/exact_matching/patient_info/configs.py
@@ -19,6 +19,31 @@ THERAPIES_ATTRS = ["therapiesRequired", "therapiesExcluded", "therapyTypesRequir
 THERAPIES_ATTRS_UNDERSCORED = ["therapies_required", "therapies_excluded", "therapy_types_required", "therapy_types_excluded", "therapy_components_required", "therapy_components_excluded"]
 TRIAL_GENETIC_MUTATIONS_ATTRS_UNDERSCORED = ["mutation_genes_required", "mutation_variants_required", "mutation_origins_required", "mutation_interpretations_required"]
 
+# Patient attrs whose value is a closed domain, and what that domain is.
+#
+# Nothing validates these fields on the way in (CB's `progression` is a bare
+# TextField behind a bare CharField serializer), so real records carry values
+# like '0' or 'Getting worse'. The two matching paths then read such a value
+# differently: `TrialQuerySet.eligible_for_progression` recognises only the
+# domain members and falls through to `return self`, so SQL keeps the trial and
+# — because the value is not empty — does not count the attr as still-to-fill-in
+# either; the matcher's `_match_progression` ends in `else: not_matched` and
+# hard-rejects every trial that requires the criterion. cancerbot#5026 measured
+# 2735 diverging (patient, trial) pairs from four patients, one of them losing
+# 43% of its corpus.
+#
+# An unrecognised value is not an answer, so `is_attr_blank` reads it as
+# unanswered — which both paths already agree means "unknown / potential".
+# Membership is exact (no case folding, no stripping): see is_attr_blank.
+#
+# Only `progression` is listed. `prior_therapy` is the same shape (the matcher
+# already blanks an unrecognised label in `_match_prior_therapy`), but its SQL
+# side runs a min/max branch rather than a no-op, so it needs its own analysis —
+# tracked separately, not folded in here.
+CLOSED_VALUE_DOMAINS = {
+    'progression': frozenset({'active', 'smoldering'}),
+}
+
 ATTR_MAPPING_TYPE_COMPUTED = "computed"
 
 # "priorSCT": "prior SCT",

--- a/matcher_app/exact_matching/patient_info/configs.py
+++ b/matcher_app/exact_matching/patient_info/configs.py
@@ -19,31 +19,6 @@ THERAPIES_ATTRS = ["therapiesRequired", "therapiesExcluded", "therapyTypesRequir
 THERAPIES_ATTRS_UNDERSCORED = ["therapies_required", "therapies_excluded", "therapy_types_required", "therapy_types_excluded", "therapy_components_required", "therapy_components_excluded"]
 TRIAL_GENETIC_MUTATIONS_ATTRS_UNDERSCORED = ["mutation_genes_required", "mutation_variants_required", "mutation_origins_required", "mutation_interpretations_required"]
 
-# Patient attrs whose value is a closed domain, and what that domain is.
-#
-# Nothing validates these fields on the way in (CB's `progression` is a bare
-# TextField behind a bare CharField serializer), so real records carry values
-# like '0' or 'Getting worse'. The two matching paths then read such a value
-# differently: `TrialQuerySet.eligible_for_progression` recognises only the
-# domain members and falls through to `return self`, so SQL keeps the trial and
-# — because the value is not empty — does not count the attr as still-to-fill-in
-# either; the matcher's `_match_progression` ends in `else: not_matched` and
-# hard-rejects every trial that requires the criterion. cancerbot#5026 measured
-# 2735 diverging (patient, trial) pairs from four patients, one of them losing
-# 43% of its corpus.
-#
-# An unrecognised value is not an answer, so `is_attr_blank` reads it as
-# unanswered — which both paths already agree means "unknown / potential".
-# Membership is exact (no case folding, no stripping): see is_attr_blank.
-#
-# Only `progression` is listed. `prior_therapy` is the same shape (the matcher
-# already blanks an unrecognised label in `_match_prior_therapy`), but its SQL
-# side runs a min/max branch rather than a no-op, so it needs its own analysis —
-# tracked separately, not folded in here.
-CLOSED_VALUE_DOMAINS = {
-    'progression': frozenset({'active', 'smoldering'}),
-}
-
 ATTR_MAPPING_TYPE_COMPUTED = "computed"
 
 # "priorSCT": "prior SCT",
@@ -304,6 +279,16 @@ USER_TO_TRIAL_ATTRS_MAPPING = {
         "disease": "MM",
         "custom_search": True,
         "searchable": True,
+        # Closed domain (mirrors ValueOptions.progressions minus the empty
+        # "Unknown"). Nothing validates writes — CB's field is a bare TextField
+        # behind a bare CharField serializer, filled by a free-text chatbot
+        # question — so records hold '0' or 'Getting worse'. Without this,
+        # `eligible_for_progression` no-ops on such a value (SQL: Eligible) while
+        # `_match_progression` falls into `else: not_matched` (matcher: Not
+        # Eligible): 2735 diverging (patient,trial) pairs from four patients,
+        # cancerbot#5026. `is_attr_blank` reads an unrecognised value as
+        # unanswered so both paths say potential.
+        "value_domain": frozenset({'active', 'smoldering'}),
         "attr": ["disease_progression_active_required", "disease_progression_smoldering_required"],
     },
     "measurable_disease_imwg": {

--- a/matcher_app/exact_matching/patient_info/patient_info_attributes.py
+++ b/matcher_app/exact_matching/patient_info/patient_info_attributes.py
@@ -5,7 +5,7 @@ from django.db import models
 from django.db.models import Q
 from django.utils.functional import cached_property
 
-from exact_matching.patient_info.configs import THERAPY_LINES_ATTRS_UNDERSCORED
+from exact_matching.patient_info.configs import CLOSED_VALUE_DOMAINS, THERAPY_LINES_ATTRS_UNDERSCORED
 from exact_matching.patient_info.convertors.base_convertor import BaseConvertor
 from exact_matching.patient_info.convertors.serum_calcium_convertor import SerumCalciumConvertor
 from exact_matching.patient_info.convertors.serum_creatinine_convertor import SerumCreatinineConvertor
@@ -141,6 +141,20 @@ class PatientInfoAttributes:
             if user_attr_type in ['float', models.fields.FloatField] and user_attr_value == 0:
                 is_blank = True
             if is_under_user_control and user_attr_value is not True:
+                is_blank = True
+
+        # A value outside a closed domain is not an answer (#5026). Reading it
+        # as unanswered here — the primitive BOTH matching paths share — is what
+        # keeps them from disagreeing about it: the SQL filter already no-ops on
+        # an unrecognised value, the potential count now stops treating it as
+        # filled, and the matcher returns 'unknown' instead of 'not_matched'.
+        # Membership is exact on purpose: the downstream handlers compare the raw
+        # value (`ctx.value == 'active'`), so accepting 'Active' or ' active' here
+        # as an answer would just move the disagreement one step along — blank on
+        # this side, `not_matched` on the matcher's. Anything that is not the
+        # stored code is unanswered.
+        if not is_blank and attr_name in CLOSED_VALUE_DOMAINS:
+            if user_attr_value not in CLOSED_VALUE_DOMAINS[attr_name]:
                 is_blank = True
 
         return is_blank

--- a/matcher_app/exact_matching/patient_info/patient_info_attributes.py
+++ b/matcher_app/exact_matching/patient_info/patient_info_attributes.py
@@ -5,7 +5,7 @@ from django.db import models
 from django.db.models import Q
 from django.utils.functional import cached_property
 
-from exact_matching.patient_info.configs import CLOSED_VALUE_DOMAINS, THERAPY_LINES_ATTRS_UNDERSCORED
+from exact_matching.patient_info.configs import THERAPY_LINES_ATTRS_UNDERSCORED
 from exact_matching.patient_info.convertors.base_convertor import BaseConvertor
 from exact_matching.patient_info.convertors.serum_calcium_convertor import SerumCalciumConvertor
 from exact_matching.patient_info.convertors.serum_creatinine_convertor import SerumCreatinineConvertor
@@ -143,18 +143,23 @@ class PatientInfoAttributes:
             if is_under_user_control and user_attr_value is not True:
                 is_blank = True
 
-        # A value outside a closed domain is not an answer (#5026). Reading it
-        # as unanswered here — the primitive BOTH matching paths share — is what
-        # keeps them from disagreeing about it: the SQL filter already no-ops on
-        # an unrecognised value, the potential count now stops treating it as
-        # filled, and the matcher returns 'unknown' instead of 'not_matched'.
-        # Membership is exact on purpose: the downstream handlers compare the raw
-        # value (`ctx.value == 'active'`), so accepting 'Active' or ' active' here
-        # as an answer would just move the disagreement one step along — blank on
-        # this side, `not_matched` on the matcher's. Anything that is not the
-        # stored code is unanswered.
-        if not is_blank and attr_name in CLOSED_VALUE_DOMAINS:
-            if user_attr_value not in CLOSED_VALUE_DOMAINS[attr_name]:
+        # A value outside the attr's closed domain is not an answer (#5026), and
+        # reading it as unanswered here — in the primitive BOTH matching paths
+        # share — is what stops them disagreeing about it. Membership is exact on
+        # purpose: the handlers compare the raw value (`ctx.value == 'active'`),
+        # so accepting 'Active' or ' active' as an answer would only move the
+        # disagreement one step along. A non-string (inline JSON reaches this
+        # untyped) is likewise not an answer, and is tested before the set
+        # lookup so an unhashable value cannot raise.
+        #
+        # This says nothing about what the SQL FILTER does with the value —
+        # `eligible_for_progression` happens to no-op on one it does not
+        # recognise, while e.g. `eligible_for_prior_therapy` runs a min/max
+        # branch. An attr whose filter is not a no-op needs that checked before
+        # a domain is declared for it.
+        value_domain = trial_attr_meta.get("value_domain")
+        if not is_blank and value_domain is not None:
+            if not isinstance(user_attr_value, str) or user_attr_value not in value_domain:
                 is_blank = True
 
         return is_blank

--- a/tests/matching/test_progression_domain_divergence.py
+++ b/tests/matching/test_progression_domain_divergence.py
@@ -1,0 +1,103 @@
+"""#5026: an out-of-domain `progression` value must read as unanswered, not as a
+hard rejection.
+
+`PatientInfo.progression` has a closed domain (`''` / `'active'` / `'smoldering'`)
+that nothing validates on the way in, so real records carry values like `'0'` or
+`'Getting worse'`. The SQL filter recognises only the domain members and no-ops on
+anything else (trial kept, and a non-empty value was counted as answered ->
+Eligible), while the matcher's final `else` branch returned `not_matched` ->
+Not Eligible. The census in cancerbot#4841 measured 2735 diverging (patient,
+trial) pairs from four patients, one losing 43% of its corpus.
+
+Contract: an unrecognised value is not an answer -> `unknown` / potential on both
+paths, exactly like a blank.
+"""
+import pytest
+
+from trials.models import Trial
+from trials.services.matching import status_equivalence as se
+from trials.services.patient_info.patient_info import PatientInfo
+from trials.services.patient_info.patient_info_attributes import PatientInfoAttributes
+from trials.services.user_to_trial_attr_matcher import UserToTrialAttrMatcher
+from tests.factories import TrialFactory
+
+OUT_OF_DOMAIN = ['0', 'Getting worse', 'slow', 'high risk', 'Active', ' active']
+
+
+def _mm_patient(progression):
+    return PatientInfo(disease='multiple myeloma', patient_age=65, progression=progression)
+
+
+@pytest.mark.parametrize('value', OUT_OF_DOMAIN)
+def test_out_of_domain_progression_reads_as_unanswered(value):
+    """The precondition: the shared `is_attr_blank` primitive treats it as blank.
+
+    Membership is exact — 'Active' and ' active' are not the stored code, and
+    accepting them here would only move the disagreement to the handler, which
+    compares the raw value.
+    """
+    assert PatientInfoAttributes(_mm_patient(value)).is_attr_blank('progression') is True
+
+
+@pytest.mark.parametrize('value', ['active', 'smoldering'])
+def test_domain_values_still_count_as_answered(value):
+    assert PatientInfoAttributes(_mm_patient(value)).is_attr_blank('progression') is False
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize('value', OUT_OF_DOMAIN)
+def test_out_of_domain_progression_is_potential_not_rejected(value):
+    trial = TrialFactory(disease='multiple myeloma', disease_progression_active_required=True)
+
+    verdict = UserToTrialAttrMatcher(trial, _mm_patient(value)).trial_match_status()
+
+    assert verdict == 'potential', (
+        f"progression={value!r} against an active-required trial should be potential, "
+        f"got {verdict!r}"
+    )
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize('value', OUT_OF_DOMAIN + ['', None])
+def test_no_sql_matcher_divergence_on_out_of_domain_progression(value):
+    """The #4832 contract: the two paths must agree, whatever the value."""
+    trial = TrialFactory(disease='multiple myeloma', disease_progression_active_required=True)
+    base = Trial.objects.filter(id=trial.id)
+
+    divs = se.compare(base, _mm_patient(value))
+
+    assert divs == [], (
+        f"progression={value!r} still diverges: "
+        f"{[(d.direction, d.matcher_unknown_attrs, d.matcher_not_matched_attrs) for d in divs]}"
+    )
+
+
+@pytest.mark.django_db
+def test_conflicting_domain_value_still_rejects():
+    """Guard against over-firing: a VALID value that contradicts the trial is
+    still a definite no. Only unrecognised values became unknown."""
+    trial = TrialFactory(disease='multiple myeloma', disease_progression_active_required=True)
+
+    verdict = UserToTrialAttrMatcher(trial, _mm_patient('smoldering')).trial_match_status()
+
+    assert verdict == 'not_eligible'
+
+
+@pytest.mark.django_db
+def test_matching_domain_value_still_eligible():
+    trial = TrialFactory(disease='multiple myeloma', disease_progression_active_required=True)
+
+    verdict = UserToTrialAttrMatcher(trial, _mm_patient('active')).trial_match_status()
+
+    assert verdict == 'eligible'
+
+
+@pytest.mark.django_db
+def test_trial_without_a_progression_requirement_is_unaffected():
+    """A trial that requires neither flag short-circuits to matched, so an
+    out-of-domain value must not turn it into a potential."""
+    trial = TrialFactory(disease='multiple myeloma')
+
+    verdict = UserToTrialAttrMatcher(trial, _mm_patient('Getting worse')).trial_match_status()
+
+    assert verdict == 'eligible'

--- a/tests/matching/test_progression_domain_divergence.py
+++ b/tests/matching/test_progression_domain_divergence.py
@@ -73,6 +73,21 @@ def test_no_sql_matcher_divergence_on_out_of_domain_progression(value):
 
 
 @pytest.mark.django_db
+@pytest.mark.parametrize('required_flag', [
+    'disease_progression_active_required',
+    'disease_progression_smoldering_required',
+])
+def test_sql_path_reads_an_out_of_domain_value_as_potential(required_flag):
+    """State the SQL side directly, not only through the equivalence helper:
+    the trial survives the filter and the count marks the criterion unmet, i.e.
+    Potential — the same verdict the matcher now returns."""
+    trial = TrialFactory(disease='multiple myeloma', **{required_flag: True})
+    base = Trial.objects.filter(id=trial.id)
+
+    assert se.sql_status_map(base, _mm_patient('Getting worse')) == {trial.id: 'potential'}
+
+
+@pytest.mark.django_db
 def test_conflicting_domain_value_still_rejects():
     """Guard against over-firing: a VALID value that contradicts the trial is
     still a definite no. Only unrecognised values became unknown."""

--- a/tests/matching/test_progression_domain_divergence.py
+++ b/tests/matching/test_progression_domain_divergence.py
@@ -141,3 +141,27 @@ def test_trial_without_a_progression_requirement_is_unaffected():
     verdict = UserToTrialAttrMatcher(trial, _mm_patient('Getting worse')).trial_match_status()
 
     assert verdict == 'eligible'
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize('value', ['active', 'smoldering'])
+@pytest.mark.parametrize('required_flags', [
+    {},
+    {'disease_progression_active_required': True},
+    {'disease_progression_smoldering_required': True},
+    {'disease_progression_active_required': True,
+     'disease_progression_smoldering_required': True},
+])
+def test_no_divergence_across_the_whole_domain(value, required_flags):
+    """The equality contract for the values that ARE answers, across every
+    requirement combination — the half the regression tests do not touch, and the
+    half a future change to the domain rule could break silently."""
+    trial = TrialFactory(disease='multiple myeloma', **required_flags)
+    base = Trial.objects.filter(id=trial.id)
+
+    divs = se.compare(base, _mm_patient(value))
+
+    assert divs == [], (
+        f"progression={value!r} vs {required_flags} diverges: "
+        f"{[(d.direction, d.matcher_unknown_attrs, d.matcher_not_matched_attrs) for d in divs]}"
+    )

--- a/tests/matching/test_progression_domain_divergence.py
+++ b/tests/matching/test_progression_domain_divergence.py
@@ -15,13 +15,19 @@ paths, exactly like a blank.
 import pytest
 
 from trials.models import Trial
+from trials.services.patient_info.configs import USER_TO_TRIAL_ATTRS_MAPPING
 from trials.services.matching import status_equivalence as se
 from trials.services.patient_info.patient_info import PatientInfo
 from trials.services.patient_info.patient_info_attributes import PatientInfoAttributes
 from trials.services.user_to_trial_attr_matcher import UserToTrialAttrMatcher
 from tests.factories import TrialFactory
 
-OUT_OF_DOMAIN = ['0', 'Getting worse', 'slow', 'high risk', 'Active', ' active']
+# The first four are values seen in production. 'Active' / ' active' are the
+# near-misses the exact-membership rule deliberately rejects. The last two are
+# non-strings: inline `patient_info` JSON reaches the field untyped (the resolver
+# coerces only dates and numerics), so a list or an int is as plausible as a bad
+# string — and a list is unhashable, which a bare set lookup would blow up on.
+OUT_OF_DOMAIN = ['0', 'Getting worse', 'slow', 'high risk', 'Active', ' active', [], 0]
 
 
 def _mm_patient(progression):
@@ -58,10 +64,17 @@ def test_out_of_domain_progression_is_potential_not_rejected(value):
 
 
 @pytest.mark.django_db
+@pytest.mark.parametrize('required_flags', [
+    {'disease_progression_active_required': True},
+    {'disease_progression_smoldering_required': True},
+    # The combination where the old code was accidentally self-consistent.
+    {'disease_progression_active_required': True,
+     'disease_progression_smoldering_required': True},
+])
 @pytest.mark.parametrize('value', OUT_OF_DOMAIN + ['', None])
-def test_no_sql_matcher_divergence_on_out_of_domain_progression(value):
+def test_no_sql_matcher_divergence_on_out_of_domain_progression(value, required_flags):
     """The #4832 contract: the two paths must agree, whatever the value."""
-    trial = TrialFactory(disease='multiple myeloma', disease_progression_active_required=True)
+    trial = TrialFactory(disease='multiple myeloma', **required_flags)
     base = Trial.objects.filter(id=trial.id)
 
     divs = se.compare(base, _mm_patient(value))
@@ -105,6 +118,18 @@ def test_matching_domain_value_still_eligible():
     verdict = UserToTrialAttrMatcher(trial, _mm_patient('active')).trial_match_status()
 
     assert verdict == 'eligible'
+
+
+@pytest.mark.django_db
+def test_domain_matches_the_options_the_ui_offers():
+    """Guard against drift: the domain is the UI's option list minus the empty
+    "Unknown". Add an option there and forget this, and every patient who picks
+    it silently becomes 'unanswered'."""
+    from trials.services.value_options import ValueOptions
+
+    offered = {code for code in ValueOptions().progressions if code != ''}
+
+    assert offered == USER_TO_TRIAL_ATTRS_MAPPING['progression']['value_domain']
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Fixes the largest divergence class measured in the cancerbot#4841 census: cancerbot-org/cancerbot#5026.

## The bug

`PatientInfo.progression` has a closed domain (`''` / `'active'` / `'smoldering'`) and nothing validates writes — CB's field is a bare `TextField` behind a bare `CharField` serializer, and the chatbot question that fills it is a free-text one — so real records hold `'0'`, `'Getting worse'`, `'slow'`, `'high risk'`.

The two matching paths then read such a value differently:

| path | behaviour on an unrecognised value | verdict |
|---|---|---|
| SQL | `eligible_for_progression` branches only on the two domain members, else `return self`; the potential count sees a non-empty value and calls the attr answered | **Eligible** |
| matcher | `_match_progression` ends in `else: return 'not_matched'` | **Not Eligible** |

## Measured

Full legacy census over a CB catalog (3 936 patients × their disease corpus = 19 733 907 (patient, trial) pairs): **2 735 diverging pairs**, the largest class of 4 119. All of it from **four MM patients**:

| patient | value | diverging trials | share of the 3 447-trial MM corpus |
|---|---|---|---|
| 1269 | `'0'` | 1 479 | **43 %** |
| 1235 | `'Getting worse'` | 569 | 17 % |
| 1026 | `'slow'` | 356 | 10 % |
| 1314 | `'high risk'` | 349 | 10 % |

36 of them land in the worst cell — SQL Eligible, matcher Not Eligible. Clinically the matcher was excluding up to 43 % of a patient's corpus on a criterion they never answered.

## The fix

An unrecognised value is not an answer, so `is_attr_blank` — the primitive **both** paths share — reads it as unanswered. That settles all three consumers at once: the SQL filter already no-ops on it (and now skips it explicitly, like any blank), the potential count stops treating it as filled, and the matcher returns `'unknown'` → Potential.

Membership is **exact**, deliberately: the handlers compare the raw value (`ctx.value == 'active'`), so accepting `'Active'` or `' active'` as answers here would just move the disagreement one step along.

`prior_therapy` is the same shape — its matcher already blanks an unrecognised label — but its SQL side runs a min/max branch instead of a no-op, so it needs its own analysis and is not folded in (8 pairs in the census).

## Verification

- 27 new tests; they fail 18-of-27 on `origin/2omop`, so they are not vacuous.
- Full suite green (1 315 passed, 5 skipped).

## Census, before vs after

Same 3 936 patients x their disease corpus = **19 733 907 (patient, trial) pairs**, legacy mode, `origin/2omop` vs both fixes:

| disease | before | after |
|---|---|---|
| MM | 2 875 | **8** |
| BC | 309 | **53** |
| FL | 936 | **0** |
| CLL | 0 | 0 |
| MCL | 0 | 0 |
| **total** | **4 120** (0.0209 %) | **61** (0.0003 %) |

What is left is not this class: 8 `prior_therapy` (the sibling case, deliberately out of scope), 30 BC lab/ULN pairs (`serum_creatinine_level`, `liver_enzyme_levels_alt`), and 25 `potential -> eligible` rows that are identical in the before run.

## Follow-up, not in this PR

The other half of #5026 is CB-side: nothing stops the junk being written in the first place (`choices` on the model, serializer validation, and the free-text chatbot question). That is an API-contract and stored-data change, so it is a separate decision.
