### PR TITLE
fix(matching): a NULL *_required column is no constraint to the filter either (#383 follow-up)

### DIFF
--- a/matcher_app/exact_matching/querysets/trial.py
+++ b/matcher_app/exact_matching/querysets/trial.py
@@ -1215,11 +1215,18 @@ class TrialQuerySet(models.QuerySet):
 
     def eligible_for_therapy_related_things_from_lines(self, therapy_codes: list[str], has_no_prior_therapy=False, patient_component_ids: list[str] | None = None, patient_class_ids: list[str] | None = None) -> models.QuerySet:
         if has_no_prior_therapy:
-            return self.filter(**{
-                f'{THERAPY_MATCH_PROFILE.therapies_required}__exact': [],
-                f'{THERAPY_MATCH_PROFILE.therapy_components_required}__exact': [],
-                f'{THERAPY_MATCH_PROFILE.therapy_types_required}__exact': [],
-            })
+            # Same NULL reading as the sibling filter below and as the count and
+            # the matcher (#383 / cb#4832): `__exact: []` alone misses a NULL
+            # column, so a treatment-naive patient lost every trial whose
+            # `*_required` is NULL while the matcher called them eligible.
+            def no_requirement(column):
+                return Q(**{f'{column}__exact': []}) | Q(**{f'{column}__isnull': True})
+
+            return self.filter(
+                no_requirement(THERAPY_MATCH_PROFILE.therapies_required)
+                & no_requirement(THERAPY_MATCH_PROFILE.therapy_components_required)
+                & no_requirement(THERAPY_MATCH_PROFILE.therapy_types_required)
+            )
 
         # The regimen (from-lines) filter needs therapy_codes, but OMOP component-only
         # patients (#224) have none while still carrying consumer-supplied components /

--- a/matcher_app/exact_matching/querysets/trial.py
+++ b/matcher_app/exact_matching/querysets/trial.py
@@ -1198,8 +1198,17 @@ class TrialQuerySet(models.QuerySet):
 
         values = [str(x).strip() for x in values]
 
+        # `__isnull` alongside `__exact: []`: a NULL jsonb column is "no list
+        # constraint". #383 (cb#4832) gave the count and the matcher that reading —
+        # `potential_attrs_to_check` tests `IS NULL OR = '[]'` and
+        # `_match_therapy_things` coalesces — but left the hard filter behind, so a
+        # NULL `*_required` column dropped the trial from the list while the matcher
+        # called the same patient eligible. Verified with the comparator before
+        # fixing: sql=not_eligible, matcher=eligible.
         return self.filter(
-            Q(**{f'{required_attr_name}__has_any_keys': values}) | Q(**{f'{required_attr_name}__exact': []})
+            Q(**{f'{required_attr_name}__has_any_keys': values})
+            | Q(**{f'{required_attr_name}__exact': []})
+            | Q(**{f'{required_attr_name}__isnull': True})
         ).exclude(
             Q(**{f'{excluded_attr_name}__has_any_keys': values})
         )

--- a/tests/matching/test_null_required_column_filter.py
+++ b/tests/matching/test_null_required_column_filter.py
@@ -9,7 +9,10 @@ reachable from data alone.
 """
 import pytest
 
-from trials.models import Therapy, TherapyComponent, TherapyComponentConnection, Trial
+from trials.models import (
+    TherapyComponentCategory, TherapyComponentCategoryConnection,
+    TherapyComponentConnection, Trial,
+)
 from trials.services.matching import status_equivalence as se
 from trials.services.patient_info.patient_info import PatientInfo
 from tests.factories import TherapyComponentFactory, TherapyFactory, TrialFactory
@@ -23,9 +26,21 @@ NULLABLE_REQUIRED = [
 
 @pytest.fixture
 def resolvable_therapy(db):
+    """A regimen that expands all the way to a drug-class type.
+
+    The category matters: without it `derive_component_and_type_values` yields
+    `therapy_types == []`, the `elif therapy_types:` guard skips
+    `eligible_for_therapy_types` entirely, and the `therapy_types_required`
+    parametrization below asserts a column the filter never looks at.
+    """
     therapy = TherapyFactory()
     component = TherapyComponentFactory()
     TherapyComponentConnection.objects.create(therapy=therapy, component=component)
+    # get_or_create: the seeded test vocab already carries the real categories.
+    category, _ = TherapyComponentCategory.objects.get_or_create(
+        code='chemotherapy_(alkylating_agent)',
+        defaults={'title': 'Chemotherapy (alkylating agent)'})
+    TherapyComponentCategoryConnection.objects.create(category=category, component=component)
     return therapy
 
 
@@ -66,3 +81,36 @@ def test_a_populated_required_column_still_excludes(resolvable_therapy):
 
     assert se.sql_status_map(base, patient) == {trial.id: 'not_eligible'}
     assert se.compare(base, patient) == []
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize('null_column', NULLABLE_REQUIRED)
+def test_a_treatment_naive_patient_keeps_a_null_required_trial(null_column):
+    """The `has_no_prior_therapy` branch of the same filter carried the same bug.
+
+    A patient who has had no therapy at all is a coherent, common state, and the
+    branch kept only trials whose three `*_required` columns are `[]` — missing
+    NULL exactly as the sibling filter did, so the trial vanished from the list
+    while the matcher (which coalesces) called the patient eligible.
+    """
+    trial = TrialFactory(disease='multiple myeloma')
+    Trial.objects.filter(id=trial.id).update(**{null_column: None})
+    trial.refresh_from_db()
+    patient = PatientInfo(disease='multiple myeloma', patient_age=65,
+                          prior_therapy='None')
+    base = Trial.objects.filter(id=trial.id)
+
+    assert se.sql_status_map(base, patient) == {trial.id: 'eligible'}
+    assert se.compare(base, patient) == []
+
+
+@pytest.mark.django_db
+def test_a_treatment_naive_patient_still_loses_a_required_trial():
+    """Guard against over-firing on the same branch: a real requirement still
+    excludes a patient who has had no therapy."""
+    trial = TrialFactory(disease='multiple myeloma', therapies_required=['krd'])
+    patient = PatientInfo(disease='multiple myeloma', patient_age=65,
+                          prior_therapy='None')
+    base = Trial.objects.filter(id=trial.id)
+
+    assert se.sql_status_map(base, patient) == {trial.id: 'not_eligible'}

--- a/tests/matching/test_null_required_column_filter.py
+++ b/tests/matching/test_null_required_column_filter.py
@@ -1,0 +1,68 @@
+"""A NULL `*_required` column is no constraint — to the filter too (#383 follow-up).
+
+cb#4832 / #383 gave the potential count and the matcher one reading of a NULL
+jsonb list ("no constraint", same as `[]`), and left the hard filter with the
+other: `Q(required__has_any_keys=values) | Q(required__exact=[])` matches neither
+for NULL, so the trial was dropped from the list while the matcher called the
+same patient eligible. The therapy list columns are `null=True`, so this is
+reachable from data alone.
+"""
+import pytest
+
+from trials.models import Therapy, TherapyComponent, TherapyComponentConnection, Trial
+from trials.services.matching import status_equivalence as se
+from trials.services.patient_info.patient_info import PatientInfo
+from tests.factories import TherapyComponentFactory, TherapyFactory, TrialFactory
+
+NULLABLE_REQUIRED = [
+    'therapies_required',
+    'therapy_components_required',
+    'therapy_types_required',
+]
+
+
+@pytest.fixture
+def resolvable_therapy(db):
+    therapy = TherapyFactory()
+    component = TherapyComponentFactory()
+    TherapyComponentConnection.objects.create(therapy=therapy, component=component)
+    return therapy
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize('null_column', NULLABLE_REQUIRED)
+def test_a_null_required_column_does_not_drop_the_trial(null_column, resolvable_therapy):
+    trial = TrialFactory(disease='multiple myeloma')
+    Trial.objects.filter(id=trial.id).update(**{null_column: None})
+    trial.refresh_from_db()
+    patient = PatientInfo(disease='multiple myeloma', patient_age=65,
+                          first_line_therapy=resolvable_therapy.code)
+    base = Trial.objects.filter(id=trial.id)
+
+    assert se.sql_status_map(base, patient) == {trial.id: 'eligible'}
+    assert se.compare(base, patient) == []
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize('null_column', NULLABLE_REQUIRED)
+def test_an_empty_required_column_is_unchanged(null_column, resolvable_therapy):
+    """Guard: `[]` already meant no constraint and must keep meaning it."""
+    trial = TrialFactory(disease='multiple myeloma', **{null_column: []})
+    patient = PatientInfo(disease='multiple myeloma', patient_age=65,
+                          first_line_therapy=resolvable_therapy.code)
+    base = Trial.objects.filter(id=trial.id)
+
+    assert se.sql_status_map(base, patient) == {trial.id: 'eligible'}
+
+
+@pytest.mark.django_db
+def test_a_populated_required_column_still_excludes(resolvable_therapy):
+    """Guard against over-firing: a real requirement the patient cannot meet still
+    drops the trial."""
+    trial = TrialFactory(disease='multiple myeloma', therapies_required=['krd'])
+    patient = PatientInfo(disease='multiple myeloma', patient_age=65,
+                          first_line_therapy=resolvable_therapy.code)
+    base = Trial.objects.filter(id=trial.id)
+
+    assert se.sql_status_map(base, patient) == {trial.id: 'not_eligible'}
+    assert se.compare(base, patient) == []


### PR DESCRIPTION
Follow-up to #383: the filter never got the NULL reading that the count and the matcher did.

## The gap

Three places decide the same thing and must agree on what a NULL jsonb list column means. #383 (cb#4832) gave the potential count `IS NULL OR = '[]'::jsonb` and the matcher `required_list or []`, and left both branches of the filter with `__exact: []`, which matches neither NULL nor anything else. Measured with the comparator before fixing:

```
therapies_required NULL:           sql=not_eligible  matcher=eligible
therapy_components_required NULL:  sql=not_eligible  matcher=eligible
treatment-naive patient (prior_therapy='None') + NULL *_required: same shape
```

The columns are `null=True`, so this is reachable from data alone — one trial in the CancerBot production catalog carries a NULL therapy column, and the same shape is what makes CB's matcher raise (cancerbot#5047).

The direction matters: the trial disappears from the list for a patient the matcher says qualifies. That is the false-negative the `status_equivalence` docstring names as the one to avoid.

## The change

`__isnull` alongside `__exact: []` on the **required** side of both branches — the ordinary filter and the `has_no_prior_therapy` one, which had the identical bug one function above.

The **excluded** side is deliberately untouched, and both reviewers checked the argument: `has_any_keys` on NULL is not true, `.exclude()` removes only true matches, so a NULL excluded list already excludes nothing — which is what "no constraint" means there.

## Verified

- 9 tests: all three required columns × both filter branches, plus over-firing guards (a populated requirement still excludes, an empty one is unchanged).
- Non-vacuous, and one of them nearly wasn't: the `therapy_types_required` parametrization passed with the fix reverted because the fixture's component had no category, so `derive_component_and_type_values` returned `therapy_types == []` and the `elif therapy_types:` guard skipped the types filter entirely. The fixture now expands all the way to a drug-class type, and the parametrization is real.
- Full suite: **1 392 passed, 5 skipped, 2 xfailed**.

## Known, not fixed here

`'null'::jsonb` — the JSON scalar, as distinct from SQL NULL — is matched by none of `__isnull`, `__exact: []` or `has_any_keys`, while the matcher's `or []` coalesces it. 0 such rows in the CancerBot catalog and nothing writes one (the field default is `list`), so it is noted rather than handled.

## Companion

CancerBot needs all three halves, not just this one, and its matcher raises rather than diverging: cancerbot-org/cancerbot#5074.

## Review

Fresh-context and codex, both on the final state. The no-prior branch and the vacuous fixture above are their findings.
