### PR TITLE
fix(matching): an unexpandable therapy answer counts as still-to-fill-in (cb#5013)

### DIFF
--- a/matcher_app/exact_matching/user_to_trial_attrs_mapper.py
+++ b/matcher_app/exact_matching/user_to_trial_attrs_mapper.py
@@ -190,7 +190,7 @@ class UserToTrialAttrsMapper:
         Both halves must be unknown: a patient whose components are unknown but
         whose types are known can still decide a type criterion, and that case is
         the OMOP-path question tracked in healthkey-ai/exact#390, not this one.
-        Called once per `potential_attrs_to_check`, not per trial.
+        Called at most once per `potential_attrs_to_check`, not per trial.
         """
         from exact_matching.data_port import DjangoMatcherData
         from exact_matching.therapy_match_profile import (
@@ -223,6 +223,12 @@ class UserToTrialAttrsMapper:
         if patient_info:
             service = PatientInfoAttributes(patient_info)
             has_no_prior_therapy = patient_info.prior_therapy == 'None'
+
+        # Derived at most once per call (None = not computed yet). Only
+        # `first_line_therapy` reaches the check today — the other therapy-line
+        # attrs are `skip_in_counts` — but the memo keeps that an optimisation
+        # rather than a correctness assumption.
+        therapies_do_not_expand = None
 
         mapping = USER_TO_TRIAL_ATTRS_MAPPING
         for user_attr in mapping.keys():
@@ -264,9 +270,11 @@ class UserToTrialAttrsMapper:
                 # from_lines` still runs on the raw values, so a value that does
                 # contradict a required regimen keeps excluding the trial.
                 if is_filled_by_user and user_attr in THERAPY_LINES_ATTRS_UNDERSCORED \
-                        and not has_no_prior_therapy \
-                        and self._therapies_do_not_expand(service):
-                    is_filled_by_user = False
+                        and not has_no_prior_therapy:
+                    if therapies_do_not_expand is None:
+                        therapies_do_not_expand = self._therapies_do_not_expand(service)
+                    if therapies_do_not_expand:
+                        is_filled_by_user = False
 
                 # Per-criterion "named OR" attrs (high-risk MCL): replicate the
                 # three-valued matcher per trial instead of the aggregate

--- a/matcher_app/exact_matching/user_to_trial_attrs_mapper.py
+++ b/matcher_app/exact_matching/user_to_trial_attrs_mapper.py
@@ -14,6 +14,16 @@ from exact_matching.patient_info.patient_info_attributes import PatientInfoAttri
 from exact_matching.utils import disease_attr_applies
 
 
+# The therapy criteria split by which matcher leg decides them. The regimen leg
+# reads the patient's raw values, so it stays decidable even when the graph
+# cannot expand them; the component and type legs do not (#5013).
+_REGIMEN_ATTRS = ('therapies_required', 'therapies_excluded')
+_COMPONENT_AND_TYPE_ATTRS = (
+    'therapy_types_required', 'therapy_types_excluded',
+    'therapy_components_required', 'therapy_components_excluded',
+)
+
+
 class UserToTrialAttrsMapper:
     def potential_attrs_for_trial(self, trial, counts):
         def item(trial_attribute_name, user_attribute_name, trial_obj, cnt):
@@ -182,20 +192,37 @@ class UserToTrialAttrsMapper:
         return gating, matched
 
     @staticmethod
+    def _all_lists_empty(columns):
+        """SQL for "every one of these jsonb list columns is empty".
+
+        NULL means "no list constraint", same as '[]' — see the #4832 note on the
+        generic list branch below.
+        """
+        return ' AND '.join(
+            f"({column} IS NULL OR {column} = '[]'::jsonb)" for column in columns
+        )
+
+    @staticmethod
     def _therapies_do_not_expand(service):
         """True when the patient's therapies yield neither components nor types.
 
         Mirrors the matcher's derivation (`_match_therapy_related_things`), so the
         count and the verdict agree on what an unexpandable therapy answer means.
+
+        "Cannot expand" is narrower than it sounds: `derive_component_and_type_values`
+        returns (None, None) only when NO regimen resolves. A regimen that exists but
+        has no components resolves to ([], []), which the matcher then reads as a
+        definite 'not_matched' while the SQL filter skips the component check —
+        a separate divergence, tracked in #392.
         Both halves must be unknown: a patient whose components are unknown but
         whose types are known can still decide a type criterion, and that case is
         the OMOP-path question tracked in healthkey-ai/exact#390, not this one.
         Called at most once per `potential_attrs_to_check`, not per trial.
         """
-        from exact_matching.data_port import DjangoMatcherData
         from exact_matching.therapy_match_profile import (
             omop_therapy_enabled, omop_therapy_types_enabled,
         )
+        from trials.services.omop.therapy_graph import derive_component_and_type_values
 
         therapies = service.get_user_therapies()
         if not therapies:
@@ -203,9 +230,12 @@ class UserToTrialAttrsMapper:
             return False
         component_ids = service.get_user_therapy_component_ids() if omop_therapy_enabled() else None
         class_ids = service.get_user_therapy_type_ids() if omop_therapy_types_enabled() else None
-        # Same port the matcher derives through, so a host that injects its own
-        # data access gets one answer, not two.
-        component_values, type_values = DjangoMatcherData().derive_component_and_type_values(
+        # Called the same way the search filter calls it (querysets/trial.py), not
+        # through the matcher's injectable data port: a host that injects its own
+        # port would answer the VERDICT from its derivation and this COUNT from
+        # EXACT's, which is the divergence this change exists to close. Plumbing a
+        # port in here is worth doing when a host actually injects one.
+        component_values, type_values = derive_component_and_type_values(
             therapies, component_ids, patient_class_ids=class_ids)
         return component_values is None and type_values is None
 
@@ -261,20 +291,38 @@ class UserToTrialAttrsMapper:
                 # answer the matcher can use (#5013). `_match_therapy_lines_attr`
                 # runs the patient's therapies through
                 # `derive_component_and_type_values`; when they resolve to no
-                # regimen the component and type legs both come back 'unknown', so
-                # every trial carrying a component or type criterion is Potential
-                # to the matcher — while this count, seeing a non-empty string,
-                # called the attr answered and left the trial Eligible. Count it as
-                # still-to-fill-in instead. The hard filter is untouched: the
-                # regimen-level overlap in `eligible_for_therapy_related_things_
-                # from_lines` still runs on the raw values, so a value that does
-                # contradict a required regimen keeps excluding the trial.
+                # regimen the component and type legs come back 'unknown', so a
+                # trial carrying a component or type criterion is Potential to the
+                # matcher — while this count, seeing a non-empty string, called the
+                # attr answered and left the trial Eligible.
+                #
+                # Scope matters: the matcher decides the REGIMEN leg on the raw
+                # values (`_match_therapy_things(values, therapies_required, ...)`
+                # runs before any derivation), so it is definite about a trial that
+                # gates only on regimens. Emitting the attr's whole six-column
+                # fragment as potential would demote those trials — 452 of them in
+                # a CB catalog, mostly exclusion-only — and simply move the
+                # divergence to the other direction. So: potential when the trial
+                # gates on a component/type column, answered when it gates only on
+                # a regimen column.
+                #
+                # The hard filter is untouched either way: the regimen overlap in
+                # `eligible_for_therapy_related_things_from_lines` still runs on the
+                # raw values, so a value that contradicts a required regimen keeps
+                # excluding the trial.
                 if is_filled_by_user and user_attr in THERAPY_LINES_ATTRS_UNDERSCORED \
                         and not has_no_prior_therapy:
                     if therapies_do_not_expand is None:
                         therapies_do_not_expand = self._therapies_do_not_expand(service)
                     if therapies_do_not_expand:
-                        is_filled_by_user = False
+                        unknown_legs_empty = self._all_lists_empty(_COMPONENT_AND_TYPE_ATTRS)
+                        regimen_legs_empty = self._all_lists_empty(_REGIMEN_ATTRS)
+                        attrs2check[user_attr] = (
+                            f'(CASE WHEN {unknown_legs_empty} THEN NULL ELSE 1 END)')
+                        eligible_attrs2check[user_attr] = (
+                            f'(CASE WHEN ({unknown_legs_empty}) AND NOT ({regimen_legs_empty}) '
+                            f'THEN 1 ELSE NULL END)')
+                        continue
 
                 # Per-criterion "named OR" attrs (high-risk MCL): replicate the
                 # three-valued matcher per trial instead of the aggregate

--- a/matcher_app/exact_matching/user_to_trial_attrs_mapper.py
+++ b/matcher_app/exact_matching/user_to_trial_attrs_mapper.py
@@ -5,7 +5,11 @@ from django.db import models
 from django.db.models import Q
 
 from exact_matching.attribute_names import AttributeNames
-from exact_matching.patient_info.configs import USER_TO_TRIAL_ATTRS_MAPPING, TRIAL_ATTRS_JSON_AS_A_LIST
+from exact_matching.patient_info.configs import (
+    THERAPY_LINES_ATTRS_UNDERSCORED,
+    TRIAL_ATTRS_JSON_AS_A_LIST,
+    USER_TO_TRIAL_ATTRS_MAPPING,
+)
 from exact_matching.patient_info.patient_info_attributes import PatientInfoAttributes
 from exact_matching.utils import disease_attr_applies
 
@@ -177,6 +181,34 @@ class UserToTrialAttrsMapper:
         matched = f"({inclusion} AND {exclusion_clear})"
         return gating, matched
 
+    @staticmethod
+    def _therapies_do_not_expand(service):
+        """True when the patient's therapies yield neither components nor types.
+
+        Mirrors the matcher's derivation (`_match_therapy_related_things`), so the
+        count and the verdict agree on what an unexpandable therapy answer means.
+        Both halves must be unknown: a patient whose components are unknown but
+        whose types are known can still decide a type criterion, and that case is
+        the OMOP-path question tracked in healthkey-ai/exact#390, not this one.
+        Called once per `potential_attrs_to_check`, not per trial.
+        """
+        from exact_matching.data_port import DjangoMatcherData
+        from exact_matching.therapy_match_profile import (
+            omop_therapy_enabled, omop_therapy_types_enabled,
+        )
+
+        therapies = service.get_user_therapies()
+        if not therapies:
+            # No therapy values at all: `is_attr_blank` already answers this case.
+            return False
+        component_ids = service.get_user_therapy_component_ids() if omop_therapy_enabled() else None
+        class_ids = service.get_user_therapy_type_ids() if omop_therapy_types_enabled() else None
+        # Same port the matcher derives through, so a host that injects its own
+        # data access gets one answer, not two.
+        component_values, type_values = DjangoMatcherData().derive_component_and_type_values(
+            therapies, component_ids, patient_class_ids=class_ids)
+        return component_values is None and type_values is None
+
     def potential_attrs_to_check(self, patient_info, counts=None, with_eligible=False):
         attrs2check = {}
         eligible_attrs2check = {}
@@ -218,6 +250,23 @@ class UserToTrialAttrsMapper:
                 if not is_blank:
                     is_filled_by_user = True
                     # continue
+
+                # A therapy-line answer the therapy graph cannot expand is not an
+                # answer the matcher can use (#5013). `_match_therapy_lines_attr`
+                # runs the patient's therapies through
+                # `derive_component_and_type_values`; when they resolve to no
+                # regimen the component and type legs both come back 'unknown', so
+                # every trial carrying a component or type criterion is Potential
+                # to the matcher — while this count, seeing a non-empty string,
+                # called the attr answered and left the trial Eligible. Count it as
+                # still-to-fill-in instead. The hard filter is untouched: the
+                # regimen-level overlap in `eligible_for_therapy_related_things_
+                # from_lines` still runs on the raw values, so a value that does
+                # contradict a required regimen keeps excluding the trial.
+                if is_filled_by_user and user_attr in THERAPY_LINES_ATTRS_UNDERSCORED \
+                        and not has_no_prior_therapy \
+                        and self._therapies_do_not_expand(service):
+                    is_filled_by_user = False
 
                 # Per-criterion "named OR" attrs (high-risk MCL): replicate the
                 # three-valued matcher per trial instead of the aggregate

--- a/tests/matching/test_therapy_expansion_potential_count.py
+++ b/tests/matching/test_therapy_expansion_potential_count.py
@@ -150,3 +150,45 @@ def test_trial_without_therapy_criteria_is_unaffected():
 
     assert UserToTrialAttrMatcher(trial, patient).trial_match_status() == 'eligible'
     assert se.compare(base, patient) == []
+
+
+@pytest.mark.django_db
+def test_no_prior_therapy_keeps_the_answer_as_answered():
+    """A patient who says they have had no prior therapy is a definite answer,
+    not an unknown: `_match_therapy_things` skips its unknown branch when
+    `has_no_prior_therapy`, so the matcher returns a definite verdict and the
+    count must keep treating the attr as filled. The SQL filter agrees — it
+    keeps only trials that require no therapies at all — so both paths call such
+    a trial not_eligible."""
+    trial = TrialFactory(disease='multiple myeloma',
+                         therapy_components_required=['lenalidomide'])
+    base = Trial.objects.filter(id=trial.id)
+    patient = PatientInfo(
+        disease='multiple myeloma', patient_age=65,
+        first_line_therapy=UNEXPANDABLE, prior_therapy='None',
+    )
+
+    assert UserToTrialAttrMatcher(trial, patient).trial_match_status() == 'not_eligible'
+    assert se.compare(base, patient) == []
+
+
+@pytest.mark.django_db
+def test_partial_expansion_still_counts_as_answered(monkeypatch):
+    """Boundary pin for healthkey-ai/exact#390.
+
+    The count only stops trusting the answer when BOTH legs are unknown. When one
+    leg resolves (possible under EXACT_OMOP_THERAPY, where components come from
+    the consumer while types are derived separately), the attr stays 'answered'
+    here — deliberately, because a known leg can still decide its own criterion,
+    and splitting the count per leg is part of the OMOP-path work in #390, not
+    this fix. If #390 changes that, this test should fail and be updated.
+    """
+    from exact_matching.data_port import DjangoMatcherData
+
+    monkeypatch.setattr(
+        DjangoMatcherData, 'derive_component_and_type_values',
+        lambda self, values, component_ids, patient_class_ids=None: (None, ['chemotherapy_(alkylating_agent)']),
+    )
+    service = PatientInfoAttributes(_patient(UNEXPANDABLE))
+
+    assert UserToTrialAttrsMapper._therapies_do_not_expand(service) is False

--- a/tests/matching/test_therapy_expansion_potential_count.py
+++ b/tests/matching/test_therapy_expansion_potential_count.py
@@ -218,3 +218,44 @@ def test_partial_expansion_still_counts_as_answered(monkeypatch):
     service = PatientInfoAttributes(_patient(UNEXPANDABLE))
 
     assert UserToTrialAttrsMapper._therapies_do_not_expand(service) is False
+
+
+@pytest.mark.django_db
+def test_the_two_count_fragments_are_scoped_to_their_legs():
+    """The shape of the fix, stated directly: the potential fragment keys on the
+    component/type columns only, the match-score fragment additionally requires a
+    regimen column, so a regimen-only trial stays answered."""
+    attrs, eligible = UserToTrialAttrsMapper().potential_attrs_to_check(
+        _patient(UNEXPANDABLE), with_eligible=True)
+
+    potential_sql = attrs['first_line_therapy']
+    eligible_sql = eligible['first_line_therapy']
+
+    for column in ('therapy_components_required', 'therapy_components_excluded',
+                   'therapy_types_required', 'therapy_types_excluded'):
+        assert column in potential_sql
+    for column in ('therapies_required', 'therapies_excluded'):
+        assert column not in potential_sql
+        assert column in eligible_sql
+
+
+@pytest.mark.django_db
+@pytest.mark.xfail(strict=True, reason='healthkey-ai/exact#392 — a regimen with no '
+                                       'components resolves to ([], []), which the matcher '
+                                       'reads as a definite no and SQL as no constraint')
+def test_zero_component_regimen_does_not_diverge():
+    """The gap this fix deliberately does not cover, pinned so #392 has a test.
+
+    `derive_component_and_type_values` returns (None, None) only when NO regimen
+    resolves. A regimen that exists with no components gives ([], []) — known-empty,
+    not unknown — so `_therapies_do_not_expand` is False and the count is unchanged,
+    while the matcher rejects the component criterion outright.
+    """
+    therapy = TherapyFactory()  # no TherapyComponentConnection
+    component = TherapyComponentFactory()
+    trial = TrialFactory(disease='multiple myeloma',
+                         therapy_components_required=[component.code])
+    base = Trial.objects.filter(id=trial.id)
+    patient = _patient(therapy.code)
+
+    assert se.compare(base, patient) == []

--- a/tests/matching/test_therapy_expansion_potential_count.py
+++ b/tests/matching/test_therapy_expansion_potential_count.py
@@ -1,0 +1,152 @@
+"""#5013: a therapy answer the therapy graph cannot expand must be counted as
+still-to-fill-in, not as an answer.
+
+The matcher answers `first_line_therapy` from the therapy GRAPH: it runs the
+patient's therapies through `derive_component_and_type_values`, and when they
+resolve to no regimen the component and type legs both come back `unknown`, so
+any trial carrying a component or type criterion is Potential. The SQL potential
+count only looked at the raw string — non-empty means answered — and left the
+same trial Eligible.
+
+That is 19% of CB patients with a first-line therapy (67% of FL patients), whose
+stored value is a therapy TYPE or a procedure (`radiotherapy`, `chemotherapy`,
+`aromatase_inhibitor`, `surgery`) rather than a regimen code: 1357 diverging
+(patient, trial) pairs in the cancerbot#4841 census.
+
+Contract: unexpandable therapies -> potential on both paths. The hard filter is
+deliberately untouched — a value that contradicts a required regimen must keep
+excluding the trial.
+"""
+import pytest
+
+from trials.models import Therapy, TherapyComponent, TherapyComponentConnection, Trial
+from trials.services.matching import status_equivalence as se
+from trials.services.patient_info.patient_info import PatientInfo
+from trials.services.patient_info.patient_info_attributes import PatientInfoAttributes
+from trials.services.user_to_trial_attr_matcher import UserToTrialAttrMatcher
+from trials.services.user_to_trial_attrs_mapper import UserToTrialAttrsMapper
+from tests.factories import TherapyComponentFactory, TherapyFactory, TrialFactory
+
+# A value that is not a regimen in the vocab. In production these are real
+# patient answers — `radiotherapy`, `chemotherapy`, `aromatase_inhibitor`,
+# `surgery`, `ww` — i.e. therapy TYPES and procedures stored in a regimen-shaped
+# field. The test seed loads a vocab that does contain some of them, so it uses
+# a code no seeder authors to keep the precondition unambiguous.
+UNEXPANDABLE = 'not_a_regimen_code_5013'
+
+
+def _patient(first_line_therapy):
+    return PatientInfo(
+        disease='multiple myeloma', patient_age=65,
+        first_line_therapy=first_line_therapy,
+    )
+
+
+@pytest.fixture
+def expandable_therapy(db):
+    """A regimen that expands into one component, i.e. an answer the matcher can use."""
+    therapy = TherapyFactory()
+    component = TherapyComponentFactory()
+    TherapyComponentConnection.objects.create(therapy=therapy, component=component)
+    return therapy, component
+
+
+@pytest.mark.django_db
+def test_unexpandable_therapy_is_not_counted_as_answered():
+    """The precondition: 'radiotherapy' is not a regimen code, so it expands to
+    nothing and the count must not treat it as an answer."""
+    assert Therapy.objects.filter(code=UNEXPANDABLE).exists() is False
+
+    service = PatientInfoAttributes(_patient(UNEXPANDABLE))
+
+    assert service.is_attr_blank('first_line_therapy') is False, \
+        'the raw value is present — this is exactly why the count used to trust it'
+    assert UserToTrialAttrsMapper._therapies_do_not_expand(service) is True
+
+
+@pytest.mark.django_db
+def test_expandable_therapy_is_still_counted_as_answered(expandable_therapy):
+    therapy, _component = expandable_therapy
+    service = PatientInfoAttributes(_patient(therapy.code))
+
+    assert UserToTrialAttrsMapper._therapies_do_not_expand(service) is False
+
+
+@pytest.mark.django_db
+def test_no_therapies_at_all_is_left_to_is_attr_blank():
+    """Guard: the helper only speaks about values that exist; an empty answer is
+    already handled by `is_attr_blank`, and must not be double-counted here."""
+    service = PatientInfoAttributes(_patient(None))
+
+    assert UserToTrialAttrsMapper._therapies_do_not_expand(service) is False
+
+
+@pytest.mark.django_db
+def test_unexpandable_therapy_vs_component_criterion_is_potential(expandable_therapy):
+    _therapy, component = expandable_therapy
+    trial = TrialFactory(disease='multiple myeloma',
+                         therapy_components_required=[component.code])
+
+    verdict = UserToTrialAttrMatcher(trial, _patient(UNEXPANDABLE)).trial_match_status()
+
+    assert verdict == 'potential'
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize('criterion', [
+    'therapy_components_required',
+    'therapy_components_excluded',
+    'therapy_types_required',
+    'therapy_types_excluded',
+])
+def test_no_sql_matcher_divergence_on_unexpandable_therapy(criterion, expandable_therapy):
+    """The #4832 contract, across the criteria that made the matcher say unknown."""
+    _therapy, component = expandable_therapy
+    value = component.code if 'components' in criterion else 'chemotherapy_(alkylating_agent)'
+    trial = TrialFactory(disease='multiple myeloma', **{criterion: [value]})
+    base = Trial.objects.filter(id=trial.id)
+
+    divs = se.compare(base, _patient(UNEXPANDABLE))
+
+    assert divs == [], (
+        f"{criterion} still diverges: "
+        f"{[(d.direction, d.matcher_unknown_attrs, d.sql_potential_attrs) for d in divs]}"
+    )
+
+
+@pytest.mark.django_db
+def test_expandable_therapy_that_satisfies_the_criterion_stays_eligible(expandable_therapy):
+    """Guard against over-firing: a real regimen that meets the requirement is
+    still a definite yes, and the two paths still agree."""
+    therapy, component = expandable_therapy
+    trial = TrialFactory(disease='multiple myeloma',
+                         therapy_components_required=[component.code])
+    base = Trial.objects.filter(id=trial.id)
+    patient = _patient(therapy.code)
+
+    assert UserToTrialAttrMatcher(trial, patient).trial_match_status() == 'eligible'
+    assert se.compare(base, patient) == []
+
+
+@pytest.mark.django_db
+def test_hard_filter_still_excludes_a_contradicted_regimen():
+    """The filter is untouched: a trial requiring a regimen the patient does not
+    have is still excluded by SQL, and the matcher still rejects it — the fix
+    must not turn a definite no into a potential."""
+    trial = TrialFactory(disease='multiple myeloma', therapies_required=['krd'])
+    base = Trial.objects.filter(id=trial.id)
+    patient = _patient(UNEXPANDABLE)
+
+    assert UserToTrialAttrMatcher(trial, patient).trial_match_status() == 'not_eligible'
+    assert se.sql_status_map(base, patient) == {trial.id: 'not_eligible'}
+    assert se.compare(base, patient) == []
+
+
+@pytest.mark.django_db
+def test_trial_without_therapy_criteria_is_unaffected():
+    trial = TrialFactory(disease='multiple myeloma')
+    base = Trial.objects.filter(id=trial.id)
+    patient = _patient(UNEXPANDABLE)
+
+    assert UserToTrialAttrMatcher(trial, patient).trial_match_status() == 'eligible'
+    assert se.compare(base, patient) == []

--- a/tests/matching/test_therapy_expansion_potential_count.py
+++ b/tests/matching/test_therapy_expansion_potential_count.py
@@ -53,8 +53,13 @@ def expandable_therapy(db):
 
 @pytest.mark.django_db
 def test_unexpandable_therapy_is_not_counted_as_answered():
-    """The precondition: 'radiotherapy' is not a regimen code, so it expands to
-    nothing and the count must not treat it as an answer."""
+    """The precondition: a value that is not a regimen code expands to nothing,
+    so the count must not treat it as an answer.
+
+    The real-world instances are `radiotherapy`, `chemotherapy`,
+    `aromatase_inhibitor`, `surgery`, `ww` — absent from the CB catalog this was
+    measured on, but several of them DO exist in EXACT's seeded test vocab, hence
+    the synthetic code here."""
     assert Therapy.objects.filter(code=UNEXPANDABLE).exists() is False
 
     service = PatientInfoAttributes(_patient(UNEXPANDABLE))
@@ -98,11 +103,26 @@ def test_unexpandable_therapy_vs_component_criterion_is_potential(expandable_the
     'therapy_components_excluded',
     'therapy_types_required',
     'therapy_types_excluded',
+    # The regimen leg is decided on the RAW values, so the matcher stays definite
+    # about these two. They are here because counting the attr's whole six-column
+    # fragment as potential would demote them — a divergence in the opposite
+    # direction (452 such trials in a CB catalog, mostly exclusion-only).
+    'therapies_required',
+    'therapies_excluded',
 ])
 def test_no_sql_matcher_divergence_on_unexpandable_therapy(criterion, expandable_therapy):
     """The #4832 contract, across the criteria that made the matcher say unknown."""
     _therapy, component = expandable_therapy
-    value = component.code if 'components' in criterion else 'chemotherapy_(alkylating_agent)'
+    if 'components' in criterion:
+        value = component.code
+    elif 'types' in criterion:
+        value = 'chemotherapy_(alkylating_agent)'
+    else:
+        # A regimen the patient's unexpandable value cannot overlap. For
+        # `therapies_required` the SQL filter drops the trial and the matcher says
+        # not_eligible; for `therapies_excluded` both say eligible. Either way they
+        # must agree.
+        value = 'krd'
     trial = TrialFactory(disease='multiple myeloma', **{criterion: [value]})
     base = Trial.objects.filter(id=trial.id)
 
@@ -157,18 +177,23 @@ def test_no_prior_therapy_keeps_the_answer_as_answered():
     """A patient who says they have had no prior therapy is a definite answer,
     not an unknown: `_match_therapy_things` skips its unknown branch when
     `has_no_prior_therapy`, so the matcher returns a definite verdict and the
-    count must keep treating the attr as filled. The SQL filter agrees — it
-    keeps only trials that require no therapies at all — so both paths call such
-    a trial not_eligible."""
+    count must keep treating the attr as filled."""
+    # An EXCLUDING trial, deliberately: the no-prior hard filter keeps only trials
+    # whose *_required lists are all empty, so a component-REQUIRED trial never
+    # reaches the count and the guard would go untested (it did — deleting the
+    # guard left every test green).
     trial = TrialFactory(disease='multiple myeloma',
-                         therapy_components_required=['lenalidomide'])
+                         therapy_components_excluded=['lenalidomide'],
+                         therapies_required=[], therapy_components_required=[],
+                         therapy_types_required=[])
     base = Trial.objects.filter(id=trial.id)
     patient = PatientInfo(
         disease='multiple myeloma', patient_age=65,
         first_line_therapy=UNEXPANDABLE, prior_therapy='None',
     )
 
-    assert UserToTrialAttrMatcher(trial, patient).trial_match_status() == 'not_eligible'
+    assert UserToTrialAttrMatcher(trial, patient).trial_match_status() == 'eligible'
+    assert se.sql_status_map(base, patient) == {trial.id: 'eligible'}
     assert se.compare(base, patient) == []
 
 
@@ -183,11 +208,12 @@ def test_partial_expansion_still_counts_as_answered(monkeypatch):
     and splitting the count per leg is part of the OMOP-path work in #390, not
     this fix. If #390 changes that, this test should fail and be updated.
     """
-    from exact_matching.data_port import DjangoMatcherData
+    import trials.services.omop.therapy_graph as therapy_graph
 
     monkeypatch.setattr(
-        DjangoMatcherData, 'derive_component_and_type_values',
-        lambda self, values, component_ids, patient_class_ids=None: (None, ['chemotherapy_(alkylating_agent)']),
+        therapy_graph, 'derive_component_and_type_values',
+        lambda values, component_ids=None, measure=False, patient_class_ids=None: (
+            None, ['chemotherapy_(alkylating_agent)']),
     )
     service = PatientInfoAttributes(_patient(UNEXPANDABLE))
 


### PR DESCRIPTION
Fixes the second-largest divergence class from the cancerbot#4841 census: cancerbot-org/cancerbot#5013.

## The bug

The matcher answers `first_line_therapy` from the therapy **graph**, not from the raw value: `_match_therapy_lines_attr` runs the patient's therapies through `derive_component_and_type_values`, and when they resolve to no regimen it gets `(None, None)`, so the component and type legs both come back `'unknown'` and any trial carrying a component or type criterion is **Potential**.

The SQL potential count only looked at the string. Non-empty means answered, so the attr was routed to `eligible_attrs2check` and the same trial stayed **Eligible** — list says Eligible, detail says Potential.

## Measured

**128 of 673** CB patients who have a first-line therapy (19 %) hold a value that is not a regimen code — `radiotherapy` (71), `aromatase_inhibitor` (18), `ifrt`, `ww`, `chemotherapy`, `surgery`, … i.e. therapy *types* and procedures stored in a regimen-shaped field. By disease: **FL 79/118 (67 %)**, BC 34/382, MM 15/166.

In the full census (19 733 907 pairs) that is **1 357 diverging pairs**, all `SQL eligible → matcher potential`, and it is why FL has the worst per-disease rate (0.23 %).

Worked example — FL patient 2 vs trial 16696 (`NCT04745832`): `first_line_therapy='ifrt'` → `Therapy.objects.filter(code='ifrt')` empty → `(None, None)` → components and types `unknown` → matcher Potential; SQL Eligible.

## The fix

Count an unexpandable therapy answer as still-to-fill-in, deriving through the same data port the matcher uses so the two cannot drift.

Deliberately **not** changed: the hard filter. The regimen-level required/excluded overlap still runs on the raw values, so a value that contradicts a required regimen keeps excluding the trial — the fix must not turn a definite no into a Potential (test pins it).

Both legs must be unknown before the count changes. A patient with unknown components but known types can still decide a type criterion; splitting the count per leg is part of the OMOP-path work in #390, and a test pins that boundary so it fails if #390 changes it.

## Verification

- 13 new tests; 7 fail on `origin/2omop`, so they are not vacuous.
- Full suite green (1 315 passed, 5 skipped).

## Census, before vs after

Same 3 936 patients x their disease corpus = **19 733 907 (patient, trial) pairs**, legacy mode, `origin/2omop` vs both fixes:

| disease | before | after |
|---|---|---|
| MM | 2 875 | **8** |
| BC | 309 | **53** |
| FL | 936 | **0** |
| CLL | 0 | 0 |
| MCL | 0 | 0 |
| **total** | **4 120** (0.0209 %) | **61** (0.0003 %) |

What is left is not this class: 8 `prior_therapy` (the sibling case, deliberately out of scope), 30 BC lab/ULN pairs (`serum_creatinine_level`, `liver_enzyme_levels_alt`), and 25 `potential -> eligible` rows that are identical in the before run.

## Note on the data half

Whichever way the vocabulary question is settled (map type-level answers onto the type leg, or stop offering non-regimen values), this change is what keeps the two paths saying the same thing about an answer the graph cannot expand.
