### PR TITLE
fix(security): attacker-controlled input 500s the auth path before verification (#405)

### DIFF
--- a/accounts/authentication.py
+++ b/accounts/authentication.py
@@ -159,7 +159,35 @@ class ServiceTokenAuthentication(BaseAuthentication):
         if not header.startswith("Bearer "):
             return None
 
-        if not hmac.compare_digest(header[7:], secret):
+        # Compare bytes, not str. `hmac.compare_digest` raises TypeError when
+        # either str argument is non-ASCII, and Django hands the header over
+        # latin-1-decoded, so any byte in 0x80-0xFF arrives here as a non-ASCII
+        # str. `Authorization: Bearer <0xE9>` was therefore an anonymous 500 --
+        # the same defect as #405, one authenticator earlier and needing no JWT
+        # shape at all, since this class runs first in DEFAULT_AUTHENTICATION_CLASSES.
+        #
+        # `latin-1` and not `utf-8`, because it is the *inverse* of what the
+        # server did: gunicorn (util.py: `str(b, 'latin1')`) and Django's ASGI
+        # handler both decode header bytes latin-1, so re-encoding latin-1
+        # reconstructs the bytes the client actually sent. Encoding utf-8 here
+        # double-encodes them, and a non-ASCII SERVICE_AUTH_TOKEN would then
+        # never match -- a silent, permanent 401 with nothing in the log. DRF
+        # uses the same inverse (`HTTP_HEADER_ENCODING = 'iso-8859-1'`).
+        #
+        # The secret is encoded utf-8 because that is how `os.environ` decoded
+        # it, with `surrogateescape` so env bytes that were not valid UTF-8
+        # cannot raise here on every request.
+        try:
+            presented = header[7:].encode("latin-1")
+        except UnicodeEncodeError:
+            # Unreachable from the wire -- latin-1 covers every byte -- but a
+            # test client can put an arbitrary str into META directly, and this
+            # method must stay total.
+            return None
+
+        if not hmac.compare_digest(
+            presented, secret.encode("utf-8", "surrogateescape")
+        ):
             return None
 
         identity, created = Identity.objects.get_or_create(

--- a/accounts/providers/base.py
+++ b/accounts/providers/base.py
@@ -33,6 +33,29 @@ def decode_jwt_unverified(token: str) -> dict[str, Any] | None:
         return None
 
 
+def unverified_str_claim(payload: dict[str, Any] | None, name: str) -> str:
+    """Read one claim out of an *unverified* payload as a string, or "".
+
+    Everything in the unverified payload is attacker-controlled: it is decoded
+    without a signature check, by design, because routing has to happen before
+    anyone can verify. `decode_jwt_unverified` already refuses a non-object
+    payload, but a well-formed object can still carry a claim of the wrong
+    type -- `{"iss": ["x"]}`, `{"iss": 5}` -- and a provider that reaches for
+    a string method on it raises before any provider verifies anything. That
+    is an anonymous 500 on the authentication path (#405).
+
+    Routing decisions here are prefix or equality comparisons, and a non-string
+    claim can never match one, so collapsing it to "" is not lossy *for that
+    kind of routing*: it routes exactly as a missing claim does. A provider that
+    routed on a claim's absence would lose the distinction -- none exists, and
+    the merge would still only reach `verify()`, not past it.
+    """
+    if payload is None:
+        return ""
+    value = payload.get(name)
+    return value if isinstance(value, str) else ""
+
+
 @dataclass
 class TokenClaims:
     """Normalized result of a successful token verification."""

--- a/accounts/providers/firebase.py
+++ b/accounts/providers/firebase.py
@@ -6,7 +6,7 @@ from typing import Any
 from django.conf import settings
 from rest_framework.exceptions import AuthenticationFailed
 
-from .base import TokenClaims, TokenProvider
+from .base import TokenClaims, TokenProvider, unverified_str_claim
 
 logger = logging.getLogger(__name__)
 
@@ -21,10 +21,12 @@ class FirebaseTokenProvider(TokenProvider):
     """
 
     def can_handle(self, token: str, unverified_payload: dict[str, Any] | None) -> bool:
-        if unverified_payload is None:
-            return False
-        iss = unverified_payload.get("iss", "")
-        return iss.startswith(FIREBASE_ISS_PREFIX)
+        # `unverified_str_claim`, not `.get("iss", "")`: the default handles a
+        # missing claim but not one of the wrong type, and `.startswith` on a
+        # list or an int is an anonymous 500 here (#405).
+        return unverified_str_claim(unverified_payload, "iss").startswith(
+            FIREBASE_ISS_PREFIX
+        )
 
     def verify(self, token: str) -> TokenClaims | None:
         try:

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -228,3 +228,176 @@ class TestInactiveIdentityIsRejected:
 
         assert _match(client).status_code == 401
         assert len(verify_calls) == 1
+
+
+def _jwt_with_payload(payload: dict) -> str:
+    """A JWT-shaped string whose payload decodes to *payload*.
+
+    The signature is nonsense on purpose: `can_handle` runs on the payload
+    decoded WITHOUT verification, so routing happens before any signature is
+    checked. That is what makes every field here attacker-controlled.
+    """
+    def _b64(obj):
+        raw = json.dumps(obj).encode()
+        return base64.urlsafe_b64encode(raw).decode().rstrip("=")
+
+    return f'{_b64({"alg": "none"})}.{_b64(payload)}.not-a-signature'
+
+
+class TestUnverifiedClaimTypes:
+    """A hostile `iss` type must route, not raise (#405).
+
+    `decode_jwt_unverified` already refuses a payload that is not an object,
+    but an object can still carry a claim of the wrong type. `.startswith` on
+    a list or an int raises `AttributeError` before any provider verifies
+    anything -- an anonymous caller turning one header into a 500.
+    """
+
+    HOSTILE = [
+        ["https://securetoken.google.com/p"],
+        5,
+        {"nested": "object"},
+        None,
+        True,
+    ]
+
+    @pytest.mark.parametrize("iss", HOSTILE)
+    def test_every_registered_provider_survives_a_hostile_iss(self, iss):
+        """Asserted across the registry, not just Firebase.
+
+        `can_handle` is the only place today that reads the unverified payload
+        before verification. Iterating every configured provider is what keeps
+        it that way when a second provider is added.
+        """
+        from accounts.providers.base import decode_jwt_unverified
+        from accounts.providers.registry import get_providers
+
+        # Every claim hostile, not just `iss`: a second provider routing on
+        # `aud` or a custom claim would reproduce #405 exactly, and a test that
+        # only poisons `iss` would pass while it did.
+        payload = {key: iss for key in ("iss", "aud", "sub", "tid", "azp")}
+        token = _jwt_with_payload(payload)
+        unverified = decode_jwt_unverified(token)
+
+        assert unverified is not None, "the payload is a valid object; only its claims are hostile"
+
+        providers = get_providers()
+        assert providers, (
+            "an empty registry would make this loop assert nothing; "
+            "PARTNER_AUTH_PROVIDERS must be configured for this guard to guard"
+        )
+
+        for provider in providers:
+            # The assertion is that this does not raise. A provider may
+            # legitimately answer True or False.
+            provider.can_handle(token, unverified)
+
+    @pytest.mark.django_db
+    def test_a_hostile_iss_is_rejected_not_a_500(self, trial):
+        """One representative value end to end.
+
+        `test_every_registered_provider_survives_a_hostile_iss` already covers
+        every hostile type at unit level; running all five through the HTTP
+        stack and the DB fixture would buy nothing but wall-clock.
+        """
+        client = APIClient()
+        client.credentials(
+            HTTP_AUTHORIZATION=f'Bearer {_jwt_with_payload({"iss": ["x"], "sub": "u1"})}'
+        )
+
+        response = _match(client)
+
+        assert response.status_code == 401, (
+            "a hostile unverified claim must be an authentication refusal, "
+            "not a server error"
+        )
+
+    def test_a_well_formed_iss_still_routes_to_firebase(self):
+        """The guard must not break routing -- otherwise it would 'fix' #405
+        by making every Firebase token unroutable."""
+        from accounts.providers.base import decode_jwt_unverified
+        from accounts.providers.firebase import FirebaseTokenProvider
+
+        token = _jwt_with_payload(
+            {"iss": "https://securetoken.google.com/exact-test", "sub": "u1"}
+        )
+
+        assert FirebaseTokenProvider().can_handle(
+            token, decode_jwt_unverified(token)
+        ) is True
+
+    def test_a_missing_iss_does_not_route(self):
+        from accounts.providers.base import decode_jwt_unverified
+        from accounts.providers.firebase import FirebaseTokenProvider
+
+        token = _jwt_with_payload({"sub": "u1"})
+
+        assert FirebaseTokenProvider().can_handle(
+            token, decode_jwt_unverified(token)
+        ) is False
+
+
+@pytest.mark.django_db
+class TestNonAsciiBearerIsNotA500:
+    """`Authorization: Bearer <non-ascii>` must be a refusal, not a crash.
+
+    `hmac.compare_digest` raises TypeError when either str argument is
+    non-ASCII, and Django hands the header over latin-1-decoded, so any byte in
+    0x80-0xFF arrives as a non-ASCII str. `ServiceTokenAuthentication` runs
+    FIRST in DEFAULT_AUTHENTICATION_CLASSES, so this needs no JWT shape and no
+    provider at all -- one header from an anonymous caller.
+
+    Same class as #405, found while reviewing its fix.
+    """
+
+    # What actually arrives. An HTTP header carries bytes; Django decodes them
+    # latin-1, so a client sending UTF-8 Cyrillic produces a str of characters
+    # in 0x80-0xFF -- the mojibake below, not the original text. Parametrising
+    # on unencodable strings would only test Django's test client, which
+    # refuses to encode them at all.
+    @pytest.mark.parametrize(
+        "bearer",
+        [
+            "\u00e9",
+            "caf\u00e9",
+            "\u0442\u043e\u043a\u0435\u043d".encode("utf-8").decode("latin-1"),
+            "\U0001f600".encode("utf-8").decode("latin-1"),
+            "\u00ff" * 64,
+        ],
+    )
+    def test_non_ascii_bearer_is_rejected(self, trial, bearer):
+        with override_settings(SERVICE_AUTH_TOKEN=SERVICE_TOKEN):
+            client = APIClient()
+            client.credentials(HTTP_AUTHORIZATION=f"Bearer {bearer}")
+
+            assert _match(client).status_code == 401
+
+    def test_the_real_service_token_still_authenticates(self, trial):
+        """The byte comparison must not break the credential it guards."""
+        with override_settings(SERVICE_AUTH_TOKEN=SERVICE_TOKEN):
+            client = APIClient()
+            client.credentials(HTTP_AUTHORIZATION=f"Bearer {SERVICE_TOKEN}")
+
+            assert _match(client).status_code == 200
+
+    def test_a_non_ascii_service_token_still_authenticates(self, trial):
+        """The inverse of the server's decode must be latin-1, not utf-8.
+
+        gunicorn (`str(b, 'latin1')`) and Django's ASGI handler both decode
+        header bytes latin-1. An honest client holding a non-ASCII token sends
+        its UTF-8 bytes; those arrive decoded latin-1. Re-encoding them utf-8
+        double-encodes -- `b'caf\xc3\xa9'` becomes `b'caf\xc3\x83\xc2\xa9'` --
+        and the token then never matches, forever, with nothing in the log.
+        A silent permanent 401 is a worse failure than the 500 this replaced.
+        """
+        token = "café-token"
+        wire_bytes = token.encode("utf-8")
+
+        with override_settings(SERVICE_AUTH_TOKEN=token):
+            client = APIClient()
+            # What the server sees after its own latin-1 decode.
+            client.credentials(
+                HTTP_AUTHORIZATION=f"Bearer {wire_bytes.decode('latin-1')}"
+            )
+
+            assert _match(client).status_code == 200


### PR DESCRIPTION
Closes #405.

## Two anonymous 500s, not one

The issue names the first. The second was found while reviewing the fix for the first, and is fixed here rather than filed separately: it is the same defect one authenticator earlier, and shipping half a class would be worse than widening the scope.

**1. A non-string `iss`** — `can_handle` did `unverified_payload.get("iss", "").startswith(PREFIX)`. The `""` default covers a *missing* claim, not one of the wrong *type*. `{"iss": ["x"]}`, `5`, `{}`, `null`, `true` all reach `.startswith` on a non-string and raise. The payload comes from `decode_jwt_unverified` — decoded **without** a signature check, by design, because routing has to happen before anyone can verify — so it is entirely attacker-controlled. No key, no account, no prior request.

**2. A non-ASCII bearer token** — `hmac.compare_digest` raises `TypeError` on a non-ASCII `str`, and the server decodes the `Authorization` header latin-1, so any byte in `0x80–0xFF` arrives as one. `Authorization: Bearer <0xE9>` is the whole exploit, and `ServiceTokenAuthentication` runs **first** in `DEFAULT_AUTHENTICATION_CLASSES`, so it needs no JWT shape at all.

Neither is an authentication bypass: both raise before anything is verified, so nothing is granted. The cost is availability on an anonymously reachable path, and noise in the monitoring where a real attack would have to be noticed.

## The fixes

1. `unverified_str_claim` in `providers/base.py` — the rule put where it generalises, so any provider reading an unverified payload gets it.
2. `hmac.compare_digest(header[7:].encode("latin-1"), secret.encode("utf-8", "surrogateescape"))`.

`latin-1` because it is the **inverse** of the server's own decode. A first draft used `utf-8`, which double-encodes: `b'caf\xc3\xa9'` → `b'caf\xc3\x83\xc2\xa9'`. A non-ASCII `SERVICE_AUTH_TOKEN` would then never have matched again — silently, permanently, with nothing in the log. That is a worse failure than the 500 it replaced, and `test_a_non_ascii_service_token_still_authenticates` fails if it comes back. DRF uses the same inverse (`HTTP_HEADER_ENCODING = 'iso-8859-1'`).

## Verification

- **11 of 26 tests fail against `origin/2omop`**; all 26 pass with the change. Full `tests/` suite: **1411 passed**, 5 skipped, 2 xfailed.
- Review fuzzed 576 realistic hostile `Authorization` headers — every byte `0x80–0xFF`, random latin-1 strings, JWTs with 9 hostile claim types across `iss`/`aud`/`sub`/`uid`: **0 responses ≥500 on this branch, 138 of 266 crash on `origin/2omop`**. Both defects confirmed independently of my own tests.
- No collision: `utf-8`+`surrogatepass` was checked exhaustively over all 1,114,112 code points and by brute force to length 3 — no two inputs share bytes, so no bypass was ever introduced.
- The registry test poisons **every** claim, not just `iss`, and asserts the registry is non-empty — an empty one would make the loop assert nothing.

## Corrections made during review, recorded

Two claims of mine were false and are fixed, not softened:

1. The `utf-8` inverse above.
2. "`surrogatepass` because latin-1 decoding can leave lone surrogates" — it cannot. latin-1 maps `0x00–0xFF` onto `U+0000–U+00FF` and nothing else, so no byte on the wire produces one. Measured, then deleted.

Worth stating because this repository has a recent history of comments asserting controls that do not exist, and I added two while fixing an instance of it.
