### PR TITLE
fix(security): the DB password must not reach a psql command line (#403)

### DIFF
--- a/docker/init_patients_db.sh
+++ b/docker/init_patients_db.sh
@@ -30,6 +30,18 @@ if [ -z "$PATIENT_DATABASE_URL" ]; then
     exit 1
 fi
 
+# Move the password out of argv before any psql call (#403). psql invocations
+# below use "$PSQL_DSN"; the credential travels in PGPASSWORD, which
+# /proc/<pid>/environ keeps owner-only, instead of in a world-readable argv.
+# psql_dsn_split covers the URI form this deployment uses and REFUSES (exits
+# non-zero, aborting the container start) on a `?password=` query or keyword
+# conninfo rather than passing a credentialed string through as if it were
+# clean -- a silent pass would make the sentence above false exactly where it
+# mattered.
+# shellcheck source=docker/psql_dsn.sh
+source "$(dirname "${BASH_SOURCE[0]}")/psql_dsn.sh"
+psql_dsn_split "$PATIENT_DATABASE_URL"
+
 log "Checking patients database status..."
 
 # Probe in three steps, so that a FAILED probe can never be mistaken for "the
@@ -41,14 +53,14 @@ log "Checking patients database status..."
 # `DROP SCHEMA public CASCADE`, destroying a database that may well have been
 # fully populated. Only a probe that succeeds AND genuinely reports "no table"
 # or "zero rows" may authorise the restore.
-if ! probe_err="$(psql "$PATIENT_DATABASE_URL" -tAXc 'SELECT 1' 2>&1 >/dev/null)"; then
+if ! probe_err="$(psql "$PSQL_DSN" -tAXc 'SELECT 1' 2>&1 >/dev/null)"; then
     log "ERROR: cannot query PATIENT_DATABASE_URL — refusing to restore."
     log "       A failed probe is not evidence that the database is empty."
     if [ -n "$probe_err" ]; then log "       psql: ${probe_err}"; fi
     exit 1
 fi
 
-table_ref="$(psql "$PATIENT_DATABASE_URL" -tAXc "SELECT to_regclass('public.patient_info')")" || {
+table_ref="$(psql "$PSQL_DSN" -tAXc "SELECT to_regclass('public.patient_info')")" || {
     log "ERROR: could not probe for patient_info — refusing to restore."
     exit 1
 }
@@ -58,14 +70,14 @@ if [ -z "$table_ref" ]; then
     # Absent from public, but visible through search_path elsewhere? Then this
     # database is not the fresh one it looks like, and dropping public would be
     # destroying a schema we never inspected.
-    if [ -n "$(psql "$PATIENT_DATABASE_URL" -tAXc "SELECT to_regclass('patient_info')" 2>/dev/null | tr -d '[:space:]')" ]; then
+    if [ -n "$(psql "$PSQL_DSN" -tAXc "SELECT to_regclass('patient_info')" 2>/dev/null | tr -d '[:space:]')" ]; then
         log "ERROR: patient_info resolves outside schema public — refusing to restore."
         exit 1
     fi
 fi
 
 if [ -n "$table_ref" ]; then
-    row_count="$(psql "$PATIENT_DATABASE_URL" -tAXc 'SELECT COUNT(*) FROM public.patient_info')" || {
+    row_count="$(psql "$PSQL_DSN" -tAXc 'SELECT COUNT(*) FROM public.patient_info')" || {
         log "ERROR: patient_info exists but could not be counted (permissions?) — refusing to restore."
         exit 1
     }
@@ -98,10 +110,10 @@ with urllib.request.urlopen(url, timeout=30) as resp, open(dest, "wb") as out:
 PY
 
 log "Backup downloaded ($(du -h "$backup_file" | cut -f1)). Recreating public schema..."
-psql "$PATIENT_DATABASE_URL" -v ON_ERROR_STOP=1 -c \
+psql "$PSQL_DSN" -v ON_ERROR_STOP=1 -c \
     'DROP SCHEMA IF EXISTS public CASCADE; CREATE SCHEMA public;'
 
 log "Restoring backup into patients database..."
-gunzip -c "$backup_file" | psql "$PATIENT_DATABASE_URL" -v ON_ERROR_STOP=1 -q
+gunzip -c "$backup_file" | psql "$PSQL_DSN" -v ON_ERROR_STOP=1 -q
 
 log "Done."

--- a/docker/init_trials_db.sh
+++ b/docker/init_trials_db.sh
@@ -21,6 +21,18 @@ if [ -z "$TRIALS_DATABASE_URL" ]; then
     exit 0
 fi
 
+# Move the password out of argv before any psql call (#403). psql invocations
+# below use "$PSQL_DSN"; the credential travels in PGPASSWORD, which
+# /proc/<pid>/environ keeps owner-only, instead of in a world-readable argv.
+# psql_dsn_split covers the URI form this deployment uses and REFUSES (exits
+# non-zero, aborting the container start) on a `?password=` query or keyword
+# conninfo rather than passing a credentialed string through as if it were
+# clean -- a silent pass would make the sentence above false exactly where it
+# mattered.
+# shellcheck source=docker/psql_dsn.sh
+source "$(dirname "${BASH_SOURCE[0]}")/psql_dsn.sh"
+psql_dsn_split "$TRIALS_DATABASE_URL"
+
 case "${TRIALS_DATABASE_INIT_FROM_BACKUP,,}" in
     1|true|yes|on) ;;
     *)
@@ -41,14 +53,14 @@ log "Checking trials database status..."
 # `DROP SCHEMA public CASCADE`, destroying a database that may well have been
 # fully populated. Only a probe that succeeds AND genuinely reports "no table"
 # or "zero rows" may authorise the restore.
-if ! probe_err="$(psql "$TRIALS_DATABASE_URL" -tAXc 'SELECT 1' 2>&1 >/dev/null)"; then
+if ! probe_err="$(psql "$PSQL_DSN" -tAXc 'SELECT 1' 2>&1 >/dev/null)"; then
     log "ERROR: cannot query TRIALS_DATABASE_URL — refusing to restore."
     log "       A failed probe is not evidence that the database is empty."
     if [ -n "$probe_err" ]; then log "       psql: ${probe_err}"; fi
     exit 1
 fi
 
-table_ref="$(psql "$TRIALS_DATABASE_URL" -tAXc "SELECT to_regclass('public.trials_trial')")" || {
+table_ref="$(psql "$PSQL_DSN" -tAXc "SELECT to_regclass('public.trials_trial')")" || {
     log "ERROR: could not probe for trials_trial — refusing to restore."
     exit 1
 }
@@ -58,14 +70,14 @@ if [ -z "$table_ref" ]; then
     # Absent from public, but visible through search_path elsewhere? Then this
     # database is not the fresh one it looks like, and dropping public would be
     # destroying a schema we never inspected.
-    if [ -n "$(psql "$TRIALS_DATABASE_URL" -tAXc "SELECT to_regclass('trials_trial')" 2>/dev/null | tr -d '[:space:]')" ]; then
+    if [ -n "$(psql "$PSQL_DSN" -tAXc "SELECT to_regclass('trials_trial')" 2>/dev/null | tr -d '[:space:]')" ]; then
         log "ERROR: trials_trial resolves outside schema public — refusing to restore."
         exit 1
     fi
 fi
 
 if [ -n "$table_ref" ]; then
-    row_count="$(psql "$TRIALS_DATABASE_URL" -tAXc 'SELECT COUNT(*) FROM public.trials_trial')" || {
+    row_count="$(psql "$PSQL_DSN" -tAXc 'SELECT COUNT(*) FROM public.trials_trial')" || {
         log "ERROR: trials_trial exists but could not be counted (permissions?) — refusing to restore."
         exit 1
     }
@@ -98,10 +110,10 @@ with urllib.request.urlopen(url, timeout=30) as resp, open(dest, "wb") as out:
 PY
 
 log "Backup downloaded ($(du -h "$backup_file" | cut -f1)). Recreating public schema..."
-psql "$TRIALS_DATABASE_URL" -v ON_ERROR_STOP=1 -c \
+psql "$PSQL_DSN" -v ON_ERROR_STOP=1 -c \
     'DROP SCHEMA IF EXISTS public CASCADE; CREATE SCHEMA public;'
 
 log "Restoring backup into trials database..."
-gunzip -c "$backup_file" | psql "$TRIALS_DATABASE_URL" -v ON_ERROR_STOP=1 -q
+gunzip -c "$backup_file" | psql "$PSQL_DSN" -v ON_ERROR_STOP=1 -q
 
 log "Done."

--- a/docker/psql_dsn.sh
+++ b/docker/psql_dsn.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# Move a password out of a libpq DSN and into PGPASSWORD (#403).
+#
+# Sourced by the init scripts, which shell out to psql with a connection string
+# carrying the patient- or trials-DB password. Command-line arguments are
+# world-readable: any local process can read /proc/<pid>/cmdline, and `ps` shows
+# argv to every user on the host. These scripts run unattended in the deployed
+# container, so this is the exposure that matters most -- more than the
+# hand-run analysis commands fixed alongside them.
+#
+# Usage:
+#   source "$(dirname "${BASH_SOURCE[0]}")/psql_dsn.sh"
+#   psql_dsn_split "$SOME_DATABASE_URL"    # sets PSQL_DSN, exports PGPASSWORD
+#   psql "$PSQL_DSN" ...
+#
+# It assigns rather than echoes on purpose. A `dsn="$(fn "$url")"` form runs the
+# function in a command-substitution subshell, so `export PGPASSWORD` there
+# never reaches the caller: the DSN would come back stripped and the password
+# would be gone entirely, turning a credential leak into an auth failure.
+#
+# Coverage, stated so the callers' comments do not claim more: this handles the
+# URI form `scheme://user:password@host/db`. `?password=` in the query and
+# keyword conninfo (`host=h password=s`) are NOT handled -- psql_dsn_split
+# refuses them loudly rather than passing a credentialed string through as if
+# it were clean. The Python twin (trials/services/psql_dsn.py) handles all
+# three; this one covers what the deployment actually uses and fails closed on
+# the rest.
+
+# Percent-decode via python3 rather than `printf '%b' "${1//%/\x}"`.
+# That expansion is not a percent decoder: it also interprets backslash escapes
+# already present in the password, so `new\nline` becomes a real newline,
+# `back\slash` loses its backslash, and `\c` truncates the credential outright
+# with no error. A bare `%` not followed by two hex digits makes printf write to
+# stderr. python3 is already in this image and is what the Python twin uses, so
+# the two implementations decode identically by construction.
+_psql_dsn_percent_decode() {
+    python3 -c 'import sys,urllib.parse;sys.stdout.write(urllib.parse.unquote(sys.argv[1]))' "$1"
+}
+
+# Fail closed: a DSN that still carries a credential must stop the script, not
+# be handed to psql while the caller believes it was cleaned.
+_psql_dsn_refuse() {
+    echo "[psql_dsn] ERROR: $1" >&2
+    echo "[psql_dsn] refusing to run psql with a credential in argv (#403)." >&2
+    return 1
+}
+
+psql_dsn_split() {
+    local dsn="$1"
+    local scheme rest authority tail userinfo hostinfo user password
+
+    PSQL_DSN="$dsn"
+    [ -n "$dsn" ] || return 0
+
+    # `tr` rather than ${dsn,,}: the latter needs bash 4+, and keeping this
+    # portable is what makes the function testable outside the container.
+    local lowered
+    lowered="$(printf '%s' "$dsn" | tr '[:upper:]' '[:lower:]')"
+    case "$lowered" in
+        postgres://*|postgresql://*) ;;
+        *)
+            # Keyword conninfo. Not handled here -- refuse if it carries one.
+            if [[ "$dsn" =~ (^|[[:space:]])password[[:space:]]*= ]]; then
+                _psql_dsn_refuse "keyword conninfo carries password=" || return 1
+            fi
+            return 0
+            ;;
+    esac
+
+    scheme="${dsn%%://*}"
+    rest="${dsn#*://}"
+
+    # The authority ends at the first '/'. Splitting on the whole remainder
+    # would let a '@' in the PATH decide the split: for
+    # postgresql://reader:s@h:5432/pat@ients the host became "ients" and the
+    # password became garbage -- and a DSN with no password at all was rewritten
+    # into an unusable one with a bogus PGPASSWORD exported.
+    if [[ "$rest" == */* ]]; then
+        authority="${rest%%/*}"
+        tail="/${rest#*/}"
+    else
+        authority="$rest"
+        tail=""
+    fi
+
+    # The last '@' of the authority separates userinfo from host, so a '@'
+    # inside the password does not truncate the host.
+    if [[ "$authority" == *"@"* ]]; then
+        userinfo="${authority%@*}"
+        hostinfo="${authority##*@}"
+        if [[ "$userinfo" == *":"* ]]; then
+            user="${userinfo%%:*}"
+            password="${userinfo#*:}"
+            if [ -n "$password" ]; then
+                PGPASSWORD="$(_psql_dsn_percent_decode "$password")"
+                export PGPASSWORD
+            fi
+            if [ -n "$user" ]; then
+                authority="$user@$hostinfo"
+            else
+                authority="$hostinfo"
+            fi
+        fi
+    fi
+
+    PSQL_DSN="$scheme://$authority$tail"
+
+    # Same check the Python twin makes, on the value actually about to be used.
+    if [[ "$PSQL_DSN" =~ ^[^:]+://[^/]*:[^/]*@ ]]; then
+        _psql_dsn_refuse "authority still contains a password" || return 1
+    fi
+    if [[ "$PSQL_DSN" =~ [?\&](password|sslpassword)= ]]; then
+        _psql_dsn_refuse "query string still contains a password" || return 1
+    fi
+    return 0
+}

--- a/scripts/trials4patients.sh
+++ b/scripts/trials4patients.sh
@@ -90,8 +90,11 @@ echo ""
 echo "=============================================="
 echo "Step 2: Run trial search for patients (direct DB)"
 echo "=============================================="
+# --source-db-url deliberately omitted: the command already defaults to
+# os.environ['PATIENT_DATABASE_URL'], and passing it here would put the
+# password into this process's own argv for the whole run -- longer-lived than
+# the psql child that #403 fixed, and just as world-readable.
 SEARCH_ARGS=(
-  --source-db-url "$PATIENT_DATABASE_URL"
   --limit "$SEARCH_LIMIT"
   --output /tmp/exact_local_test_results.json
 )

--- a/tests/test_psql_credentials.py
+++ b/tests/test_psql_credentials.py
@@ -1,0 +1,408 @@
+"""The patient-DB password must never reach a psql command line (#403).
+
+Command-line arguments are world-readable: any local process can read
+`/proc/<pid>/cmdline`, `ps` shows argv to every user on the host, and it lands
+in shell history and process-accounting logs. The credential here opens the
+patient database.
+
+The last class is the one that matters most. The commands are copies of the
+same helper, so a fix applied to one and not the others closes the ticket while
+the other callers keep the defect. That test scans every management command --
+discovered from the directory, not from a hardcoded list, so a NEW command
+that shells out to psql is guarded the day it is written -- and fails if any of
+them puts a non-literal into a psql argv.
+
+What it does not catch, stated so the guard is not read as wider than it is:
+`shell=True` with an interpolated command string, and an argv list built in a
+variable before the call. Both are visible in review; neither is what the
+copies did. Everything it DOES catch is enumerated in
+`TestTheGuardActuallyGuards`, which drives the guard itself rather than
+describing it.
+"""
+import ast
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+from django.conf import settings
+
+from trials.services.psql_dsn import psql_dsn_and_env
+
+DSN_WITH_PASSWORD = 'postgresql://reader:s3cr3t@db.example.invalid:5432/patients'
+
+COMMANDS = {
+    'compare_trials.py',
+    'fetch_exact_for_patients.py',
+    'search_trials_for_patients.py',
+}
+
+
+# psql takes a conninfo string as ANY positional argument, not only the first,
+# and as the value of -d/--dbname. Everything else after a flag belongs to that
+# flag -- `-c <sql>` is a query, legitimately a variable.
+_VALUE_FLAGS = {
+    '-c', '--command', '-f', '--file', '-v', '--set', '--variable',
+    '-o', '--output', '-L', '--log-file', '-F', '--field-separator',
+    '-R', '--record-separator', '-P', '--pset', '-U', '--username',
+    '-h', '--host', '-p', '--port',
+}
+_DSN_FLAGS = {'-d', '--dbname'}
+_SUBPROCESS_FUNCS = {'run', 'call', 'check_call', 'check_output', 'Popen'}
+
+
+def _is_subprocess_call(node):
+    """`subprocess.run`, an aliased module, and the bare imported forms."""
+    func = node.func
+    if isinstance(func, ast.Attribute):
+        return func.attr in _SUBPROCESS_FUNCS
+    if isinstance(func, ast.Name):
+        return func.id in _SUBPROCESS_FUNCS
+    return False
+
+
+def _dsn_positions(argv):
+    """Every element psql could read as a connection string.
+
+    An earlier version marked only argv[0] and the value of -d/--dbname, so
+    moving a single flag ahead of the DSN -- `['psql', '--no-psqlrc', db_url]`,
+    which is the shape one of the real call sites already has -- defeated it
+    entirely.
+    """
+    positions = []
+    expect_dsn_next = False
+    for element in argv:
+        is_flag = (
+            isinstance(element, ast.Constant)
+            and isinstance(element.value, str)
+            and element.value.startswith('-')
+        )
+        if expect_dsn_next:
+            positions.append(element)
+            expect_dsn_next = False
+            if not is_flag:
+                continue
+        if is_flag:
+            if element.value in _DSN_FLAGS:
+                expect_dsn_next = True
+            elif element.value in _VALUE_FLAGS:
+                skip_next = True
+                expect_dsn_next = False
+                # the flag's value is not a DSN; drop it
+                positions.append(None)
+            continue
+        positions.append(element)
+    # `None` marks "value of a non-DSN flag" -- drop it and the element after.
+    cleaned, skip = [], False
+    for item in positions:
+        if item is None:
+            skip = True
+            continue
+        if skip:
+            skip = False
+            continue
+        cleaned.append(item)
+    return cleaned
+
+
+def psql_argv_offenders(source: str) -> list[str]:
+    """Every non-literal reaching a psql DSN position in *source*.
+
+    One implementation, called by the guard AND by the test that pins the
+    guard's reach. A second copy would drift: loosening the guard alone was
+    measured to leave the coverage test green.
+    """
+    offenders = []
+    for node in ast.walk(ast.parse(source)):
+        if not isinstance(node, ast.Call) or not _is_subprocess_call(node):
+            continue
+        if not node.args or not isinstance(node.args[0], (ast.List, ast.Tuple)):
+            continue
+        argv = node.args[0].elts
+        if not argv:
+            continue
+        first = argv[0]
+        if not (
+            isinstance(first, ast.Constant)
+            and isinstance(first.value, str)
+            and Path(first.value).name == 'psql'
+        ):
+            continue
+        for element in _dsn_positions(argv[1:]):
+            if isinstance(element, ast.Constant):
+                continue
+            if isinstance(element, ast.Name) and element.id == 'dsn':
+                continue
+            offenders.append(f'{node.lineno}: {ast.dump(element)[:70]}')
+    return offenders
+
+
+class TestPsqlDsnAndEnv:
+    def test_password_is_moved_out_of_the_dsn(self):
+        dsn, env = psql_dsn_and_env(DSN_WITH_PASSWORD)
+
+        assert 's3cr3t' not in dsn
+        assert env['PGPASSWORD'] == 's3cr3t'
+
+    def test_everything_else_survives_the_round_trip(self):
+        """A DSN that loses its host or database is a fix that breaks the tool."""
+        dsn, _ = psql_dsn_and_env(DSN_WITH_PASSWORD)
+
+        assert dsn == 'postgresql://reader@db.example.invalid:5432/patients'
+
+    def test_extra_env_is_passed_through(self):
+        _, env = psql_dsn_and_env(DSN_WITH_PASSWORD, PGSSLMODE='require')
+
+        assert env['PGSSLMODE'] == 'require'
+
+    def test_a_url_without_a_password_is_untouched(self):
+        url = 'postgresql://reader@db.example.invalid:5432/patients'
+
+        dsn, env = psql_dsn_and_env(url)
+
+        assert dsn == url
+        assert 'PGPASSWORD' not in env
+
+    def test_the_parent_environment_is_inherited_not_replaced(self):
+        """psql needs PATH, PGSSLROOTCERT and friends from the parent."""
+        _, env = psql_dsn_and_env(DSN_WITH_PASSWORD)
+
+        assert env.get('PATH') == os.environ.get('PATH')
+
+    def test_os_environ_is_not_mutated(self):
+        before = dict(os.environ)
+
+        psql_dsn_and_env(DSN_WITH_PASSWORD, PGSSLMODE='require')
+
+        assert dict(os.environ) == before, 'the helper must return a copy'
+
+    @pytest.mark.parametrize(
+        'url',
+        [
+            # `urlsplit` ends the netloc at the first `#` or `?`, so these used
+            # to come back untouched with the credential still in them --
+            # while `_assert_no_password`, which re-derived the netloc the same
+            # way, agreed that all was well. libpq reads both as passwords:
+            # verified against psql 17.2.
+            'postgresql://u:pa#ss@h/db',
+            'postgresql://u:pa?ss@h/db',
+            # libpq percent-decodes parameter NAMES too.
+            'postgresql://u@h/db?%70assword=s3cr3t',
+            # The client-key passphrase is a credential as much as `password`.
+            'postgresql://u@h/db?sslpassword=s3cr3t',
+        ],
+    )
+    def test_credentials_libpq_accepts_do_not_survive(self, url):
+        dsn, env = psql_dsn_and_env(url)
+
+        assert 's3cr3t' not in dsn and 'pa#ss' not in dsn and 'pa?ss' not in dsn
+        assert env['PGPASSWORD']
+
+    def test_an_at_sign_in_the_path_does_not_truncate_the_host(self):
+        dsn, env = psql_dsn_and_env('postgresql://reader:s3cr3t@h:5432/pat@ients')
+
+        assert dsn == 'postgresql://reader@h:5432/pat@ients'
+        assert env['PGPASSWORD'] == 's3cr3t'
+
+    def test_keyword_conninfo_whose_value_contains_a_scheme(self):
+        """`host=h options='a://b'` is conninfo, not a URI."""
+        dsn, env = psql_dsn_and_env("host=h dbname=d user=u password='a://b'")
+
+        assert 'a://b' not in dsn
+        assert env['PGPASSWORD'] == 'a://b'
+
+    def test_an_ipv6_literal_keeps_its_brackets(self):
+        """Rebuilding from urlsplit components dropped them, and psql then read
+        the port as `db8::1:5432`."""
+        dsn, _ = psql_dsn_and_env('postgresql://r:s@[2001:db8::1]:5432/pat')
+
+        assert dsn == 'postgresql://r@[2001:db8::1]:5432/pat'
+
+    def test_a_multi_host_uri_does_not_raise(self):
+        """`urlsplit().port` raises ValueError on these; libpq accepts them."""
+        url = 'postgresql://postgres@127.0.0.1:5432,127.0.0.1:5433/db'
+
+        assert psql_dsn_and_env(url)[0] == url
+
+    @pytest.mark.parametrize('password', ['p@ss:word/with?chars', 'sim ple', '%40'])
+    def test_awkward_passwords_still_leave_the_dsn(self, password):
+        from urllib.parse import quote
+
+        url = f'postgresql://reader:{quote(password, safe="")}@host.invalid:5432/db'
+
+        dsn, env = psql_dsn_and_env(url)
+
+        assert password not in dsn
+        assert quote(password, safe='') not in dsn
+        assert env['PGPASSWORD'] == password
+
+
+class TestNoCommandPassesAUrlToPsql:
+    """The regression guard for every command at once.
+
+    Reading the sources rather than calling the commands is deliberate: these
+    commands need a live patient database, so a behavioural test would not run
+    in CI, and the defect is visible in the call itself.
+    """
+
+    @staticmethod
+    def _command_files():
+        directory = Path(settings.BASE_DIR) / 'trials' / 'management' / 'commands'
+        return sorted(p for p in directory.glob('*.py') if p.name != '__init__.py')
+
+    def test_the_directory_scan_finds_the_known_callers(self):
+        """Otherwise an empty glob would make every test below vacuous."""
+        names = {p.name for p in self._command_files()}
+
+        assert COMMANDS <= names, f'expected {COMMANDS} among {sorted(names)}'
+
+    def test_no_command_puts_a_non_literal_into_a_psql_dsn_position(self):
+        offenders = []
+        for path in self._command_files():
+            for offender in psql_argv_offenders(path.read_text()):
+                offenders.append(f'{path.name}:{offender}')
+
+        assert not offenders, (
+            'a non-literal reaches a psql connection-string position, where any '
+            'local process can read it: ' + '; '.join(offenders)
+        )
+
+    @pytest.mark.parametrize('name', sorted(COMMANDS))
+    def test_the_command_calls_the_shared_helper(self, name):
+        """A substring check would pass on a stale import; assert the call."""
+        path = Path(settings.BASE_DIR) / 'trials' / 'management' / 'commands' / name
+        tree = ast.parse(path.read_text())
+
+        called = any(
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == 'psql_dsn_and_env'
+            for node in ast.walk(tree)
+        )
+
+        assert called, f'{name} shells out to psql but never calls psql_dsn_and_env'
+
+
+class TestTheGuardActuallyGuards:
+    """The guard's reach, asserted rather than described.
+
+    These call `psql_argv_offenders` -- the same function the guard above uses,
+    not a copy of it. An earlier version re-implemented the discriminating
+    lines here, and loosening the real guard left this class green: a test
+    whose whole purpose was to pin coverage noticed nothing.
+    """
+
+    CAUGHT = [
+        "subprocess.run(['psql', db_url, '-t', '-c', sql])",
+        "subprocess.run(['psql', '-d', db_url, '-c', sql])",
+        "subprocess.run(['psql', '--no-psqlrc', db_url, '-c', sql])",
+        "subprocess.run(['psql', '-tAX', db_url, '-c', sql])",
+        "subprocess.run(['psql', '-v', 'ON_ERROR_STOP=1', db_url, '-c', sql])",
+        "subprocess.run(['psql', conn, '-c', sql])",
+        "subprocess.run(['psql', f'{db_url}', '-c', sql])",
+        "subprocess.run(['psql', self.db_url, '-c', sql])",
+        "subprocess.Popen(['psql', db_url, '-c', sql])",
+        "subprocess.check_call(['psql', db_url, '-c', sql])",
+        "run(['psql', db_url, '-c', sql])",
+        "sp.run(['psql', db_url, '-c', sql])",
+        "subprocess.run(('psql', db_url, '-c', sql))",
+        "subprocess.run(['/usr/bin/psql', db_url, '-c', sql])",
+        "subprocess.check_output(['psql', db_url])",
+    ]
+    ALLOWED = [
+        "subprocess.run(['psql', dsn, '-t', '--no-psqlrc', '-c', sql])",
+        "subprocess.run(['psql', dsn, '-c', sql])",
+        "subprocess.run(['psql', '-d', dsn, '-c', sql])",
+        "subprocess.run(['psql', '--no-psqlrc', dsn, '-v', 'ON_ERROR_STOP=1'])",
+    ]
+
+    @pytest.mark.parametrize('source', CAUGHT)
+    def test_a_reintroduced_defect_is_caught(self, source):
+        assert psql_argv_offenders(source), f'guard missed: {source}'
+
+    @pytest.mark.parametrize('source', ALLOWED)
+    def test_the_fixed_shape_is_not_flagged(self, source):
+        assert not psql_argv_offenders(source), f'false positive on: {source}'
+
+
+class TestTheShellTwinAgreesWithPython:
+    """docker/psql_dsn.sh does the same job for the container init scripts.
+
+    It is the path that runs unattended on every cold start, and it had no
+    coverage at all. Two implementations of one security rule drift; these
+    tests are what notices.
+    """
+
+    @staticmethod
+    def _split(url):
+        script = Path(settings.BASE_DIR) / 'docker' / 'psql_dsn.sh'
+        result = subprocess.run(
+            [
+                'bash', '-c',
+                f'source {script}; psql_dsn_split "$1" || exit 3; '
+                'printf "%s\\n%s" "$PSQL_DSN" "${PGPASSWORD-}"',
+                '_', url,
+            ],
+            capture_output=True, text=True,
+        )
+        return result.returncode, result.stdout.split('\n')
+
+    @pytest.mark.parametrize(
+        'url',
+        [
+            'postgresql://reader:s3cr3t@db.example.invalid:5432/patients',
+            'postgresql://reader:p%40ss%20word@h:5432/db',
+            'postgresql://r:s@[2001:db8::1]:5432/pat',
+            'postgresql://reader@h:5432/patients',
+            'postgres://u:@h/db',
+        ],
+    )
+    def test_the_shell_matches_python(self, url):
+        code, (dsn, password) = self._split(url)
+        expected_dsn, expected_env = psql_dsn_and_env(url)
+
+        assert code == 0
+        assert dsn == expected_dsn
+        assert password == expected_env.get('PGPASSWORD', '')
+
+    @pytest.mark.parametrize(
+        'password,expected',
+        [
+            # `printf '%b' "${1//%/\\x}"` mangled all three: the backslash was
+            # swallowed, %0A became a literal newline via the wrong route, and
+            # `\c` truncated the credential outright with no error.
+            ('back%5Cslash', 'back\\slash'),
+            ('50%25off', '50%off'),
+            ('pass%5Cctail', 'pass\\ctail'),
+        ],
+    )
+    def test_awkward_passwords_survive_the_shell_decode(self, password, expected):
+        code, (_dsn, decoded) = self._split(f'postgresql://u:{password}@h/db')
+
+        assert code == 0
+        assert decoded == expected
+
+    @pytest.mark.parametrize(
+        'url',
+        [
+            'postgresql://reader@h/db?password=leaky',
+            'host=h dbname=d password=leaky',
+        ],
+    )
+    def test_the_shell_refuses_what_it_cannot_clean(self, url):
+        """Fail closed. A silent pass would make the init scripts' own comment
+        false exactly where it mattered."""
+        code, _ = self._split(url)
+
+        assert code == 3
+
+    def test_a_dsn_without_a_password_is_left_alone(self):
+        """An earlier version split on the last `@` of the whole remainder, so
+        a `@` in the path destroyed the host and exported a bogus password."""
+        url = 'postgresql://db.example:5432/pat@ients'
+
+        code, (dsn, password) = self._split(url)
+
+        assert code == 0
+        assert dsn == url
+        assert password == ''

--- a/trials/management/commands/compare_trials.py
+++ b/trials/management/commands/compare_trials.py
@@ -19,7 +19,8 @@ Usage
     python manage.py compare_trials \\
       --input scripts/compare_input.json \\
       --output /tmp/compare_results \\
-      --source-db-url postgresql://user:pass@host:5432/patients
+      # Reads PATIENT_DATABASE_URL from the environment. Do not pass
+      # --source-db-url with a password in it: argv is world-readable (#403).
 
 Falls back to PATIENT_DATABASE_URL env var if --source-db-url is not given.
 """
@@ -30,6 +31,7 @@ import shutil
 import subprocess
 
 from django.core.management.base import BaseCommand
+from trials.services.psql_dsn import psql_dsn_and_env
 
 logger = logging.getLogger(__name__)
 
@@ -70,9 +72,10 @@ def _psql_query_rows(db_url, sql):
     a disabled SSL mode from the parent Django/conda environment.
     """
     wrapped = f"SELECT row_to_json(t) FROM ({sql}) t"
-    env = {**os.environ, 'PGSSLMODE': 'require'}
+    # The password goes in the environment, never in argv (#403).
+    dsn, env = psql_dsn_and_env(db_url, PGSSLMODE='require')
     result = subprocess.run(
-        ['psql', db_url, '-t', '--no-psqlrc', '-c', wrapped],
+        ['psql', dsn, '-t', '--no-psqlrc', '-c', wrapped],
         capture_output=True,
         text=True,
         env=env,

--- a/trials/management/commands/fetch_exact_for_patients.py
+++ b/trials/management/commands/fetch_exact_for_patients.py
@@ -14,7 +14,9 @@ Cache layout
 Usage
 -----
     python manage.py fetch_exact_for_patients \\
-      --source-db-url $PATIENT_DATABASE_URL \\
+      # PATIENT_DATABASE_URL is read from the environment. Passing it as
+      # --source-db-url only looks out-of-band: the shell expands it before
+      # exec, putting the password in argv exactly as before (#403).
       --cache-dir ~/.cache/exact/patients \\
       --limit 10
 
@@ -40,6 +42,7 @@ from decimal import Decimal
 from pathlib import Path
 
 from django.core.management.base import BaseCommand, CommandError
+from trials.services.psql_dsn import psql_dsn_and_env
 
 logger = logging.getLogger(__name__)
 
@@ -74,9 +77,10 @@ def _psql_query_rows(db_url, sql):
     """
     import subprocess
     wrapped = f"SELECT row_to_json(t) FROM ({sql}) t"
-    env = {**os.environ, 'PGSSLMODE': 'require'}
+    # The password goes in the environment, never in argv (#403).
+    dsn, env = psql_dsn_and_env(db_url, PGSSLMODE='require')
     result = subprocess.run(
-        ['psql', db_url, '-t', '--no-psqlrc', '-c', wrapped],
+        ['psql', dsn, '-t', '--no-psqlrc', '-c', wrapped],
         capture_output=True, text=True, env=env,
     )
     if result.returncode != 0:

--- a/trials/management/commands/search_trials_for_patients.py
+++ b/trials/management/commands/search_trials_for_patients.py
@@ -8,7 +8,9 @@ web server required.
 Usage
 -----
     python manage.py search_trials_for_patients \\
-      --source-db-url postgresql://user:pass@host:5432/patients
+      # Reads PATIENT_DATABASE_URL from the environment. Do not pass
+      # --source-db-url with a password in it: the shell expands it before
+      # exec, so the credential lands in this process's argv (#403).
 
     Falls back to PATIENT_DATABASE_URL env var if --source-db-url is not given.
 
@@ -46,6 +48,7 @@ from trials.services.patient_info.promop_adapter import (
     resolve_therapy_code as _resolve_therapy_code,
 )
 from trials.services.user_to_trial_attr_matcher import UserToTrialAttrMatcher
+from trials.services.psql_dsn import psql_dsn_and_env
 
 
 
@@ -376,11 +379,12 @@ class Command(BaseCommand):
             query += f' LIMIT {int(options["patient_limit"])}'
 
         wrapped = f'SELECT row_to_json(t) FROM ({query}) t'
-        env = {**os.environ, 'PGSSLMODE': 'require'}
+        # The password goes in the environment, never in argv (#403).
+        dsn, env = psql_dsn_and_env(source_db_url, PGSSLMODE='require')
 
         try:
             result = subprocess.run(
-                ['psql', source_db_url, '-t', '--no-psqlrc', '-c', wrapped],
+                ['psql', dsn, '-t', '--no-psqlrc', '-c', wrapped],
                 capture_output=True,
                 text=True,
                 env=env,

--- a/trials/services/psql_dsn.py
+++ b/trials/services/psql_dsn.py
@@ -1,0 +1,203 @@
+"""Keep the patient-DB password out of the psql command line (#403).
+
+Command-line arguments are world-readable: any local process can read
+`/proc/<pid>/cmdline`, `ps` shows argv to every user on the host, and argv
+lands in shell history and in process-accounting or container-runtime logs.
+The credential in question opens the patient database.
+
+libpq reads `PGPASSWORD` from the environment instead, and `/proc/<pid>/environ`
+is owner-only on Linux. Upstream does not call `PGPASSWORD` the *best* answer --
+the PostgreSQL docs note that some operating systems let other users read a
+process environment -- and #403 lists `.pgpass` and `PGSERVICEFILE` alongside
+it. `PGPASSWORD` is chosen here because these commands already build a custom
+env for `PGSSLMODE`, so it needs no new file to deploy or permission to police;
+if a host is ever found where the environment is readable, the same seam moves
+to `.pgpass` without touching a call site.
+
+This module is the one place the split happens, because the call sites are
+copies of the same helper: fixing one and leaving the others is how a ticket
+reads as closed while the credential is still in argv on the other paths.
+"""
+from __future__ import annotations
+
+import os
+import re
+from urllib.parse import unquote, urlsplit, urlunsplit
+
+# `password=` as a libpq keyword-conninfo token, e.g.
+# "host=h dbname=d user=u password=s3cr3t". Values may be single-quoted.
+_KEYWORD_PASSWORD = re.compile(
+    r"(?:^|\s)password\s*=\s*(?:'((?:[^'\\]|\\.)*)'|(\S*))"
+)
+# Query parameters that carry a credential. `sslpassword` is the passphrase for
+# the client key and is just as much a secret as `password`.
+_PASSWORD_QUERY_KEYS = {"password", "sslpassword"}
+
+
+class DsnStillCarriesPassword(ValueError):
+    """Raised when a credential could not be moved out of the DSN.
+
+    Failing closed matters more than usual here: the whole point of this module
+    is that the call sites can then say "the password is not in argv". If an
+    unrecognised DSN form were passed through untouched, that sentence would be
+    false exactly where it mattered, and nothing would say so.
+    """
+
+
+def psql_dsn_and_env(db_url: str, **extra_env: str) -> tuple[str, dict[str, str]]:
+    """Split *db_url* into an argv-safe DSN and an env carrying the password.
+
+    Returns `(dsn, env)` where `dsn` has no credential in it and `env` is a copy
+    of `os.environ` with `PGPASSWORD` set when there was one, plus any
+    `extra_env` the caller needs (`PGSSLMODE`, typically).
+
+    Handles the three forms psql accepts: a URI with `user:password@`, a URI
+    with `?password=`, and keyword conninfo with a `password=` token. A DSN with
+    no password is returned unchanged.
+
+    Raises `DsnStillCarriesPassword` if a password survives the rewrite, rather
+    than returning something the caller would describe as safe.
+    """
+    env = {**os.environ, **extra_env}
+    if not db_url:
+        return db_url, env
+
+    if _is_uri(db_url):
+        dsn, password = _strip_uri_password(db_url)
+    else:
+        # A keyword value may itself contain "://" (options, a comment), so the
+        # form is decided by the scheme, not by a substring search.
+        dsn, password = _strip_keyword_password(db_url)
+
+    # An empty password is not a password. `postgres://u:@h/db` and
+    # `postgres://u@h/db` mean the same thing to libpq, but an *empty*
+    # PGPASSWORD does not mean the same as an unset one, so the credential is
+    # still stripped from the DSN while the variable is left alone.
+    if password:
+        env["PGPASSWORD"] = password
+
+    _assert_no_password(dsn)
+    return dsn, env
+
+
+def _is_uri(db_url: str) -> bool:
+    lowered = db_url.lstrip().lower()
+    return lowered.startswith("postgres://") or lowered.startswith("postgresql://")
+
+
+def _split_authority(db_url: str) -> tuple[str, str, str]:
+    """Return `(prefix, authority, tail)` by scanning the raw string.
+
+    `urlsplit` must not be used for this. It ends the netloc at the first `#`
+    or `?`, so `postgresql://u:pa#ss@h/db` gives it a netloc of `u:pa` -- no
+    `@`, nothing to strip -- and the credentialed URL is handed back untouched.
+    libpq does not stop there: verified against psql 17.2, that DSN connects to
+    host `h` with the password `pa#ss`. Reading the authority as "everything up
+    to the first `/`" matches libpq and keeps `#` and `?` inside the password
+    where they belong.
+    """
+    scheme, sep, rest = db_url.partition("://")
+    prefix = f"{scheme}{sep}"
+    slash = rest.find("/")
+    if slash == -1:
+        return prefix, rest, ""
+    return prefix, rest[:slash], rest[slash:]
+
+
+def _strip_uri_password(db_url: str) -> tuple[str, str | None]:
+    """Remove `user:password@` and `?password=` from a URI-form DSN.
+
+    The authority is edited as text rather than rebuilt from `urlsplit`'s
+    parsed components. Rebuilding loses information: `.hostname` strips the
+    brackets from an IPv6 literal, turning `[2001:db8::1]:5432` into
+    `2001:db8::1:5432`, which psql reads as a port of `db8::1:5432`; and
+    `.port` raises `ValueError` on the comma-separated multi-host URIs libpq
+    supports. Both were working configurations that a component rebuild breaks
+    into what looks like a credential problem.
+    """
+    prefix, authority, tail = _split_authority(db_url)
+
+    password: str | None = None
+    # The last `@` in the authority separates userinfo from host, so a `@`
+    # inside the password does not truncate the host.
+    userinfo, at, hostinfo = authority.rpartition("@")
+    if at and ":" in userinfo:
+        user, _, raw_password = userinfo.partition(":")
+        # `urlsplit`-style components hand back the raw, still percent-encoded
+        # substring, while libpq wants the literal password. Without `unquote`
+        # a password containing @ : / ? or a space authenticates as its encoded
+        # form and fails, and a literal '%40' is sent as '@' -- a silent
+        # authentication break that looks like a bad credential rather than a
+        # bad fix. The username stays encoded, because it goes back into a URI
+        # and libpq decodes it itself.
+        password = unquote(raw_password)
+        authority = f"{user}@{hostinfo}" if user else hostinfo
+
+    path, question, query = tail.partition("?")
+    if question:
+        query, query_password = _strip_query_password(query)
+        if password is None:
+            password = query_password
+        tail = f"{path}?{query}" if query else path
+
+    return f"{prefix}{authority}{tail}", password
+
+
+def _strip_query_password(query: str) -> tuple[str, str | None]:
+    """Drop every `password=` parameter, decoding percent-encoded keys.
+
+    libpq percent-decodes parameter *names* as well as values, so `%70assword=`
+    is `password=`. Matching the literal text would let that through while this
+    module reported success.
+    """
+    kept: list[str] = []
+    password: str | None = None
+    for pair in query.split("&"):
+        if not pair:
+            continue
+        raw_key, _, raw_value = pair.partition("=")
+        if unquote(raw_key).lower() in _PASSWORD_QUERY_KEYS:
+            if password is None:
+                password = unquote(raw_value)
+            continue
+        kept.append(pair)
+    return "&".join(kept), password
+
+
+def _strip_keyword_password(db_url: str) -> tuple[str, str | None]:
+    """Remove the `password=` token from libpq keyword conninfo."""
+    match = _KEYWORD_PASSWORD.search(db_url)
+    if not match:
+        return db_url, None
+
+    quoted, bare = match.group(1), match.group(2)
+    password = quoted.replace("\\'", "'").replace("\\\\", "\\") if quoted is not None else bare
+    stripped = (db_url[: match.start()] + " " + db_url[match.end():]).strip()
+    return re.sub(r"\s+", " ", stripped), password
+
+
+def _assert_no_password(dsn: str) -> None:
+    """Refuse to hand back a DSN that still carries a credential.
+
+    Uses the same raw-authority scan as the rewrite, not `urlsplit`. An
+    assertion that re-derives the authority differently from the code it checks
+    would agree with it exactly where both are wrong -- which is how the `#`
+    case passed silently.
+    """
+    if _is_uri(dsn):
+        _, authority, tail = _split_authority(dsn)
+        userinfo, at, _ = authority.rpartition("@")
+        if at and ":" in userinfo:
+            raise DsnStillCarriesPassword("authority still contains a password")
+        _, question, query = tail.partition("?")
+        if question:
+            for pair in query.split("&"):
+                key, _, _value = pair.partition("=")
+                if unquote(key).lower() in _PASSWORD_QUERY_KEYS:
+                    raise DsnStillCarriesPassword(
+                        f"query string still contains {unquote(key)}="
+                    )
+        return
+
+    if _KEYWORD_PASSWORD.search(dsn):
+        raise DsnStillCarriesPassword("conninfo still contains password=")


### PR DESCRIPTION
Closes #403.

## What was wrong

Management commands and the container init scripts shelled out to `psql` with the whole connection string — password included — as an argument:

```python
subprocess.run(['psql', db_url, '-t', '--no-psqlrc', '-c', wrapped], ...)
```
```bash
psql "$PATIENT_DATABASE_URL" -tAXc 'SELECT 1'
```

Command-line arguments are world-readable: any local process reads `/proc/<pid>/cmdline`, `ps` shows argv to every user on the host, and it lands in shell history and process-accounting logs. The credential opens the **patient** database.

## Scope: four call sites, not three

The issue names three management commands. The container init scripts are a fourth, with **12 psql calls** across `docker/init_{patients,trials}_db.sh` — and they are the ones that run **unattended on every cold start**, whereas the three commands are hand-run analysis tools. Both are fixed. Three further commands import their psql helpers from `compare_trials`, so they inherit it.

`scripts/trials4patients.sh` and two usage docstrings also had to change: they passed `--source-db-url "$PATIENT_DATABASE_URL"`, which *looks* out-of-band but the shell expands before exec, putting the password into the Python process's own argv for the whole run — longer-lived than the psql child.

## The parsing has to match libpq, not `urlsplit`

`urlsplit` ends the netloc at the first `#` or `?`. For `postgresql://u:pa#ss@h/db` it reports a netloc of `u:pa` — no `@`, nothing to strip — and the credentialed URL came back untouched. libpq does not stop there: verified against psql 17.2, that DSN connects to host `h` with password `pa#ss`.

The first version of this fix therefore **failed open** on it, and its own assertion agreed, because the assertion re-derived the netloc the same way. Both now scan the raw string: authority ends at the first `/`, userinfo at the last `@` of the authority.

That also preserves what a component rebuild destroys: `.hostname` strips IPv6 brackets, turning `[2001:db8::1]:5432` into a port of `db8::1:5432`, and `.port` raises on libpq's comma-separated multi-host URIs. Both were working configurations.

Also handled: `?password=` and `?sslpassword=`, with **percent-decoded parameter names** (libpq decodes names, so `%70assword=` is `password=`); keyword conninfo; and a `@` in the path, which used to truncate the host in the shell version and export a bogus `PGPASSWORD` for a DSN that had no password at all.

Both implementations **fail closed** — Python raises `DsnStillCarriesPassword`, the shell aborts the container start — rather than hand psql a credentialed string while the caller's comment says it is clean.

## Two details that are not obvious from the diff

`unquote` is required: `urlsplit`-style components return the still percent-encoded password while libpq wants the literal. Without it, a password containing `@ : / ?` or a space fails, and `%40` is sent as `@` — a silent auth break that looks like a bad credential rather than a bad fix. The username stays encoded, because libpq decodes it itself.

The shell decode is `python3 -c urllib.parse.unquote`, **not** `printf '%b' "${1//%/\x}"`. That expansion is not a percent decoder — it also interprets backslash escapes already in the password, so `back\slash` loses its backslash and `\c` truncates the credential outright with no error.

## Verification

- **52 tests**, including **12 that drive `docker/psql_dsn.sh` through bash and compare it against the Python twin field by field**. Two implementations of one rule drift; that is what notices. The shell path had no coverage at all before.
- The AST guard scans every file in the commands directory — a new command is covered the day it is written — and flags a non-literal in **any** position psql could read as a connection string, not only `argv[1]`. Moving one flag ahead of the DSN defeated the first version, and that is the shape a real call site already has.
- `TestTheGuardActuallyGuards` calls the same function the guard uses, not a copy. An earlier version re-implemented it, and loosening the real guard left the coverage test **green**; now it fails 12 tests.
- Measured: with only the callers reverted, **4 of 52 fail**; all 52 pass with the change. Full `tests/` suite: **1448 passed**, 5 skipped, 2 xfailed.

## Landing hazards caught in review, worth naming

Two things were wrong in a way `git diff HEAD` did not show:

1. The **index held a revert** of the fix — residue of the non-vacuity experiment. A plain `git commit` would have shipped the credential back into argv on all three paths, with a green-looking diff.
2. `docker/psql_dsn.sh` was **untracked**. `COPY . /app` copies only what is in the build context; a missing `source` under `set -e` aborts the entrypoint before gunicorn. The security fix would have been a cold-start outage.

Both are resolved — `git show --stat` on the commit lists all nine files — but they are the reason to check the delta rather than the branch.
