### PR TITLE
fix(matching): decide the therapy count from the same bag the matcher reads (follow-up to #394)

### DIFF
--- a/matcher_app/exact_matching/user_to_trial_attrs_mapper.py
+++ b/matcher_app/exact_matching/user_to_trial_attrs_mapper.py
@@ -310,7 +310,15 @@ class UserToTrialAttrsMapper:
                 # `eligible_for_therapy_related_things_from_lines` still runs on the
                 # raw values, so a value that contradicts a required regimen keeps
                 # excluding the trial.
-                if is_filled_by_user and user_attr in THERAPY_LINES_ATTRS_UNDERSCORED \
+                # Not gated on `is_filled_by_user`: the matcher answers
+                # `first_line_therapy` from `get_user_therapies()`, which folds in
+                # the other therapy lines and the supportive rows, so an
+                # unexpandable value in `second_line_therapy` leaves this field
+                # blank while still driving the verdict. Deciding from the same bag
+                # is what keeps the two paths together —
+                # `_therapies_do_not_expand` returns False for an empty bag, the
+                # case `is_attr_blank` already owns.
+                if user_attr in THERAPY_LINES_ATTRS_UNDERSCORED \
                         and not has_no_prior_therapy:
                     if therapies_do_not_expand is None:
                         therapies_do_not_expand = self._therapies_do_not_expand(service)

--- a/matcher_app/exact_matching/user_to_trial_attrs_mapper.py
+++ b/matcher_app/exact_matching/user_to_trial_attrs_mapper.py
@@ -310,18 +310,23 @@ class UserToTrialAttrsMapper:
                 # `eligible_for_therapy_related_things_from_lines` still runs on the
                 # raw values, so a value that contradicts a required regimen keeps
                 # excluding the trial.
-                # Not gated on `is_filled_by_user`: the matcher answers
-                # `first_line_therapy` from `get_user_therapies()`, which folds in
-                # the other therapy lines and the supportive rows, so an
-                # unexpandable value in `second_line_therapy` leaves this field
-                # blank while still driving the verdict. Deciding from the same bag
-                # is what keeps the two paths together —
-                # `_therapies_do_not_expand` returns False for an empty bag, the
-                # case `is_attr_blank` already owns.
+                # The matcher answers `first_line_therapy` from
+                # `get_user_therapies()` — the bag that folds in the other therapy
+                # lines and the supportive rows — while `is_attr_blank` looks only
+                # at the field. So the count has to ask the bag, not the field:
+                # a value in `second_line_therapy` drives the verdict either way,
+                # and reading `first_line_therapy` as unanswered because that one
+                # column is empty demoted trials the matcher had already decided.
+                #
+                # An empty bag is left alone: that is the state `is_attr_blank`
+                # owns, and both paths agree on it.
                 if user_attr in THERAPY_LINES_ATTRS_UNDERSCORED \
-                        and not has_no_prior_therapy:
+                        and not has_no_prior_therapy and service.get_user_therapies():
                     if therapies_do_not_expand is None:
                         therapies_do_not_expand = self._therapies_do_not_expand(service)
+                    # The bag expands: the matcher decides every leg from it, so
+                    # the attr is answered however empty the field itself is.
+                    is_filled_by_user = not therapies_do_not_expand
                     if therapies_do_not_expand:
                         unknown_legs_empty = self._all_lists_empty(_COMPONENT_AND_TYPE_ATTRS)
                         regimen_legs_empty = self._all_lists_empty(_REGIMEN_ATTRS)

--- a/tests/matching/test_therapy_expansion_potential_count.py
+++ b/tests/matching/test_therapy_expansion_potential_count.py
@@ -347,3 +347,84 @@ def test_a_required_regimen_the_bag_cannot_meet_still_excludes(source, expandabl
 
     assert se.sql_status_map(base, patient) == {trial.id: 'not_eligible'}
     assert se.compare(base, patient) == []
+
+
+@pytest.mark.django_db
+def test_a_mixed_bag_counts_as_answered(expandable_therapy):
+    """One resolvable therapy is enough: `derive_component_and_type_values` returns
+    that regimen's components, so every leg is decidable and the matcher is
+    definite — the count must not treat the bag as unexpandable because one of the
+    values is junk."""
+    therapy, component = expandable_therapy
+    trial = TrialFactory(disease='multiple myeloma',
+                         therapy_components_required=[component.code])
+    base = Trial.objects.filter(id=trial.id)
+    patient = PatientInfo(disease='multiple myeloma', patient_age=65,
+                          first_line_therapy=therapy.code,
+                          second_line_therapy=UNEXPANDABLE)
+
+    assert UserToTrialAttrsMapper._therapies_do_not_expand(
+        PatientInfoAttributes(patient)) is False
+    assert se.compare(base, patient) == []
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize('bag', ['empty', 'expandable', 'unexpandable'])
+@pytest.mark.parametrize('criterion', ['therapy_components_required', 'therapies_excluded'])
+def test_no_prior_therapy_agrees_for_every_bag(bag, criterion, expandable_therapy, request):
+    """`has_no_prior_therapy` bypasses the bag override entirely, so the pre-existing
+    route has to agree on its own for all three bag states.
+
+    It does not, for one of the six: a patient who says "no prior therapy" while
+    carrying a resolvable one is dropped by the coarse no-prior filter (which keeps
+    only trials requiring nothing) and called eligible by the matcher (which
+    evaluates the real overlap). Contradictory data — 4 such patients in the
+    production catalog — and pre-existing: neither #394 nor #395 touches that
+    route. Filed as #396, xfailed here so closing it flips this green.
+    """
+    if bag == 'expandable' and criterion == 'therapy_components_required':
+        request.node.add_marker(pytest.mark.xfail(
+            strict=True, reason='#396 — no-prior filter drops it, matcher says eligible'))
+    therapy, component = expandable_therapy
+    value = component.code if 'components' in criterion else 'krd'
+    trial = TrialFactory(disease='multiple myeloma', **{criterion: [value]})
+    base = Trial.objects.filter(id=trial.id)
+    therapies = {'empty': None, 'expandable': therapy.code, 'unexpandable': UNEXPANDABLE}[bag]
+    patient = PatientInfo(disease='multiple myeloma', patient_age=65,
+                          prior_therapy='None', first_line_therapy=therapies)
+
+    assert se.compare(base, patient) == []
+
+
+@pytest.mark.django_db
+def test_an_empty_bag_keeps_the_generic_fragment():
+    """Not just "the paths agree" — that the special pair did not fire at all, so
+    the empty case is still `is_attr_blank`'s."""
+    attrs = UserToTrialAttrsMapper().potential_attrs_to_check(
+        PatientInfo(disease='multiple myeloma', patient_age=65))
+
+    fragment = attrs['first_line_therapy']
+
+    for column in ('therapies_required', 'therapies_excluded',
+                   'therapy_components_required', 'therapy_types_excluded'):
+        assert column in fragment, 'the generic six-column fragment, not the scoped pair'
+
+
+@pytest.mark.django_db
+def test_the_attr_is_counted_once_though_it_sits_in_both_dicts(expandable_therapy):
+    """`match_score`'s denominator is `num_nonnulls(potential + filled)`, and this
+    attr now appears in both. The two fragments are mutually exclusive by
+    construction, so it must contribute exactly one — a trial gating on a
+    component AND a regimen column counts 1, not 2."""
+    _therapy, component = expandable_therapy
+    trial = TrialFactory(disease='multiple myeloma',
+                         therapy_components_required=[component.code],
+                         therapies_excluded=['krd'])
+    patient = PatientInfo(disease='multiple myeloma', patient_age=65,
+                          first_line_therapy=UNEXPANDABLE)
+
+    annotated = (Trial.objects.filter(id=trial.id)
+                 .with_potential_attrs_count(patient).first())
+
+    assert annotated.potential_attrs_count == 1
+    assert 0 <= annotated.match_score <= 100

--- a/tests/matching/test_therapy_expansion_potential_count.py
+++ b/tests/matching/test_therapy_expansion_potential_count.py
@@ -307,3 +307,43 @@ def test_an_empty_therapy_bag_is_left_to_is_attr_blank():
     assert UserToTrialAttrsMapper._therapies_do_not_expand(
         PatientInfoAttributes(patient)) is False
     assert se.compare(base, patient) == []
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize('source', ['second_line_therapy', 'later_therapy', 'supportive_therapies'])
+@pytest.mark.parametrize('criterion', ['therapies_excluded', 'therapy_components_required'])
+def test_an_expandable_value_on_another_line_is_answered(source, criterion, expandable_therapy):
+    """The mirror of the unexpandable case, and the other half of the same
+    principle: when the bag DOES expand, the matcher decides every leg from it and
+    is definite — so reading `first_line_therapy` as unanswered just because that
+    one column is empty demotes a trial the matcher already called eligible."""
+    therapy, component = expandable_therapy
+    value = component.code if 'components' in criterion else 'krd'
+    trial = TrialFactory(disease='multiple myeloma', **{criterion: [value]})
+    base = Trial.objects.filter(id=trial.id)
+    payload = ({'therapy': therapy.code} if source == 'supportive_therapies' else therapy.code)
+    patient = PatientInfo(disease='multiple myeloma', patient_age=65,
+                          **{source: [payload] if source == 'supportive_therapies' else payload})
+
+    divs = se.compare(base, patient)
+
+    assert divs == [], (
+        f"{source}={therapy.code!r} vs {criterion} diverges: "
+        f"{[(d.direction, d.matcher_unknown_attrs, d.sql_potential_attrs) for d in divs]}")
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize('source', ['second_line_therapy', 'later_therapies', 'supportive_therapies'])
+def test_a_required_regimen_the_bag_cannot_meet_still_excludes(source, expandable_therapy):
+    """The not-eligible leg for the newly-counted population: the hard filter is
+    reached through the post-loop fire, not the therapy-line dispatch, so it needs
+    its own pin."""
+    trial = TrialFactory(disease='multiple myeloma', therapies_required=['krd'])
+    base = Trial.objects.filter(id=trial.id)
+    payload = ({'therapy': UNEXPANDABLE} if source in ('later_therapies', 'supportive_therapies')
+               else UNEXPANDABLE)
+    patient = PatientInfo(disease='multiple myeloma', patient_age=65,
+                          **{source: [payload] if source != 'second_line_therapy' else payload})
+
+    assert se.sql_status_map(base, patient) == {trial.id: 'not_eligible'}
+    assert se.compare(base, patient) == []

--- a/tests/matching/test_therapy_expansion_potential_count.py
+++ b/tests/matching/test_therapy_expansion_potential_count.py
@@ -259,3 +259,25 @@ def test_zero_component_regimen_does_not_diverge():
     patient = _patient(therapy.code)
 
     assert se.compare(base, patient) == []
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize('field', ['second_line_therapy', 'later_therapy'])
+@pytest.mark.parametrize('criterion', ['therapies_excluded', 'therapy_components_required'])
+def test_an_unexpandable_value_on_another_line_still_agrees(field, criterion, expandable_therapy):
+    """The matcher answers `first_line_therapy` from `get_user_therapies()`, which
+    folds in the other lines and the supportive rows — so an unexpandable value in
+    `second_line_therapy` drives the verdict while leaving `first_line_therapy`
+    blank. Gating the count on that field being filled left the old
+    all-six-columns fragment in place and demoted regimen-only trials."""
+    _therapy, component = expandable_therapy
+    value = component.code if 'components' in criterion else 'krd'
+    trial = TrialFactory(disease='multiple myeloma', **{criterion: [value]})
+    base = Trial.objects.filter(id=trial.id)
+    patient = PatientInfo(disease='multiple myeloma', patient_age=65, **{field: UNEXPANDABLE})
+
+    divs = se.compare(base, patient)
+
+    assert divs == [], (
+        f"{field}={UNEXPANDABLE!r} vs {criterion} diverges: "
+        f"{[(d.direction, d.matcher_unknown_attrs, d.sql_potential_attrs) for d in divs]}")

--- a/tests/matching/test_therapy_expansion_potential_count.py
+++ b/tests/matching/test_therapy_expansion_potential_count.py
@@ -281,3 +281,29 @@ def test_an_unexpandable_value_on_another_line_still_agrees(field, criterion, ex
     assert divs == [], (
         f"{field}={UNEXPANDABLE!r} vs {criterion} diverges: "
         f"{[(d.direction, d.matcher_unknown_attrs, d.sql_potential_attrs) for d in divs]}")
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize('source', ['later_therapies', 'supportive_therapies'])
+def test_an_unexpandable_value_in_a_list_source_still_agrees(source, expandable_therapy):
+    """`get_user_therapies()` folds the two JSON list sources into the same bag as
+    the scalar lines, so they have to reach the count the same way."""
+    trial = TrialFactory(disease='multiple myeloma', therapies_excluded=['krd'])
+    base = Trial.objects.filter(id=trial.id)
+    patient = PatientInfo(disease='multiple myeloma', patient_age=65,
+                          **{source: [{'therapy': UNEXPANDABLE}]})
+
+    assert se.compare(base, patient) == []
+
+
+@pytest.mark.django_db
+def test_an_empty_therapy_bag_is_left_to_is_attr_blank():
+    """The control: with no therapies at all the special fragment must not fire —
+    that state is `is_attr_blank`'s, and both paths already agree on it."""
+    trial = TrialFactory(disease='multiple myeloma', therapies_excluded=['krd'])
+    base = Trial.objects.filter(id=trial.id)
+    patient = PatientInfo(disease='multiple myeloma', patient_age=65)
+
+    assert UserToTrialAttrsMapper._therapies_do_not_expand(
+        PatientInfoAttributes(patient)) is False
+    assert se.compare(base, patient) == []


### PR DESCRIPTION
Follow-up to #394: the count has to ask the therapy **bag**, not the `first_line_therapy` column.

## What #394 missed

`_match_therapy_lines_attr` answers `first_line_therapy` from `get_user_therapies()`, which folds in `second_line_therapy`, `later_therapy`, `later_therapies` and the supportive rows. `is_attr_blank` looks only at the one column. #394 gated its scoped fragment on that column being non-blank, so the two paths still disagreed whenever the value that drives the verdict sits on another line:

- **unexpandable value elsewhere** — the count kept the old all-six-columns fragment and made a regimen-only trial Potential while the matcher called it eligible;
- **expandable value elsewhere** — the count read `first_line_therapy` as unanswered and demoted a trial the matcher had already decided, `matchScore` dropping to match.

Both measured with the comparator before fixing, both now pinned:

```
blank + expandable(second)      therapies_excluded            sql=potential  matcher=eligible  DIVERGE
blank + expandable(supportive)  therapy_components_required   sql=potential  matcher=eligible  DIVERGE
```

## The change

The branch keys on the bag being non-empty, and sets `is_filled_by_user` from whether it expands: expands → answered (the matcher decides every leg from it), does not expand → the two scoped fragments as before. An empty bag is still left to `is_attr_blank`, the state both paths already agree on.

## Verified

- 8 new cases across the scalar lines, `later_therapies`, the supportive rows, the empty-bag control, and the not-eligible leg (where the hard filter is reached through the post-loop fire rather than the therapy-line dispatch). Non-vacuous: 6 of them fail against #394 as merged.
- Full suite: **1 373 passed, 5 skipped, 1 xfailed**.

## Same fix, other repo

CancerBot runs its own copy of this mapper, so the identical correction is in cancerbot-org/cancerbot#5052. Keeping the two in step is the point; letting only one of them learn this would be how the next divergence starts.

## Review status

Fresh-context review done (it is what found the expandable half) and its findings applied. **Codex's half is owed on the final state** — quota exhausted until ~18:16; result will be posted here before this should be merged.
