### PR TITLE
fix(auth): honor Identity.is_active in the house auth backends

### DIFF
--- a/accounts/authentication.py
+++ b/accounts/authentication.py
@@ -10,6 +10,9 @@ token skip ``provider.verify()`` and the DB lookup.
 
 Unlike promop, EXACT does **not** own OMOP Person/PatientInfo, so the
 identity is resolved (get-or-create) but no patient row is provisioned.
+
+Both backends reject a deactivated ``Identity`` (``is_active=False``), on the
+cached path as well as the freshly-verified one — see ``_reject_if_inactive``.
 """
 from __future__ import annotations
 
@@ -32,6 +35,21 @@ logger = logging.getLogger(__name__)
 def _token_cache_key(token: str) -> str:
     digest = hashlib.sha256(token.encode()).hexdigest()[:32]
     return f"auth:partner:{digest}"
+
+
+def _reject_if_inactive(identity: Identity) -> Identity:
+    """Raise for a deactivated Identity, mirroring DRF's own backends.
+
+    ``IsAuthenticated`` only consults ``is_authenticated``, which
+    ``AbstractBaseUser`` hardcodes to ``True`` — so without this check an
+    Identity deactivated in the admin keeps full API access. DRF's built-in
+    ``TokenAuthentication``/``BasicAuthentication`` reject inactive users
+    (rest_framework/authentication.py); these house backends must match, or
+    ``is_active`` is a control that silently does nothing.
+    """
+    if not identity.is_active:
+        raise AuthenticationFailed("User inactive or deleted.")
+    return identity
 
 
 class PartnerAuthentication(BaseAuthentication):
@@ -71,7 +89,7 @@ class PartnerAuthentication(BaseAuthentication):
             if claims is None:
                 continue
 
-            identity = self._get_or_create_identity(claims)
+            identity = _reject_if_inactive(self._get_or_create_identity(claims))
             self._to_cache(token, identity.pk, claims)
             return (identity, claims)
 
@@ -89,6 +107,10 @@ class PartnerAuthentication(BaseAuthentication):
             identity = Identity.objects.get(pk=data["pk"])
         except Identity.DoesNotExist:
             return None
+        # Checked on the cached path as well: the cache stores the verification
+        # result, not an authorization decision, so a deactivation must take
+        # effect immediately rather than after AUTH_TOKEN_CACHE_TTL.
+        _reject_if_inactive(identity)
         claims = TokenClaims(**data["claims"])
         return (identity, claims)
 
@@ -147,7 +169,11 @@ class ServiceTokenAuthentication(BaseAuthentication):
             identity.set_unusable_password()
             identity.save(update_fields=["password"])
 
-        return (identity, "service-token")
+        # Deactivating the service Identity is the kill switch for the shared
+        # service token; without this it would have no effect. Note it must be
+        # *deactivated*, not deleted — `get_or_create` above would silently
+        # re-provision a fresh, active row on the very next request.
+        return (_reject_if_inactive(identity), "service-token")
 
     def authenticate_header(self, request):
         return "Bearer"

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -9,6 +9,7 @@ import base64
 import json
 
 import pytest
+from django.core.cache import cache as django_cache
 from django.test import override_settings
 from rest_framework.test import APIClient
 
@@ -23,6 +24,19 @@ SERVICE_TOKEN = "test-service-token-value"
 @pytest.fixture
 def trial(db):
     return TrialFactory(disease="Multiple Myeloma")
+
+
+@pytest.fixture(autouse=True)
+def _clear_token_cache():
+    """The verified-token cache is LocMem and lives for the whole process.
+
+    Without this, a test that authenticates leaves an entry keyed by its bearer
+    behind, and a later test reusing the same bearer silently becomes a cache
+    hit — so correctness would rest on collection order.
+    """
+    django_cache.clear()
+    yield
+    django_cache.clear()
 
 
 def _match(client):
@@ -113,3 +127,104 @@ class TestDefaultDeny:
         client = APIClient()
         client.credentials(HTTP_AUTHORIZATION=f"Bearer {token}")
         assert _match(client).status_code == 401
+
+
+@pytest.mark.django_db
+class TestInactiveIdentityIsRejected:
+    """`is_active=False` must revoke API access on both house backends.
+
+    `IsAuthenticated` only consults `is_authenticated`, which `AbstractBaseUser`
+    hardcodes to True — so without an explicit check the admin's `is_active`
+    toggle is a control that silently does nothing, and an offboarded partner
+    keeps full access. DRF's own backends reject inactive users; these tests
+    lock the house backends to the same behaviour.
+    """
+
+    @override_settings(SERVICE_AUTH_TOKEN=SERVICE_TOKEN)
+    def test_deactivated_service_identity_is_rejected(self, trial):
+        client = APIClient()
+        client.credentials(HTTP_AUTHORIZATION=f"Bearer {SERVICE_TOKEN}")
+        assert _match(client).status_code == 200
+
+        Identity.objects.filter(
+            issuer=ServiceTokenAuthentication.SERVICE_ISSUER,
+            sub=ServiceTokenAuthentication.SERVICE_SUB,
+        ).update(is_active=False)
+
+        assert _match(client).status_code == 401
+
+    def test_deactivated_partner_identity_is_rejected_via_the_cached_path(
+        self, trial, monkeypatch
+    ):
+        """Deactivated after a successful request, so the 401 comes from the
+        cache-hit branch. The cold-cache counterpart is the test below it."""
+        monkeypatch.setattr(
+            "accounts.authentication.get_providers",
+            lambda: [_FakeFirebaseProvider()],
+        )
+        client = APIClient()
+        client.credentials(HTTP_AUTHORIZATION="Bearer fake.partner.jwt")
+        assert _match(client).status_code == 200
+
+        Identity.objects.filter(
+            issuer=_FakeFirebaseProvider.ISSUER, sub=_FakeFirebaseProvider.SUB,
+        ).update(is_active=False)
+
+        assert _match(client).status_code == 401
+
+    def test_already_inactive_partner_identity_is_rejected_on_fresh_verification(
+        self, trial, monkeypatch
+    ):
+        """Cold cache: the identity is already inactive before the first request.
+
+        Covers the freshly-verified path independently of the cached one — the
+        provider verifies the token successfully and the rejection has to come
+        from the is_active check on `_get_or_create_identity`'s result.
+        """
+        Identity.objects.create(
+            issuer=_FakeFirebaseProvider.ISSUER,
+            sub=_FakeFirebaseProvider.SUB,
+            is_active=False,
+        )
+        monkeypatch.setattr(
+            "accounts.authentication.get_providers",
+            lambda: [_FakeFirebaseProvider()],
+        )
+        client = APIClient()
+        client.credentials(HTTP_AUTHORIZATION="Bearer fake.partner.jwt")
+        assert _match(client).status_code == 401
+
+    def test_deactivation_is_not_deferred_by_the_token_cache(self, trial, monkeypatch):
+        """A deactivation must bite immediately, not after AUTH_TOKEN_CACHE_TTL.
+
+        The first request populates the verified-token cache; the second is a
+        cache hit that never reaches `provider.verify`. Without the check on
+        the cached path the deactivated identity would keep access for up to
+        `AUTH_TOKEN_CACHE_TTL` seconds.
+        """
+        verify_calls = []
+
+        class _CountingProvider(_FakeFirebaseProvider):
+            def verify(self, token):
+                verify_calls.append(token)
+                return super().verify(token)
+
+        monkeypatch.setattr(
+            "accounts.authentication.get_providers",
+            lambda: [_CountingProvider()],
+        )
+        client = APIClient()
+        client.credentials(HTTP_AUTHORIZATION="Bearer fake.partner.jwt")
+
+        assert _match(client).status_code == 200
+        assert _match(client).status_code == 200
+        # Second request was served from the cache, so the deactivation below
+        # exercises the cached path rather than a fresh verification.
+        assert len(verify_calls) == 1
+
+        Identity.objects.filter(
+            issuer=_FakeFirebaseProvider.ISSUER, sub=_FakeFirebaseProvider.SUB,
+        ).update(is_active=False)
+
+        assert _match(client).status_code == 401
+        assert len(verify_calls) == 1


### PR DESCRIPTION
Part of the security-audit follow-up tracked in #397.

## The problem

`IsAuthenticated` only consults `request.user.is_authenticated`, which `AbstractBaseUser` hardcodes to `True`. Neither `PartnerAuthentication` nor `ServiceTokenAuthentication` ever read `Identity.is_active` — so unticking the admin's **is_active** box revoked nothing.

An offboarded partner kept full access to every `/trials/*` endpoint until Firebase itself revoked the token, which is a different system under different ownership. The operator saw the account marked inactive and got no signal that the control had done nothing. For SOC 2, "access is revoked on termination" is currently a control we cannot evidence.

DRF's own backends reject inactive users (`rest_framework/authentication.py:103,205`) — these two were the exception, not the rule.

Confirmed by probe before the fix:

```
is_active=True  -> is_authenticated=True  IsAuthenticated grants access: True
is_active=False -> is_authenticated=True  IsAuthenticated grants access: True
```

## The change

`_reject_if_inactive` raises `AuthenticationFailed` for a deactivated `Identity`, applied at all three sites that can return an authenticated tuple: partner fresh verification, partner cache hit, and the service token.

Raising rather than returning `None` is deliberate: a recognised credential attached to a disabled account is an *invalid* credential, not "this backend didn't handle it". That matches DRF's own token backend and stops a revoked credential from silently falling through to a later authenticator.

The cache path is covered too. The verified-token cache stores the *verification result*, not an authorization decision, so a deactivation has to bite immediately rather than after `AUTH_TOKEN_CACHE_TTL` (60s by default).

## Tests

Four new tests in `tests/test_auth.py`, each verified to fail without the change:

- deactivated **service** identity → 401
- deactivated **partner** identity → 401
- **already-inactive** identity on a cold cache → 401 (exercises the fresh-verification path independently)
- deactivation is **not deferred by the token cache** — asserts the second request never re-entered `provider.verify`, so it genuinely tests the cached branch rather than passing for the wrong reason

`tests/test_auth.py`: 11 passed.

## Review

Reviewed cold by a second model and by Codex. Codex's one substantive note — that the fresh-verification path was not independently tested — is addressed by the third test above.
