### PR TITLE
fix(security): remove the verified-token cache, which never re-read the token (#404)

### DIFF
--- a/accounts/authentication.py
+++ b/accounts/authentication.py
@@ -3,25 +3,34 @@
 ``PartnerAuthentication`` delegates to pluggable token providers configured
 in ``PARTNER_AUTH_PROVIDERS``.  Each provider first gets a lightweight
 ``can_handle()`` check (unverified JWT payload inspection — no secrets, no
-external calls) before the real ``verify()`` is invoked.  Verified tokens are
-cached (Django cache, keyed by ``SHA256(token)[:32]``) for up to
-``AUTH_TOKEN_CACHE_TTL`` seconds so repeated requests with the same Bearer
-token skip ``provider.verify()`` and the DB lookup.
+external calls) before the real ``verify()`` is invoked.
+
+Every request is verified. There is deliberately no cache of verification
+results: one used to hold the identity and claims for ``AUTH_TOKEN_CACHE_TTL``
+seconds keyed by ``SHA256(token)[:32]``, and on a hit the token itself was
+never looked at again — so an **expired** token kept working until the entry
+aged out (#404). It bought only the provider round trip, not the database
+lookup, which ran on the cached path too.
 
 Unlike promop, EXACT does **not** own OMOP Person/PatientInfo, so the
 identity is resolved (get-or-create) but no patient row is provisioned.
 
-Both backends reject a deactivated ``Identity`` (``is_active=False``), on the
-cached path as well as the freshly-verified one — see ``_reject_if_inactive``.
+Both backends reject a deactivated ``Identity`` (``is_active=False``) — see
+``_reject_if_inactive``.
+
+What removing the cache does NOT close: with
+``FIREBASE_SKIP_REVOCATION_CHECK`` set, the provider calls
+``verify_id_token(check_revoked=False)``, which validates signature, issuer,
+audience and ``exp`` but not whether the token was revoked. So a revoked token
+is still accepted until it expires, and that is a configuration decision rather
+than a code one — tracked as #410, not here.
 """
 from __future__ import annotations
 
-import hashlib
 import hmac
 import logging
 
 from django.conf import settings
-from django.core.cache import cache as django_cache
 from rest_framework.authentication import BaseAuthentication
 from rest_framework.exceptions import AuthenticationFailed
 
@@ -30,11 +39,6 @@ from .providers import get_providers
 from .providers.base import TokenClaims, decode_jwt_unverified
 
 logger = logging.getLogger(__name__)
-
-
-def _token_cache_key(token: str) -> str:
-    digest = hashlib.sha256(token.encode()).hexdigest()[:32]
-    return f"auth:partner:{digest}"
 
 
 def _reject_if_inactive(identity: Identity) -> Identity:
@@ -62,10 +66,6 @@ class PartnerAuthentication(BaseAuthentication):
 
         token = header[7:]
 
-        cached = self._from_cache(token)
-        if cached is not None:
-            return cached
-
         providers = get_providers()
         if not providers:
             return None
@@ -90,46 +90,12 @@ class PartnerAuthentication(BaseAuthentication):
                 continue
 
             identity = _reject_if_inactive(self._get_or_create_identity(claims))
-            self._to_cache(token, identity.pk, claims)
             return (identity, claims)
 
         return None
 
     def authenticate_header(self, request):
         return "Bearer"
-
-    @staticmethod
-    def _from_cache(token: str):
-        data = django_cache.get(_token_cache_key(token))
-        if data is None:
-            return None
-        try:
-            identity = Identity.objects.get(pk=data["pk"])
-        except Identity.DoesNotExist:
-            return None
-        # Checked on the cached path as well: the cache stores the verification
-        # result, not an authorization decision, so a deactivation must take
-        # effect immediately rather than after AUTH_TOKEN_CACHE_TTL.
-        _reject_if_inactive(identity)
-        claims = TokenClaims(**data["claims"])
-        return (identity, claims)
-
-    @staticmethod
-    def _to_cache(token: str, identity_pk: int, claims: TokenClaims):
-        django_cache.set(
-            _token_cache_key(token),
-            {
-                "pk": identity_pk,
-                "claims": {
-                    "issuer": claims.issuer,
-                    "sub": claims.sub,
-                    "email": claims.email,
-                    "name": claims.name,
-                    "raw": claims.raw,
-                },
-            },
-            timeout=getattr(settings, "AUTH_TOKEN_CACHE_TTL", 60),
-        )
 
     @staticmethod
     def _get_or_create_identity(claims: TokenClaims) -> Identity:

--- a/exact/settings.py
+++ b/exact/settings.py
@@ -250,7 +250,6 @@ FIREBASE_PROJECT_ID = os.environ.get('FIREBASE_PROJECT_ID', 'exact-test' if DEBU
 FIREBASE_SKIP_REVOCATION_CHECK = os.environ.get(
     'FIREBASE_SKIP_REVOCATION_CHECK', 'true' if DEBUG else 'false'
 ).lower() in ('1', 'true')
-AUTH_TOKEN_CACHE_TTL = int(os.environ.get('AUTH_TOKEN_CACHE_TTL', '60'))
 SERVICE_AUTH_TOKEN = os.environ.get('SERVICE_AUTH_TOKEN', '')
 
 # Persistent DRF tokens (username/password -> never-expiring bearer, no scope,

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -27,16 +27,28 @@ def trial(db):
 
 
 @pytest.fixture(autouse=True)
-def _clear_token_cache():
-    """The verified-token cache is LocMem and lives for the whole process.
+def _assert_no_auth_state_is_cached():
+    """There is no verified-token cache any more (#404), and there must not be.
 
-    Without this, a test that authenticates leaves an entry keyed by its bearer
-    behind, and a later test reusing the same bearer silently becomes a cache
-    hit — so correctness would rest on collection order.
+    A reintroduced cache would let one test's bearer authenticate a later test,
+    so correctness would rest on collection order -- and in production an
+    expired token would keep working until the entry aged out.
+
+    The assertion inspects LocMem's actual keyspace. An earlier version asked
+    `django_cache.get("auth:partner:sentinel")`, which can never be non-None
+    because real keys are `auth:partner:<sha256 digest>` -- so it could not
+    fail, and did not fire even with the cache fully restored.
     """
+    from django.core.cache.backends.locmem import _caches
+
     django_cache.clear()
     yield
+    leaked = [
+        key for store in _caches.values() for key in store
+        if "auth:partner:" in key
+    ]
     django_cache.clear()
+    assert not leaked, f"a verified-token cache was reintroduced: {leaked[:3]}"
 
 
 def _match(client):
@@ -153,25 +165,6 @@ class TestInactiveIdentityIsRejected:
 
         assert _match(client).status_code == 401
 
-    def test_deactivated_partner_identity_is_rejected_via_the_cached_path(
-        self, trial, monkeypatch
-    ):
-        """Deactivated after a successful request, so the 401 comes from the
-        cache-hit branch. The cold-cache counterpart is the test below it."""
-        monkeypatch.setattr(
-            "accounts.authentication.get_providers",
-            lambda: [_FakeFirebaseProvider()],
-        )
-        client = APIClient()
-        client.credentials(HTTP_AUTHORIZATION="Bearer fake.partner.jwt")
-        assert _match(client).status_code == 200
-
-        Identity.objects.filter(
-            issuer=_FakeFirebaseProvider.ISSUER, sub=_FakeFirebaseProvider.SUB,
-        ).update(is_active=False)
-
-        assert _match(client).status_code == 401
-
     def test_already_inactive_partner_identity_is_rejected_on_fresh_verification(
         self, trial, monkeypatch
     ):
@@ -194,13 +187,14 @@ class TestInactiveIdentityIsRejected:
         client.credentials(HTTP_AUTHORIZATION="Bearer fake.partner.jwt")
         assert _match(client).status_code == 401
 
-    def test_deactivation_is_not_deferred_by_the_token_cache(self, trial, monkeypatch):
-        """A deactivation must bite immediately, not after AUTH_TOKEN_CACHE_TTL.
+    def test_every_request_is_verified_again(self, trial, monkeypatch):
+        """No cached path: the second request must reach `provider.verify` too.
 
-        The first request populates the verified-token cache; the second is a
-        cache hit that never reaches `provider.verify`. Without the check on
-        the cached path the deactivated identity would keep access for up to
-        `AUTH_TOKEN_CACHE_TTL` seconds.
+        This is the property that closes #404. A verification cache returned
+        the stored identity without looking at the token again, so an expired
+        token kept authenticating until the entry aged out. Counting
+        `verify` calls asserts the absence of that path directly, rather than
+        asserting that some cache happens to be empty.
         """
         verify_calls = []
 
@@ -218,16 +212,27 @@ class TestInactiveIdentityIsRejected:
 
         assert _match(client).status_code == 200
         assert _match(client).status_code == 200
-        # Second request was served from the cache, so the deactivation below
-        # exercises the cached path rather than a fresh verification.
-        assert len(verify_calls) == 1
+
+        assert len(verify_calls) == 2, (
+            "the second request was served without re-verifying the token"
+        )
+
+    def test_deactivation_bites_on_the_next_request(self, trial, monkeypatch):
+        """`is_active` was already checked on both paths (#398); with the cache
+        gone there is only one path, and this pins that it still bites."""
+        monkeypatch.setattr(
+            "accounts.authentication.get_providers",
+            lambda: [_FakeFirebaseProvider()],
+        )
+        client = APIClient()
+        client.credentials(HTTP_AUTHORIZATION="Bearer fake.partner.jwt")
+        assert _match(client).status_code == 200
 
         Identity.objects.filter(
             issuer=_FakeFirebaseProvider.ISSUER, sub=_FakeFirebaseProvider.SUB,
         ).update(is_active=False)
 
         assert _match(client).status_code == 401
-        assert len(verify_calls) == 1
 
 
 def _jwt_with_payload(payload: dict) -> str:


### PR DESCRIPTION
Closes #404.

## What was wrong

`PartnerAuthentication` cached each verification for `AUTH_TOKEN_CACHE_TTL` (60s), keyed by `SHA256(token)[:32]`, and returned it without consulting any provider:

```python
cached = self._from_cache(token)
if cached is not None:
    return cached
```

On a hit the token itself was never looked at again, so an **expired** token kept authenticating until the entry aged out.

## Removed, not bounded

Bounding entries by the token's `exp` shrinks the window; removing the cache makes expiry exact on every request. What it cost is smaller than it looks: the cached path still ran `Identity.objects.get(pk=...)`, so the cache saved the provider call and **not** the database lookup — the docstring it replaces claimed it skipped both. `AUTH_TOKEN_CACHE_TTL` goes with it rather than surviving as a setting that controls nothing.

## The operational cost, per environment

Signing keys are not the concern: `firebase_admin/_token_gen.py:251` wraps the certificate fetch in `cachecontrol.CacheControl(requests.Session())`, held per app, so keys are cached per process and the steady-state per-request cost is an RSA verify, not an HTTPS round trip.

The uncached call is a different one. Outside `DEBUG` the default is `FIREBASE_SKIP_REVOCATION_CHECK=false` → `check_revoked=True` → `_auth_client.py:757` `get_user()` → a POST to `/accounts:lookup`, which has **no** cache. **On an environment that has not set the flag, this turns an amortised backend call into one per authenticated request.** The removed cache was absorbing it for 60s per token per process. Stated here rather than discovered later.

`exact-staging` does set the flag, so it is unaffected. That is Cloud Run configuration and unreadable from this repository — `deploy-staging.yml` passes no `--set-env-vars` — so it was read from the running service:

```
$ gcloud run services describe exact-staging --region us-central1 \
    --format="value(spec.template.spec.containers[0].env)"
DEBUG=false, FIREBASE_SKIP_REVOCATION_CHECK=true, ENVIRONMENT=staging
```

The same probe is why the LocMem claim holds: no `REDIS_URL`, and `exact/cache_config.py:65` returns LocMem without one — so the cache being removed was per-process anyway.

## What this does not close

With the flag set, `verify_id_token(check_revoked=False)` still validates signature, issuer, audience and `exp`; what it skips is the backend check for a revoked refresh token or a disabled user. A revoked token is accepted until it expires, independently of any cache — and `Identity.is_active` does not compensate: it is a local flag written only by `accounts/models.py:61` and the admin fieldset, with nothing reading Firebase's disabled or revoked state into it.

Configuration with an owner, not a code defect: **#410**. The module docstring says so where the next reader of this code will see it, not only in the tracker.

## Tests

`test_every_request_is_verified_again` counts `provider.verify` calls and requires two for two requests carrying the same bearer — asserting the absence of the cached path directly, rather than that some cache happens to be empty.

Measured: restoring `accounts/authentication.py` from `origin/2omop` fails that test and trips the autouse fixture on three more. Full `tests/` suite: **1463 passed**, 5 skipped, 2 xfailed.

## Two review corrections, recorded

1. The autouse fixture originally asked `django_cache.get("auth:partner:sentinel")`. Real keys are `auth:partner:<sha256 digest>`, so that could never be non-None — it did not fire even with the cache fully restored, while its docstring described a check it was not performing. It now inspects LocMem's actual keyspace.
2. The commit added `test_deactivation_bites_on_the_next_request` while leaving `test_deactivated_partner_identity_is_rejected_via_the_cached_path` standing — byte-identical body, and a docstring describing the branch this PR deletes. The stale one is gone.

Both are the same failure mode this repository keeps hitting: an assertion that describes a control rather than exercising it.
