### PR TITLE
fix(docker): a failed DB probe must not authorise DROP SCHEMA

### DIFF
--- a/docker/init_patients_db.sh
+++ b/docker/init_patients_db.sh
@@ -31,16 +31,57 @@ if [ -z "$PATIENT_DATABASE_URL" ]; then
 fi
 
 log "Checking patients database status..."
-row_count="$(psql "$PATIENT_DATABASE_URL" -tAXc \
-    'SELECT COUNT(*) FROM patient_info' 2>/dev/null || true)"
-row_count="${row_count//[[:space:]]/}"
 
-if [[ "$row_count" =~ ^[0-9]+$ ]] && [ "$row_count" -gt 0 ]; then
-    log "patient_info already populated (${row_count} rows) — skipping restore."
-    exit 0
+# Probe in three steps, so that a FAILED probe can never be mistaken for "the
+# database is empty". The previous single-shot form
+#     row_count="$(psql ... 2>/dev/null || true)"
+# collapsed every failure mode — unreachable host, wrong credentials, missing
+# SELECT grant, renamed table — into an empty string. That
+# empty string failed the numeric test below and fell through to
+# `DROP SCHEMA public CASCADE`, destroying a database that may well have been
+# fully populated. Only a probe that succeeds AND genuinely reports "no table"
+# or "zero rows" may authorise the restore.
+if ! probe_err="$(psql "$PATIENT_DATABASE_URL" -tAXc 'SELECT 1' 2>&1 >/dev/null)"; then
+    log "ERROR: cannot query PATIENT_DATABASE_URL — refusing to restore."
+    log "       A failed probe is not evidence that the database is empty."
+    if [ -n "$probe_err" ]; then log "       psql: ${probe_err}"; fi
+    exit 1
 fi
 
-log "patient_info is empty or missing — restoring from backup."
+table_ref="$(psql "$PATIENT_DATABASE_URL" -tAXc "SELECT to_regclass('public.patient_info')")" || {
+    log "ERROR: could not probe for patient_info — refusing to restore."
+    exit 1
+}
+table_ref="${table_ref//[[:space:]]/}"
+
+if [ -z "$table_ref" ]; then
+    # Absent from public, but visible through search_path elsewhere? Then this
+    # database is not the fresh one it looks like, and dropping public would be
+    # destroying a schema we never inspected.
+    if [ -n "$(psql "$PATIENT_DATABASE_URL" -tAXc "SELECT to_regclass('patient_info')" 2>/dev/null | tr -d '[:space:]')" ]; then
+        log "ERROR: patient_info resolves outside schema public — refusing to restore."
+        exit 1
+    fi
+fi
+
+if [ -n "$table_ref" ]; then
+    row_count="$(psql "$PATIENT_DATABASE_URL" -tAXc 'SELECT COUNT(*) FROM public.patient_info')" || {
+        log "ERROR: patient_info exists but could not be counted (permissions?) — refusing to restore."
+        exit 1
+    }
+    row_count="${row_count//[[:space:]]/}"
+    if ! [[ "$row_count" =~ ^[0-9]+$ ]]; then
+        log "ERROR: unexpected row-count output '${row_count}' — refusing to restore."
+        exit 1
+    fi
+    if [ "$row_count" -gt 0 ]; then
+        log "patient_info already populated (${row_count} rows) — skipping restore."
+        exit 0
+    fi
+    log "patient_info exists and is empty — restoring from backup."
+else
+    log "patient_info does not exist — restoring from backup."
+fi
 log "Backup source: $PATIENT_DATABASE_BACKUP_URL"
 
 backup_file="$(mktemp --suffix=.sql.gz)"

--- a/docker/init_trials_db.sh
+++ b/docker/init_trials_db.sh
@@ -31,16 +31,57 @@ case "${TRIALS_DATABASE_INIT_FROM_BACKUP,,}" in
 esac
 
 log "Checking trials database status..."
-row_count="$(psql "$TRIALS_DATABASE_URL" -tAXc \
-    'SELECT COUNT(*) FROM trials_trial' 2>/dev/null || true)"
-row_count="${row_count//[[:space:]]/}"
 
-if [[ "$row_count" =~ ^[0-9]+$ ]] && [ "$row_count" -gt 0 ]; then
-    log "trials_trial already populated (${row_count} rows) — skipping restore."
-    exit 0
+# Probe in three steps, so that a FAILED probe can never be mistaken for "the
+# database is empty". The previous single-shot form
+#     row_count="$(psql ... 2>/dev/null || true)"
+# collapsed every failure mode — unreachable host, wrong credentials, missing
+# SELECT grant, renamed table — into an empty string. That
+# empty string failed the numeric test below and fell through to
+# `DROP SCHEMA public CASCADE`, destroying a database that may well have been
+# fully populated. Only a probe that succeeds AND genuinely reports "no table"
+# or "zero rows" may authorise the restore.
+if ! probe_err="$(psql "$TRIALS_DATABASE_URL" -tAXc 'SELECT 1' 2>&1 >/dev/null)"; then
+    log "ERROR: cannot query TRIALS_DATABASE_URL — refusing to restore."
+    log "       A failed probe is not evidence that the database is empty."
+    if [ -n "$probe_err" ]; then log "       psql: ${probe_err}"; fi
+    exit 1
 fi
 
-log "trials_trial is empty or missing — restoring from backup."
+table_ref="$(psql "$TRIALS_DATABASE_URL" -tAXc "SELECT to_regclass('public.trials_trial')")" || {
+    log "ERROR: could not probe for trials_trial — refusing to restore."
+    exit 1
+}
+table_ref="${table_ref//[[:space:]]/}"
+
+if [ -z "$table_ref" ]; then
+    # Absent from public, but visible through search_path elsewhere? Then this
+    # database is not the fresh one it looks like, and dropping public would be
+    # destroying a schema we never inspected.
+    if [ -n "$(psql "$TRIALS_DATABASE_URL" -tAXc "SELECT to_regclass('trials_trial')" 2>/dev/null | tr -d '[:space:]')" ]; then
+        log "ERROR: trials_trial resolves outside schema public — refusing to restore."
+        exit 1
+    fi
+fi
+
+if [ -n "$table_ref" ]; then
+    row_count="$(psql "$TRIALS_DATABASE_URL" -tAXc 'SELECT COUNT(*) FROM public.trials_trial')" || {
+        log "ERROR: trials_trial exists but could not be counted (permissions?) — refusing to restore."
+        exit 1
+    }
+    row_count="${row_count//[[:space:]]/}"
+    if ! [[ "$row_count" =~ ^[0-9]+$ ]]; then
+        log "ERROR: unexpected row-count output '${row_count}' — refusing to restore."
+        exit 1
+    fi
+    if [ "$row_count" -gt 0 ]; then
+        log "trials_trial already populated (${row_count} rows) — skipping restore."
+        exit 0
+    fi
+    log "trials_trial exists and is empty — restoring from backup."
+else
+    log "trials_trial does not exist — restoring from backup."
+fi
 log "Backup source: $TRIALS_DATABASE_BACKUP_URL"
 
 backup_file="$(mktemp --suffix=.sql.gz)"


### PR DESCRIPTION
Part of the security-audit follow-up tracked in #397.

## The problem

The restore guard in both bootstrap scripts read:

```bash
row_count="$(psql ... 2>/dev/null || true)"
```

`2>/dev/null || true` collapsed **every** failure mode — unreachable host, wrong credentials, missing `SELECT` grant, renamed table, wrong `search_path` — into an empty string. That empty string failed the `^[0-9]+$` test and fell straight through to:

```bash
psql ... -c 'DROP SCHEMA IF EXISTS public CASCADE; CREATE SCHEMA public;'
```

against a database that may have been fully populated. No attacker needed: a permissions change or a schema rename, followed by any container restart with the flag on, destroys the schema and replaces it with a stale dump. The guard written to prevent exactly that was the thing that failed open.

Demonstrated on the pre-change script with an unreachable database:

```
[init_patients_db] Checking patients database status...
[init_patients_db] patient_info is empty or missing — restoring from backup.
[init_patients_db] !!! WOULD NOW DROP SCHEMA public CASCADE AND RESTORE !!!
```

## The change

Probe in three steps and abort on any probe failure:

1. connectivity (`SELECT 1`)
2. table existence (`to_regclass('public.<table>')`)
3. the count

Only a probe that **succeeds** and genuinely reports "no table" or "zero rows" now authorises the restore. Using `to_regclass` rather than error-string matching keeps the legitimate fresh-database path working — a first-run bootstrap still restores normally.

Both the existence check and the count are schema-qualified to `public`, the schema the restore actually drops. Leaving the count to resolve through `search_path` would let an empty same-named table in another schema authorise dropping a populated `public` — caught in review, and the intermediate revision of this patch did exactly that.

## Verification

Against a real PostgreSQL 17 under bash 5 (these scripts use `${VAR,,}`, so bash 4+):

| scenario | result |
|---|---|
| table absent (fresh DB) | proceed to restore |
| populated | skip, exit 0 |
| unreachable host | **refuse**, exit 1 |
| table present, `SELECT` revoked | **refuse**, exit 1 |
| `search_path=alt` (empty) with `public` populated | skip, exit 0 |

The pre-change script reached the DROP in the unreachable-host case; the intermediate revision reached it in the `search_path` case. Both now refuse.

## Not in scope

The scripts keep a pre-existing inconsistency: patients errors out when init is enabled but its URL is missing, while trials silently skips. Left alone to keep this diff to the safety fix.
