### PR TITLE
Fix the bridge's mount contract, patient resolution and CSS layering

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -26,14 +26,94 @@ Federated React 19 remote that ships the `TrialMatches` component. Toolchain mir
 ```ts
 // In the host:
 import("exact_remote/TrialMatches").then(({ TrialMatches }) => { /* … */ });
-import("exact_remote/types").then(({ /* TrialMatchesProps, … */ }) => { /* … */ });
+import("exact_remote/TrialMatchesBridge").then((mod) => { /* … */ });
+import("exact_remote/types").then(({ /* TrialMatchesProps, TrialMatchesBridgeProps, … */ }) => { /* … */ });
 ```
+
+### `./TrialMatches` — React hosts
 
 The host must provide:
 
 - An `axios.AxiosInstance` with `baseURL` (typically `/api`) and `Authorization: Token <…>`.
 - A TanStack `QueryClient` (optional — the component spins up its own otherwise).
 - Either a CTOMOP `personId` or an inline `patientInfo` payload (mutually exclusive; `patientInfo` wins to match the server-side `resolve_patient_info` precedence).
+
+### `./TrialMatchesBridge` — hosts that are not React
+
+HealthTree ONE is SvelteKit, so it mounts through the provider contract instead.
+Props are data-only: the host passes `baseUrl` + `getToken` rather than a live
+axios instance, so it needs neither axios nor react-query.
+
+```ts
+const { default: provider } = await loadRemote("exact_remote/TrialMatchesBridge");
+
+await provider().render({
+  dom,                                     // the container element
+  baseUrl: "https://exact.example",        // EXACT origin
+  apiBasePath: "/api",                     // defaults to "" — pass it if the
+                                           // API is not at the origin itself
+  ctomopBaseUrl: "https://promop.example", // optional — see below
+  ctomopApiBasePath: "/api",               // optional, defaults to "/api"
+  getToken,                                // any function; see sessionKey below
+  sessionKey: auth.userId,                 // change it when the user changes
+});
+
+provider().destroy({ moduleName: "exact_remote/TrialMatchesBridge", dom });
+```
+
+The bridge sends `Authorization: Bearer <token>` — note this differs from the
+`Token <…>` scheme the `./TrialMatches` section above documents for the axios
+instance a React host builds itself.
+
+`provider()` is memoised on purpose: bridge-react keys its mounted roots in a
+map private to each factory call, so a `render` and a `destroy` that went
+through two different calls would unmount nothing.
+
+Patient resolution:
+
+- Pass `patientInfo` or `personId` and the host owns it — the bridge does not
+  fetch. An explicit prop wins on every render, including after a resolution
+  has already happened, so switching profile or starting impersonation takes
+  effect immediately.
+- Pass `ctomopBaseUrl` and nothing else, and the bridge resolves the signed-in
+  patient itself: PRomop's `/patient-info/me/`, then EXACT's
+  `/normalize-ctomop-row/`. It must be the caller's own token — EXACT's
+  server-side `person_id` resolver is disabled by default because its service
+  token is not bound to the caller (IDOR), so fetching "me" is what makes
+  PRomop enforce access. The same token goes to both origins, so it has to be
+  valid at both.
+- Pass neither and you get the same "nothing to match against" state as
+  `./TrialMatches` on its own.
+
+`sessionKey` identifies the signed-in user: change it and the bridge re-resolves,
+keep it and the bridge holds what it has. It must be a scalar that is stable
+within a session; `null`, `""`, `NaN` and booleans are treated as "not passed"
+(they are what `?? null`, `?? ""`, `Number(sub)` and `ready && id` produce when
+there is nothing to read), and an object would be a new value on every render. Without one, `getToken`'s identity is
+used as the signal instead — safe, but blunt, because a host that builds
+`getToken` inline rebuilds it on every render and each rebuild sends the user
+back to the loading state, losing their filters and the query cache. Pass a
+`sessionKey` and `getToken` can be as unstable as you like.
+
+Either way the bridge must be able to tell sessions apart: a mount reused
+across a logout/login with no changing signal keeps showing the previous
+user's matches.
+
+### Cascade-layer contract (both exports)
+
+The remote appends its stylesheet to the **host's** `<head>`, so the host
+should declare the layer order before anything else:
+
+```css
+@layer properties, theme, base, components, mf-remote, utilities;
+```
+
+Everything this remote injects goes into `mf-remote`, which puts it above the
+host's preflight (our screens still style themselves) and below the host's
+utilities (we cannot restyle the host's chrome). A host that declares no order
+still gets the layer — but note that unlayered host declarations then outrank
+every rule of ours regardless of specificity, which is the trade this contract
+makes on purpose. See `src/federation/cssLayer.ts`.
 
 ## CSS token contract
 

--- a/frontend/src/federation/TrialMatchesBridge.test.ts
+++ b/frontend/src/federation/TrialMatchesBridge.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+
+import { AxiosHeaders } from "axios";
+
+import provider, {
+  buildClient,
+  RESOLVE_TIMEOUT_MS,
+  SEARCH_TIMEOUT_MS,
+} from "./TrialMatchesBridge";
+
+describe("the exposed provider", () => {
+  it("is memoised, so render() and destroy() share one rootMap", () => {
+    // bridge-react's own factory is `() => { const rootMap = new Map(); … }`,
+    // and `destroy` no-ops when the node is not in *its* map. The documented
+    // `provider().render(…)` / `provider().destroy(…)` pair therefore
+    // unmounted nothing: the React tree, its popstate listener and its
+    // QueryClient survived, and the next mount called createRoot() on a
+    // container that already had a live root.
+    expect(provider()).toBe(provider());
+  });
+
+  it("exposes both halves of the mount contract", () => {
+    const p = provider();
+    expect(typeof p.render).toBe("function");
+    expect(typeof p.destroy).toBe("function");
+  });
+});
+
+describe("buildClient", () => {
+  const noToken = async () => undefined;
+
+  it("resolves the baseURL from the origin and the base path", () => {
+    expect(buildClient("https://exact.example/", "api", noToken, undefined).defaults.baseURL).toBe(
+      "https://exact.example/api",
+    );
+  });
+
+  it("leaves the search client untimed", () => {
+    // axios normalises an absent timeout to 0, which means "no timeout" — not
+    // a zero-length abort. Asserted through the constant, so that a timeout
+    // reintroduced here fails rather than quietly multiplying by react-query's
+    // three retries.
+    expect(SEARCH_TIMEOUT_MS).toBeUndefined();
+    expect(buildClient("https://e", "", noToken, SEARCH_TIMEOUT_MS).defaults.timeout).toBe(0);
+  });
+
+  it("bounds the resolution, which blocks the whole screen", () => {
+    expect(RESOLVE_TIMEOUT_MS).toBe(10_000);
+    expect(buildClient("https://e", "", noToken, RESOLVE_TIMEOUT_MS).defaults.timeout).toBe(
+      10_000,
+    );
+  });
+
+  it("attaches the token as a Bearer header", async () => {
+    const client = buildClient("https://e", "", async () => "tok-1", undefined);
+    const config = await runRequestInterceptor(client);
+    expect(config.headers.Authorization).toBe("Bearer tok-1");
+  });
+
+  it("sends no Authorization header when the host has no token", async () => {
+    // Better than an empty `Bearer `: the server sees an anonymous request
+    // and says so, rather than rejecting a malformed credential.
+    const client = buildClient("https://e", "", noToken, undefined);
+    const config = await runRequestInterceptor(client);
+    expect(config.headers.Authorization).toBeUndefined();
+  });
+
+  it("propagates a rejection from the token reader, so the request never goes out", async () => {
+    const client = buildClient("https://e", "", async () => {
+      throw new Error("session changed");
+    }, undefined);
+    await expect(runRequestInterceptor(client)).rejects.toThrow("session changed");
+  });
+});
+
+/** Drive the request interceptor without a network round trip. */
+async function runRequestInterceptor(
+  client: ReturnType<typeof buildClient>,
+): Promise<{ headers: Record<string, unknown> }> {
+  const handlers: { fulfilled: (c: unknown) => unknown }[] = [];
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (client.interceptors.request as any).forEach((h: { fulfilled: (c: unknown) => unknown }) =>
+    handlers.push(h),
+  );
+  // A real AxiosHeaders, not a bare object: if axios ever required `.set()`,
+  // a plain object would keep these tests green while every real request went
+  // out unauthenticated.
+  let config: unknown = { headers: new AxiosHeaders() };
+  for (const handler of handlers) config = await handler.fulfilled(config);
+  return config as { headers: Record<string, unknown> };
+}

--- a/frontend/src/federation/TrialMatchesBridge.tsx
+++ b/frontend/src/federation/TrialMatchesBridge.tsx
@@ -5,57 +5,93 @@
  * such as ht-phr. This entry serves hosts that are not React — HealthTree ONE
  * is SvelteKit — and exposes the provider contract:
  *
- *     const provider = await loadRemote("exact_remote/TrialMatchesBridge");
+ *     const { default: provider } = await loadRemote("exact_remote/TrialMatchesBridge");
  *     await provider().render({ dom, baseUrl, getToken, ... });
  *     provider().destroy({ moduleName, dom });
+ *
+ * The two `provider()` calls above must reach the same instance, and with
+ * bridge-react's own factory they do not: `createBridgeComponent` returns
+ * `() => { const rootMap = new Map(); ... }`, so each call gets a private map,
+ * and `destroy` — which is `rootMap.get(dom)` plus a no-op when absent —
+ * unmounts nothing. The React tree, its `popstate` listener and its
+ * QueryClient survive, and the next mount calls `createRoot()` on a container
+ * that already has a live root. We memoise the factory below so `provider()`
+ * is idempotent and the contract above holds as written.
  *
  * Props are data-only: the host passes `baseUrl` + `getToken` instead of a live
  * AxiosInstance, so it needs neither axios nor react-query, and EXACT keeps
  * ownership of how it calls its own API.
  * See ht-phr/docs/mf-bridge-proposal.md §6.2.
  */
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import axios, { type AxiosInstance } from "axios";
 import { createBridgeComponent } from "@module-federation/bridge-react/v19";
 
 import TrialMatches from "./TrialMatches";
-import type { TrialMatchesProps } from "./types";
+import { normalizeCtomopRow } from "./api";
+import {
+  hasUsableSessionKey,
+  joinBaseUrl,
+  nextSessionState,
+  selectBridgeView,
+  resolveSessionSignal,
+  selectPatientInfo,
+  shouldResolvePatient,
+  type PatientLoad,
+} from "./bridgeState";
+import type { PatientInfo, TrialMatchesBridgeProps } from "./types";
 
-export interface TrialMatchesBridgeProps
-  extends Omit<TrialMatchesProps, "apiClient" | "queryClient"> {
-  /** Service origin, e.g. "https://exact-staging-….run.app". */
-  baseUrl: string;
-  /**
-   * PRomop origin. When given (and no `patientInfo`/`personId` is passed), the
-   * bridge loads the signed-in patient itself: PRomop's /patient-info/me/ with
-   * the caller's own token, then EXACT's /normalize-ctomop-row/.
-   *
-   * That two-step is EXACT's business, not the host's, so it lives here rather
-   * than being reimplemented by every host. It also has to be the caller's
-   * token: EXACT's server-side `person_id` resolver is disabled by default
-   * because its CTOMOP service token is not bound to the caller and would let
-   * any person_id through (IDOR). Fetching "me" makes PRomop enforce access.
-   */
-  ctomopBaseUrl?: string;
-  /** Appended to baseUrl to form the axios baseURL. */
-  apiBasePath?: string;
-  /** Resolves the caller's bearer token; the host owns authentication. */
-  getToken?: () => Promise<string | null | undefined> | string | null | undefined;
+export type { TrialMatchesBridgeProps };
+
+/** Bounds the bridge's own patient resolution, which blocks the whole screen:
+ *  without it a hung PRomop leaves the loading state up forever, with no retry
+ *  and nothing for the user to do. Matches the dev clients
+ *  (`src/dev/exactAuth.ts`, `src/dev/ctomopClient.ts`). */
+export const RESOLVE_TIMEOUT_MS = 10_000;
+
+/** The client handed to TrialMatches gets no timeout, which is what a React
+ *  host building its own client has today.
+ *
+ *  Note this diverges from the dev harness, whose `makeExactClient`
+ *  (`src/dev/exactAuth.ts:76`) does set 10s on the same endpoint.
+ *
+ *  It runs `/trials/` — a matcher call over the whole corpus, behind a service
+ *  that cold-starts — and TrialMatches' QueryClient is built with no
+ *  `defaultOptions`, so react-query's default three retries with backoff
+ *  apply. Any per-attempt ceiling is therefore multiplied by four before the
+ *  user sees anything: a 60s budget turns a slow-but-fine search into a
+ *  four-minute failure. Bounding that belongs with whoever owns the retry
+ *  policy, not with a timeout invented here. */
+export const SEARCH_TIMEOUT_MS = undefined;
+
+type TokenReader = () => Promise<string | null | undefined>;
+
+/* Both of the misconfigurations below are silent: the screen looks like a
+ * legitimate state, so nothing tells the host developer they wired it wrong.
+ * Once per page is enough to be findable without becoming noise. */
+const warned = new Set<string>();
+function warnOnce(key: string, message: string): void {
+  if (warned.has(key)) return;
+  warned.add(key);
+  console.warn(`[exact-remote] ${message}`);
 }
 
-function buildClient(
+/** Exported for tests: this is the function that attaches the credential, so
+ *  the header, the resolved baseURL and the timeout are worth pinning. */
+export function buildClient(
   baseUrl: string,
   apiBasePath: string,
-  getToken?: TrialMatchesBridgeProps["getToken"],
+  readToken: TokenReader,
+  timeout: number | undefined,
 ): AxiosInstance {
   const client = axios.create({
-    baseURL: `${baseUrl.replace(/\/$/, "")}${apiBasePath}`,
+    baseURL: joinBaseUrl(baseUrl, apiBasePath),
     headers: { "Content-Type": "application/json" },
+    timeout,
   });
 
   client.interceptors.request.use(async (config) => {
-    if (!getToken) return config;
-    const token = await getToken();
+    const token = await readToken();
     if (token) config.headers.Authorization = `Bearer ${token}`;
     return config;
   });
@@ -63,71 +99,343 @@ function buildClient(
   return client;
 }
 
-type PatientLoad =
-  | { status: "idle" | "loading" }
-  | { status: "ready"; patientInfo: TrialMatchesProps["patientInfo"] }
-  | { status: "error" };
-
 function TrialMatchesBridgeRoot({
   baseUrl,
   apiBasePath = "",
   ctomopBaseUrl,
+  ctomopApiBasePath = "/api",
   getToken,
+  sessionKey,
   ...rest
 }: TrialMatchesBridgeProps) {
+  // TrialMatches' client is derived from props, with no ref in the path. An
+  // earlier round read `getToken` through a ref so a host rebuilding the
+  // function would not get a new AxiosInstance; that bought nothing and cost
+  // correctness. `apiClient` is in no react-query key (`hooks.ts:41`) and
+  // TrialMatches' QueryClient is scoped to its mount, so a fresh instance
+  // costs one allocation — no refetch, no lost cache. Against that, a ref
+  // written during render is not rolled back when React abandons the render,
+  // and a ref written from an effect is updated only after the children have
+  // committed, so TrialMatches' own subscription could fire through the
+  // previous getter. Deriving from props has neither failure mode.
+  //
+  // The session contract lives in `sessionSignal` below: `sessionKey` when the
+  // host passes one, `getToken`'s identity when it does not. Holding a
+  // resolved patient across a change of credentials would show one user the
+  // previous user's matches on a mount the host reused, and the fallback is
+  // the safe default rather than the cheap one — without a `sessionKey`, a
+  // host that builds `getToken` inline re-resolves on every render.
   const apiClient = useMemo(
-    () => buildClient(baseUrl, apiBasePath, getToken),
+    () =>
+      buildClient(
+        baseUrl,
+        apiBasePath,
+        async () => getToken?.(),
+        SEARCH_TIMEOUT_MS,
+      ),
     [baseUrl, apiBasePath, getToken],
   );
 
-  // Only when the host has not resolved the patient itself.
-  const shouldLoad = Boolean(ctomopBaseUrl) && !rest.patientInfo && !rest.personId;
-  const [load, setLoad] = useState<PatientLoad>({ status: shouldLoad ? "loading" : "idle" });
+  // The resolution is the one place that needs the latest getter *without*
+  // re-running: a token refresh replaces `getToken` while the session is
+  // unchanged, and a resolution in flight should carry the fresh token.
+  // Written from an effect, never during render, so a render React abandons
+  // can never touch it — and declared above the resolution effect, so within a
+  // commit the ref is current before the resolution reads it.
+  //
+  // It cannot cross a session either: a session change re-runs the resolution
+  // effect, and cleanup sets `cancelled` during that commit. An async
+  // continuation cannot interleave with a commit, so the `cancelled` check
+  // before the second call is what guarantees the row and the token belong to
+  // the same user.
+  const getTokenRef = useRef(getToken);
+  useEffect(() => {
+    getTokenRef.current = getToken;
+  });
+
+  const hasToken = getToken != null;
+  // A resolution can fail for reasons that go away: a token that had not
+  // arrived, a service that was restarting, a `getToken` the host has since
+  // replaced within the same session. None of those re-run the effect on their
+  // own, and the only escape was a page reload — which in a host that mounts
+  // this on a route is a real cost. One button covers the whole class.
+  const [retry, setRetry] = useState(0);
+  const shouldLoad = shouldResolvePatient({ ctomopBaseUrl, ...rest });
+  const [load, setLoad] = useState<PatientLoad>(
+    shouldLoad ? { status: "loading" } : { status: "idle" },
+  );
+
+  // Everything that decides *whose* profile a resolved state belongs to. The
+  // session half is compared by identity (it may be a function) and so cannot
+  // go in the string.
+  const routeKey = [
+    shouldLoad,
+    baseUrl,
+    apiBasePath,
+    ctomopBaseUrl ?? "",
+    ctomopApiBasePath,
+  ].join("|");
+  const sessionSignal: unknown = resolveSessionSignal(sessionKey, getToken);
+  const keyed = hasUsableSessionKey(sessionKey);
+  const [session, setSession] = useState({ key: routeKey, signal: sessionSignal });
+
+  // Reset here, in render, and not in the effect below. A passive effect runs
+  // after the commit, so the first frame under new credentials would still
+  // paint the previous patient's matches — one frame of somebody else's PHI,
+  // and long enough for react-query to render its cached list. This is React's
+  // documented "adjusting state when a prop changes" pattern: the re-render
+  // happens before the browser paints. `current` is used for the rest of this
+  // pass so it is correct even in the render that schedules the reset.
+  let current = load;
+  const reset = nextSessionState(session, { routeKey, sessionSignal, shouldLoad });
+  if (reset) {
+    current = reset.load;
+    setSession(reset.session);
+    setLoad(reset.load);
+  }
+
+  // `patientInfo: null` reads as "no profile" and suppresses the fetch, which
+  // is the documented contract — but `profile ?? null` is how a host with no
+  // types spells "I do not have one", and that host then sees the empty-profile
+  // screen forever with a `ctomopBaseUrl` it passed and we ignored.
+  useEffect(() => {
+    if (ctomopBaseUrl && rest.patientInfo === null) {
+      warnOnce(
+        "explicit-null-patient",
+        "`patientInfo: null` was passed alongside `ctomopBaseUrl`, so the " +
+          "signed-in patient will not be resolved. Omit `patientInfo` " +
+          "entirely to have the bridge fetch it.",
+      );
+    }
+  }, [ctomopBaseUrl, rest.patientInfo]);
+
+  // A signal that changes constantly resets the mount constantly, and each
+  // reset re-resolves the patient and takes TrialMatches' filters with it.
+  // Two spellings do that: no `sessionKey`, so an inline `getToken` is the
+  // signal and every host render is a new one; or a `sessionKey` that is not a
+  // scalar, so every host render is a new object. The second is worse and used
+  // to be unreportable, because the guard was "no sessionKey was passed".
+  //
+  // The fourth change is the threshold, not the first: a host with no
+  // `sessionKey` is *told* to hand over a new `getToken` when the user
+  // changes, so a few resets are the contract working. Only a stream of them
+  // says anything.
+  const signalChanges = useRef(0);
+  const lastSignal = useRef<unknown>(sessionSignal);
+  useEffect(() => {
+    // Count changes, not effect runs. Refs survive StrictMode's double-invoke
+    // of the mount effect, so this short-circuits the second run rather than
+    // spending the budget before the host has done anything.
+    if (Object.is(lastSignal.current, sessionSignal)) return;
+    lastSignal.current = sessionSignal;
+    signalChanges.current += 1;
+    if (signalChanges.current > 3) {
+      warnOnce(
+        "session-thrash",
+        keyed
+          ? "`sessionKey` has changed on nearly every render, so each one " +
+              "resets the mount and re-resolves the patient. Pass a scalar " +
+              "that changes only with the signed-in user, not an object."
+          : "the session signal has changed repeatedly and no usable " +
+              "`sessionKey` was passed, so `getToken`'s identity is being " +
+              "used and each change resets the mount. Pass a stable " +
+              "`getToken` plus a `sessionKey`.",
+      );
+    }
+  }, [sessionSignal, keyed]);
 
   useEffect(() => {
-    if (!shouldLoad || !ctomopBaseUrl) return;
+    // Clear a state that belongs to a previous set of props. Without this the
+    // bridge stayed on the spinner (or the error card) forever once the host
+    // supplied a patient of its own, because the effect below returns early
+    // and nothing else ever wrote the state.
+    if (!shouldLoad || !ctomopBaseUrl) {
+      setLoad((prev) => (prev.status === "idle" ? prev : { status: "idle" }));
+      return;
+    }
+
     let cancelled = false;
+    // Already set during render on a session change; this covers a first mount
+    // and a retry, without an extra render when it is a no-op.
+    setLoad((prev) => (prev.status === "loading" ? prev : { status: "loading" }));
+
+    // Both clients belong to this resolution, and read the ref rather than a
+    // captured `getToken` so a refresh mid-flight is picked up. See the note
+    // where the ref is written for why that cannot cross a session.
+    const readTokenForThisSession: TokenReader = async () => {
+      // The interceptor runs after the `cancelled` check below, so check again
+      // here rather than resting on an argument about when React commits.
+      // Aborting beats sending: a row fetched as one user must never leave
+      // under another's credentials, even into a response we would discard.
+      if (cancelled) throw new Error("[exact-remote] session changed");
+      return getTokenRef.current?.();
+    };
 
     (async () => {
       try {
-        const ctomop = buildClient(ctomopBaseUrl, "/api", getToken);
+        // Both clients belong to this resolution — the shared `apiClient` is
+        // TrialMatches' and reads the unguarded token.
+        const ctomop = buildClient(
+          ctomopBaseUrl,
+          ctomopApiBasePath,
+          readTokenForThisSession,
+          RESOLVE_TIMEOUT_MS,
+        );
+        const exact = buildClient(
+          baseUrl,
+          apiBasePath,
+          readTokenForThisSession,
+          RESOLVE_TIMEOUT_MS,
+        );
         const me = await ctomop.get("/patient-info/me/");
-        const row = (me.data as { patient_info?: Record<string, unknown> })?.patient_info;
+        const row = (me.data as { patient_info?: PatientInfo })?.patient_info;
         if (!row) {
           if (!cancelled) setLoad({ status: "ready", patientInfo: null });
           return;
         }
+        if (cancelled) return;
         // The inline path does no normalisation of its own — receptor statuses
         // to codes, TNM strings to short codes — so run EXACT's normaliser.
-        const normalized = await apiClient.post("/normalize-ctomop-row/", row);
-        if (!cancelled) {
-          setLoad({ status: "ready", patientInfo: normalized.data as TrialMatchesProps["patientInfo"] });
-        }
-      } catch {
-        if (!cancelled) setLoad({ status: "error" });
+        const normalized = await normalizeCtomopRow(exact, row);
+        if (!cancelled) setLoad({ status: "ready", patientInfo: normalized });
+      } catch (error) {
+        // A resolution that moved on is not a failure to report to whoever is
+        // looking at the screen now.
+        if (cancelled) return;
+        const httpStatus = axios.isAxiosError(error)
+          ? error.response?.status
+          : undefined;
+        // An expired token, a wrong `ctomopBaseUrl` and an outage are one
+        // message to the user but must not be one message to the operator.
+        //
+        // Scalars only, never the error object. An AxiosError carries
+        // `config.headers.Authorization` — a live bearer token — and, on the
+        // normalise call, `config.data`, which is the entire patient row. This
+        // remote runs inside somebody else's page, where console-instrumenting
+        // SDKs (Sentry breadcrumbs, Datadog RUM, LogRocket) ship console
+        // arguments off-box by default.
+        console.warn(
+          "[exact-remote] could not resolve the signed-in patient",
+          {
+            httpStatus,
+            code: axios.isAxiosError(error) ? error.code : undefined,
+            url: axios.isAxiosError(error) ? error.config?.url : undefined,
+          },
+        );
+        setLoad({ status: "error", httpStatus });
       }
     })();
 
     return () => {
       cancelled = true;
     };
-  }, [shouldLoad, ctomopBaseUrl, getToken, apiClient]);
+  }, [
+    shouldLoad,
+    baseUrl,
+    apiBasePath,
+    ctomopBaseUrl,
+    ctomopApiBasePath,
+    sessionSignal,
+    // Whether there is a getter at all, not which one. A host whose session id
+    // is ready before its token would otherwise resolve unauthenticated once
+    // and land on the error card with nothing to re-run this, because
+    // `sessionSignal` never moved.
+    hasToken,
+    retry,
+  ]);
 
-  if (load.status === "loading") {
-    return <div className="exact-root" style={{ padding: "1rem" }}>Loading your health profile…</div>;
-  }
+  const patientInfo = selectPatientInfo(rest.patientInfo, current);
+  const view = selectBridgeView({
+    shouldLoad,
+    load: current,
+    patientInfo,
+    personId: rest.personId,
+  });
 
-  if (load.status === "error") {
+  if (view === "loading") {
     return (
-      <div className="exact-root" style={{ padding: "1rem" }} role="alert">
-        Couldn't load your health profile for trial matching. Please refresh to try again.
+      <div
+        className="exact-root"
+        style={{ padding: "1rem" }}
+        role="status"
+        aria-busy="true"
+      >
+        Loading your health profile…
       </div>
     );
   }
 
-  const patientInfo = load.status === "ready" ? load.patientInfo : rest.patientInfo;
+  if (view === "error") {
+    const httpStatus = current.status === "error" ? current.httpStatus : undefined;
+    const expired = httpStatus === 401 || httpStatus === 403;
+    return (
+      <div className="exact-root" style={{ padding: "1rem" }} role="alert">
+        <p style={{ margin: "0 0 0.75rem" }}>
+          {expired
+            ? "Your session has expired. Please sign in again to see trial matches."
+            : "Couldn't load your health profile for trial matching."}
+        </p>
+        {/* Offered on 401/403 too. Signing in is the host's job, but the
+            bridge has no way to hear that it happened: a `getToken` that
+            exists and returns nothing until auth initialises resolves once,
+            401s, and nothing re-runs it — `sessionSignal` never moved and a
+            reader was always present. Without this the screen is terminal. */}
+        <button
+          type="button"
+          className="exact-btn-view"
+          // The shared button is `width: 100%` for the trial cards it was
+          // written for; here it sits under a sentence.
+          style={{ width: "auto" }}
+          onClick={() => setRetry((n) => n + 1)}
+        >
+          {expired ? "I've signed in — try again" : "Try again"}
+        </button>
+      </div>
+    );
+  }
 
-  return <TrialMatches apiClient={apiClient} {...rest} patientInfo={patientInfo} />;
+  // A known-empty profile is not an error and not a developer mistake: it is a
+  // patient who has not filled anything in yet. Left to fall through,
+  // TrialMatches renders its own "Pass a `patientInfo` payload or `personId`"
+  // developer notice — with literal <code> tags — to that user.
+  if (view === "no-profile") {
+    return (
+      <div className="exact-root" style={{ padding: "1rem" }}>
+        Add your health profile to see clinical trials matched to you.
+      </div>
+    );
+  }
+
+  // `apiClient` after the spread on purpose: it carries this bridge's auth, and
+  // an untyped host copy-pasting the React-host props must not replace it.
+  return (
+    <TrialMatches
+      {...rest}
+      apiClient={apiClient}
+      patientInfo={patientInfo}
+      // `null` is the bridge's spelling of "not given"; TrialMatches' own
+      // contract only knows `undefined`.
+      personId={rest.personId ?? undefined}
+    />
+  );
 }
 
-export default createBridgeComponent({ rootComponent: TrialMatchesBridgeRoot });
+const createProvider = createBridgeComponent({
+  rootComponent: TrialMatchesBridgeRoot,
+});
+
+let provider: ReturnType<typeof createProvider> | null = null;
+
+/** Memoised so `provider().render(…)` and `provider().destroy(…)` share one
+ *  `rootMap` — see the note at the top of this file. Roots are keyed by DOM
+ *  node inside bridge-react, so one instance still serves many mounts.
+ *
+ *  One consequence: the factory reads `federationRuntime.instance` in its
+ *  body, so the value from the first call is now frozen for the page. Every
+ *  use of it is optional-chained, so the only effect is that MF's own
+ *  `beforeBridgeRender`/`afterBridgeRender` hooks stay silent if something
+ *  calls this before the runtime registers. */
+export default function trialMatchesBridgeProvider() {
+  provider ??= createProvider();
+  return provider;
+}

--- a/frontend/src/federation/bridgeState.test.ts
+++ b/frontend/src/federation/bridgeState.test.ts
@@ -1,0 +1,270 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  hasUsableSessionKey,
+  joinBaseUrl,
+  nextSessionState,
+  selectBridgeView,
+  resolveSessionSignal,
+  selectPatientInfo,
+  shouldResolvePatient,
+  type PatientLoad,
+} from "./bridgeState";
+
+describe("joinBaseUrl", () => {
+  it("joins an origin and a path whichever way the host spells the slashes", () => {
+    for (const [origin, path] of [
+      ["https://exact.example", "/api"],
+      ["https://exact.example/", "/api"],
+      // Without normalisation this concatenated to "https://exact.exampleapi".
+      ["https://exact.example", "api"],
+      ["https://exact.example/", "api/"],
+    ] as const) {
+      expect(joinBaseUrl(origin, path)).toBe("https://exact.example/api");
+    }
+  });
+
+  it("leaves the origin alone when there is no base path", () => {
+    expect(joinBaseUrl("https://exact.example/", "")).toBe("https://exact.example");
+  });
+
+  it("keeps a multi-segment path", () => {
+    expect(joinBaseUrl("https://promop.example", "/api/v1")).toBe(
+      "https://promop.example/api/v1",
+    );
+  });
+});
+
+describe("selectPatientInfo", () => {
+  const fetched = { diseaseCode: "MM" };
+  const ready: PatientLoad = { status: "ready", patientInfo: fetched };
+
+  it("uses what the bridge resolved when the host said nothing", () => {
+    expect(selectPatientInfo(undefined, ready)).toBe(fetched);
+  });
+
+  it("lets an explicit prop win even after a patient has been resolved", () => {
+    // The wrong-patient bug: the host switches profile (or starts
+    // impersonating) and re-renders with an explicit payload, and the bridge
+    // kept matching against whoever was loaded at mount time.
+    const explicit = { diseaseCode: "FL" };
+    expect(selectPatientInfo(explicit, ready)).toBe(explicit);
+  });
+
+  it("treats an explicit null as an answer, not as 'ask again'", () => {
+    expect(selectPatientInfo(null, ready)).toBeNull();
+  });
+
+  it("passes nothing through while the resolution is still in flight", () => {
+    expect(selectPatientInfo(undefined, { status: "loading" })).toBeUndefined();
+    expect(selectPatientInfo(undefined, { status: "error" })).toBeUndefined();
+    expect(selectPatientInfo(undefined, { status: "idle" })).toBeUndefined();
+  });
+
+  it("surfaces a resolved-but-empty profile as null, not as 'nothing known'", () => {
+    expect(
+      selectPatientInfo(undefined, { status: "ready", patientInfo: null }),
+    ).toBeNull();
+  });
+});
+
+describe("shouldResolvePatient", () => {
+  it("resolves only when the host gave somewhere to ask and no answer", () => {
+    expect(shouldResolvePatient({ ctomopBaseUrl: "https://promop.example" })).toBe(true);
+  });
+
+  it("does not resolve without a PRomop origin", () => {
+    expect(shouldResolvePatient({})).toBe(false);
+  });
+
+  it("does not second-guess a host that supplied the patient", () => {
+    const ctomopBaseUrl = "https://promop.example";
+    expect(shouldResolvePatient({ ctomopBaseUrl, patientInfo: { a: 1 } })).toBe(false);
+    expect(shouldResolvePatient({ ctomopBaseUrl, patientInfo: null })).toBe(false);
+    expect(shouldResolvePatient({ ctomopBaseUrl, personId: 9009 })).toBe(false);
+  });
+
+  it("treats a null personId as no answer and still resolves", () => {
+    // `personId: pid ?? null` is the idiomatic spelling in a host that has no
+    // types to stop it, and there is no useful difference between "no person
+    // id" and "a null person id".
+    expect(shouldResolvePatient({ ctomopBaseUrl: "https://promop.example", personId: null })).toBe(
+      true,
+    );
+  });
+
+  it("treats personId 0 as an answer, however unlikely a value it is", () => {
+    expect(shouldResolvePatient({ ctomopBaseUrl: "https://promop.example", personId: 0 })).toBe(
+      false,
+    );
+  });
+});
+
+describe("selectBridgeView", () => {
+  const view = (over: Partial<Parameters<typeof selectBridgeView>[0]> = {}) =>
+    selectBridgeView({
+      shouldLoad: false,
+      load: { status: "idle" },
+      patientInfo: undefined,
+      ...over,
+    });
+
+  it("shows the spinner while resolving", () => {
+    expect(view({ load: { status: "loading" } })).toBe("loading");
+  });
+
+  it("shows the spinner in the gap before the effect starts resolving", () => {
+    // The render between the host dropping its own patient and the effect
+    // firing. Anything but "loading" flashes the developer notice for a frame.
+    expect(view({ shouldLoad: true, load: { status: "idle" } })).toBe("loading");
+  });
+
+  it("shows the error card, not a half-rendered match list", () => {
+    expect(view({ load: { status: "error", httpStatus: 401 } })).toBe("error");
+  });
+
+  it("gives a real empty state to a patient with no profile", () => {
+    // Both routes to the same answer: the bridge resolved an empty row, and
+    // the host said so outright.
+    expect(view({ shouldLoad: true, load: { status: "ready", patientInfo: null }, patientInfo: null })).toBe(
+      "no-profile",
+    );
+    expect(view({ patientInfo: null })).toBe("no-profile");
+  });
+
+  it("keeps the developer notice for a host that wired nothing up", () => {
+    // `undefined` is nobody answering, which is a wiring mistake and should
+    // stay loud rather than being dressed up as an empty profile.
+    expect(view({ patientInfo: undefined })).toBe("matches");
+  });
+
+  it("does not claim 'no profile' when a personId is in play", () => {
+    expect(view({ patientInfo: null, personId: 9009 })).toBe("matches");
+  });
+
+  it("treats a null personId as no personId", () => {
+    // Non-TypeScript hosts are the point of this bridge, and `pid ?? null` is
+    // how they spell it.
+    expect(view({ patientInfo: null, personId: null })).toBe("no-profile");
+  });
+
+  it("puts the error card ahead of the empty-profile screen", () => {
+    // Pins the branch order: a failed resolution must not be dressed up as a
+    // patient who simply has no profile.
+    expect(view({ load: { status: "error" }, patientInfo: null })).toBe("error");
+  });
+
+  it("passes through to the matches once a patient is resolved", () => {
+    expect(
+      view({ shouldLoad: true, load: { status: "ready", patientInfo: { a: 1 } }, patientInfo: { a: 1 } }),
+    ).toBe("matches");
+  });
+});
+
+describe("nextSessionState", () => {
+  const prev = { key: "true|https://e||https://p|/api", signal: "user-1" };
+
+  it("keeps what it has when nothing moved", () => {
+    expect(
+      nextSessionState(prev, { routeKey: prev.key, sessionSignal: "user-1", shouldLoad: true }),
+    ).toBeNull();
+  });
+
+  it("drops the resolved patient when the signed-in user changes", () => {
+    // The whole point: user-2 must never render against user-1's profile.
+    const next = nextSessionState(prev, {
+      routeKey: prev.key,
+      sessionSignal: "user-2",
+      shouldLoad: true,
+    });
+    expect(next).toEqual({
+      session: { key: prev.key, signal: "user-2" },
+      load: { status: "loading" },
+    });
+  });
+
+  it("compares the signal by identity, so a getToken fallback works", () => {
+    const a = () => "t";
+    const b = () => "t";
+    expect(
+      nextSessionState({ key: prev.key, signal: a }, {
+        routeKey: prev.key,
+        sessionSignal: b,
+        shouldLoad: true,
+      }),
+    ).not.toBeNull();
+    expect(
+      nextSessionState({ key: prev.key, signal: a }, {
+        routeKey: prev.key,
+        sessionSignal: a,
+        shouldLoad: true,
+      }),
+    ).toBeNull();
+  });
+
+  it("drops it when the service it was fetched from changes", () => {
+    expect(
+      nextSessionState(prev, {
+        routeKey: "true|https://other||https://p|/api",
+        sessionSignal: "user-1",
+        shouldLoad: true,
+      }),
+    ).not.toBeNull();
+  });
+
+  it("goes idle rather than to a spinner when there is nothing to resolve", () => {
+    // The host now supplies the patient itself, so a spinner would never end.
+    expect(
+      nextSessionState(prev, { routeKey: "false|x", sessionSignal: "user-1", shouldLoad: false }),
+    ).toEqual({
+      session: { key: "false|x", signal: "user-1" },
+      load: { status: "idle" },
+    });
+  });
+});
+
+describe("resolveSessionSignal", () => {
+  const getToken = () => "tok";
+
+  it("uses the session key the host gave it", () => {
+    expect(resolveSessionSignal("user-1", getToken)).toBe("user-1");
+    // 0 is a real id, unlike the spellings below.
+    expect(resolveSessionSignal(0, getToken)).toBe(0);
+  });
+
+  it("falls back to getToken for every spelling of 'I do not have one'", () => {
+    // Each of these, taken literally, would pin the signal to one value for
+    // every user and silently disable the session guard.
+    // `false` is `auth.ready && auth.userId` before auth is ready — and the
+    // quietest of the lot, because a stuck signal never thrashes and so never
+    // trips the warning either.
+    for (const key of [undefined, null, "", false, true] as const) {
+      expect(resolveSessionSignal(key, getToken)).toBe(getToken);
+      expect(hasUsableSessionKey(key)).toBe(false);
+    }
+  });
+
+  it("falls back for NaN, which would otherwise reset on every render", () => {
+    // `Number(sub)` on a non-numeric id. NaN never equals itself, so it is not
+    // a stuck signal but a permanently changing one: React's "Too many
+    // re-renders", i.e. the remote's subtree dying inside the host page.
+    expect(resolveSessionSignal(Number.NaN, getToken)).toBe(getToken);
+    expect(hasUsableSessionKey(Number.NaN)).toBe(false);
+  });
+
+  it("reports a usable key as usable", () => {
+    expect(hasUsableSessionKey("user-1")).toBe(true);
+    expect(hasUsableSessionKey(0)).toBe(true);
+  });
+});
+
+describe("nextSessionState under a NaN signal", () => {
+  it("does not reset forever when the signal is NaN", () => {
+    // Defence in depth: `resolveSessionSignal` keeps NaN out, and `Object.is`
+    // means it would still settle if one arrived another way.
+    const prev = { key: "k", signal: Number.NaN };
+    expect(
+      nextSessionState(prev, { routeKey: "k", sessionSignal: Number.NaN, shouldLoad: true }),
+    ).toBeNull();
+  });
+});

--- a/frontend/src/federation/bridgeState.ts
+++ b/frontend/src/federation/bridgeState.ts
@@ -1,0 +1,171 @@
+/* Pure helpers behind `TrialMatchesBridge`.
+ *
+ * They live outside the component so the two decisions that decide *which
+ * patient's data reaches the matcher* can be unit-tested without a DOM: the
+ * bridge itself has no test harness in this repo (no jsdom, no
+ * @testing-library), and "which patient" is not something to leave to a
+ * manual check.
+ */
+
+import type { PatientInfo } from "./types";
+
+/** Outcome of the bridge's self-driven `/patient-info/me/` resolution. */
+export type PatientLoad =
+  /** Nothing to resolve — the host supplied the patient, or no `ctomopBaseUrl`. */
+  | { status: "idle" }
+  | { status: "loading" }
+  | { status: "ready"; patientInfo: PatientInfo | null }
+  | { status: "error"; httpStatus?: number };
+
+/** Join a service origin with an API base path.
+ *
+ *  Both halves are host-supplied, so neither slash can be assumed: `"api"`
+ *  used to concatenate straight onto the origin and produce `https://hostapi`.
+ */
+export function joinBaseUrl(origin: string, basePath: string): string {
+  const trimmed = origin.trim().replace(/\/+$/, "");
+  const path = basePath.trim().replace(/^\/+/, "").replace(/\/+$/, "");
+  return path ? `${trimmed}/${path}` : trimmed;
+}
+
+/** Decide which patient payload reaches `TrialMatches`.
+ *
+ *  An explicit prop always wins, on every render — including after the bridge
+ *  has already resolved somebody. The previous form (`ready ? fetched : prop`)
+ *  pinned the first resolved patient for the life of the mount, so a host that
+ *  switched profile or started impersonating kept matching against the patient
+ *  loaded at mount time. That is a wrong-patient display, not a stale render.
+ *
+ *  `undefined` means "the host said nothing"; `null` is a real value the host
+ *  can pass to mean "no patient", so the two are not collapsed.
+ */
+export function selectPatientInfo(
+  propPatientInfo: PatientInfo | null | undefined,
+  load: PatientLoad,
+): PatientInfo | null | undefined {
+  if (propPatientInfo !== undefined) return propPatientInfo;
+  return load.status === "ready" ? load.patientInfo : undefined;
+}
+
+/** Whether the bridge should resolve the signed-in patient itself.
+ *
+ *  Only when the host gave it somewhere to ask and has not answered the
+ *  question already — an explicit `patientInfo` or `personId` means the host
+ *  owns the resolution and we must not make a second, contradictory one.
+ */
+export function shouldResolvePatient(props: {
+  ctomopBaseUrl?: string;
+  patientInfo?: PatientInfo | null;
+  personId?: string | number | null;
+}): boolean {
+  return (
+    Boolean(props.ctomopBaseUrl) &&
+    props.patientInfo === undefined &&
+    // `== null` on purpose, and asymmetric with `patientInfo` above. A host
+    // that is not TypeScript — which is the whole reason this bridge exists —
+    // writes `personId: pid ?? null`, and there is no useful distinction
+    // between "no person id" and "a null person id". `patientInfo` does have
+    // one: `null` is the answer "this patient has no profile".
+    props.personId == null
+  );
+}
+
+/** Which of the bridge's four screens to show.
+ *
+ *  Extracted for the same reason as the two decisions above: there is no jsdom
+ *  or @testing-library here, so a branch left inside the component is a branch
+ *  nothing checks — and one of these branches is what a patient with no
+ *  profile sees.
+ */
+export function selectBridgeView(args: {
+  shouldLoad: boolean;
+  load: PatientLoad;
+  patientInfo: PatientInfo | null | undefined;
+  personId?: string | number | null;
+}): "loading" | "error" | "no-profile" | "matches" {
+  const { shouldLoad, load, patientInfo, personId } = args;
+
+  // `idle` while a resolution is due is the render between the host dropping
+  // its own patient and the effect starting ours. Treating it as anything
+  // else flashes the developer notice below for one frame.
+  if (load.status === "loading" || (shouldLoad && load.status === "idle")) {
+    return "loading";
+  }
+  if (load.status === "error") return "error";
+
+  // `null` is the answer "this patient has no profile", whether the bridge
+  // resolved it or the host stated it. `undefined` means nobody answered,
+  // which is a host wiring mistake and keeps TrialMatches' developer notice.
+  if (patientInfo === null && personId == null) return "no-profile";
+
+  return "matches";
+}
+
+/** What the bridge believes about the current route and signed-in user. */
+export interface BridgeSession {
+  /** Everything about *where* it is asking. */
+  key: string;
+  /** Who it is asking as. Compared by identity — it may be a function. */
+  signal: unknown;
+}
+
+/** Decide whether a render has to drop the resolved patient because it belongs
+ *  to a different route or a different signed-in user. Returns `null` when
+ *  nothing changed.
+ *
+ *  This is the check that stops one user's matches from rendering for the next
+ *  one, so it is a pure function with tests rather than a condition buried in a
+ *  component that has no test harness. The caller applies the result during
+ *  render, not from an effect: an effect runs after the commit, which is one
+ *  painted frame of the previous patient's data too late.
+ */
+export function nextSessionState(
+  prev: BridgeSession,
+  next: { routeKey: string; sessionSignal: unknown; shouldLoad: boolean },
+): { session: BridgeSession; load: PatientLoad } | null {
+  // `Object.is`, not `===`: a `NaN` signal never equals itself, and this runs
+  // during render — a reset on every pass with unchanged props is React's
+  // "Too many re-renders", i.e. the remote's whole subtree dying inside the
+  // host page.
+  if (prev.key === next.routeKey && Object.is(prev.signal, next.sessionSignal)) {
+    return null;
+  }
+  return {
+    session: { key: next.routeKey, signal: next.sessionSignal },
+    load: next.shouldLoad ? { status: "loading" } : { status: "idle" },
+  };
+}
+
+/** What identifies the signed-in user for resolution purposes.
+ *
+ *  A host passes `sessionKey` to say "this is the user"; without one, the
+ *  identity of `getToken` is the only signal available and is used instead —
+ *  conservative, since a change re-resolves.
+ *
+ *  The rejected spellings all come from the same place: these hosts have no
+ *  types, so `auth.userId ?? null`, `user?.id ?? ""`, `Number(sub)` on a
+ *  non-numeric id and `auth.ready && auth.userId` are all things they write.
+ *  Read literally, each pins the signal to one value for every user and
+ *  silently disables the guard — and the boolean and empty-string ones are the
+ *  quietest, because a stuck signal never thrashes and so never warns either.
+ *  `NaN` is worse in the other direction: it never equals itself, so it resets
+ *  forever. None of them is a real user id, so none is treated as one.
+ *
+ *  The parameter is `unknown` on purpose. The type says `string | number |
+ *  null`, but the hosts this exists for have nothing enforcing that, and a
+ *  guard that only holds when the caller was already correct is not a guard.
+ *  An object still passes through: it thrashes rather than sticking, and the
+ *  bridge has a warning that names that case.
+ */
+export function resolveSessionSignal(sessionKey: unknown, getToken: unknown): unknown {
+  if (sessionKey == null || sessionKey === "") return getToken;
+  if (typeof sessionKey === "boolean") return getToken;
+  if (typeof sessionKey === "number" && Number.isNaN(sessionKey)) return getToken;
+  return sessionKey;
+}
+
+/** Whether `sessionKey` was usable, i.e. whether the signal above is a real
+ *  session key or the `getToken` fallback. */
+export function hasUsableSessionKey(sessionKey: unknown): boolean {
+  return resolveSessionSignal(sessionKey, undefined) !== undefined;
+}

--- a/frontend/src/federation/cssLayer.test.ts
+++ b/frontend/src/federation/cssLayer.test.ts
@@ -1,4 +1,6 @@
-import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { layerRemoteCss } from "./cssLayer";
 
@@ -51,5 +53,107 @@ describe("layerRemoteCss", () => {
     expect(layerRemoteCss("@keyframes spin{to{rotate:360deg}}")).toBe(
       "@keyframes spin{to{rotate:360deg}}",
     );
+  });
+
+  describe("refuses to guess rather than corrupting the cascade", () => {
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    function silenceWarn() {
+      return vi.spyOn(console, "warn").mockImplementation(() => {});
+    }
+
+    it("leaves a sheet with an unbalanced `}` untouched", () => {
+      // Clamping depth to zero and carrying on put every remaining rule
+      // *outside* the layer — silently, and above everything inside it.
+      const warn = silenceWarn();
+      const css = ".a{color:red}}.b{color:blue}";
+      expect(layerRemoteCss(css)).toBe(css);
+      expect(warn).toHaveBeenCalled();
+    });
+
+    it("leaves a sheet with an unclosed `{` untouched", () => {
+      const warn = silenceWarn();
+      const css = ".a{color:red";
+      expect(layerRemoteCss(css)).toBe(css);
+      expect(warn).toHaveBeenCalled();
+    });
+
+    it("leaves a sheet with an unterminated string untouched", () => {
+      const warn = silenceWarn();
+      const css = '.a:after{content:"oops}';
+      expect(layerRemoteCss(css)).toBe(css);
+      expect(warn).toHaveBeenCalled();
+    });
+
+    it("leaves a sheet with an unterminated comment untouched", () => {
+      // Otherwise the layer's closing brace lands inside the comment and the
+      // `@layer` block never closes — the browser then drops rules the sheet
+      // as written would have applied.
+      const warn = silenceWarn();
+      const css = ".a{color:red}/*";
+      expect(layerRemoteCss(css)).toBe(css);
+      expect(warn).toHaveBeenCalled();
+    });
+
+    it("leaves a sheet carrying an @import untouched", () => {
+      // Wrapped in a layer the @import is invalid and the parser drops it;
+      // hoisted out, the imported sheet would outrank our own layer. Neither
+      // is a safe silent default.
+      const warn = silenceWarn();
+      const css = '@import url("fonts.css");.a{color:red}';
+      expect(layerRemoteCss(css)).toBe(css);
+      expect(warn).toHaveBeenCalled();
+    });
+  });
+
+  it("hoists @font-face and the non-webkit keyframes prefixes", () => {
+    const css =
+      "@font-face{font-family:X;src:url(x.woff2)}" +
+      "@-moz-keyframes spin{to{rotate:360deg}}" +
+      ".a{color:red}";
+    const out = layerRemoteCss(css);
+    expect(out.indexOf("@font-face")).toBeLessThan(out.indexOf("@layer mf-remote"));
+    expect(out.indexOf("@-moz-keyframes")).toBeLessThan(out.indexOf("@layer mf-remote"));
+    expect(out).toContain("@layer mf-remote{.a{color:red}}");
+  });
+
+  it("documents the top-level-only limit: a nested @keyframes stays in the layer", () => {
+    // Not a bug being asserted as correct — a known limit, locked so it is
+    // noticed if someone puts an animation inside a media query.
+    const css = "@media (min-width:1px){@keyframes k{to{opacity:1}}}";
+    expect(layerRemoteCss(css)).toBe(`@layer mf-remote{${css}}`);
+  });
+
+  it("is lossless: every byte of the input survives inside the output", () => {
+    const css =
+      "/* header */@property --x{syntax:'<length>';inherits:false}" +
+      "@layer theme, base;.exact-root{--y:1}" +
+      "@media (min-width:40rem){.exact-root .grid{display:grid}}";
+    const out = layerRemoteCss(css);
+    const stripped = out
+      .replace(/^@layer mf-remote\{/m, "")
+      .replace(/\}$/, "")
+      .replace(/@layer mf-remote\{/, "")
+      .replace(/\n/g, "");
+    for (const rule of ["@property --x", "@layer theme, base;", ".exact-root{--y:1}", "@media (min-width:40rem)"]) {
+      expect(stripped).toContain(rule);
+    }
+  });
+
+  it("still layers the sheet this remote actually ships", () => {
+    // Every other test here is a synthetic string, so a bail-out introduced by
+    // an edit to exact.css — a top-level @import for a font, an unbalanced
+    // brace — would return the sheet unlayered, reinstate the header-collapse
+    // this module exists to prevent, and leave the suite green. The only other
+    // signal is a console.warn in a browser nobody is watching.
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const css = readFileSync(new URL("./exact.css", import.meta.url), "utf8");
+    const out = layerRemoteCss(css);
+    expect(warn).not.toHaveBeenCalled();
+    expect(out).toContain("@layer mf-remote{");
+    expect(out).not.toBe(css);
+    vi.restoreAllMocks();
   });
 });

--- a/frontend/src/federation/cssLayer.ts
+++ b/frontend/src/federation/cssLayer.ts
@@ -17,22 +17,58 @@
  * built from. Our internal layer order survives as sub-layers of it, and rules
  * we ship unlayered stay the strongest thing we have.
  *
- * A host that declares no order gets `mf-remote` appended after its own
- * layers, which is where our rules already sit today: nothing regresses.
+ * This is not free, and the trade is deliberate. Per the cascade-layers spec
+ * an *unlayered* normal declaration beats every layered one regardless of
+ * specificity, so on a host that declares no layer order — or that ships an
+ * unlayered preflight, as Tailwind v3 does — rules of ours that used to win on
+ * source order now lose to it. We accept that: losing a button background is
+ * recoverable, erasing the host's header is not, and every remote owes the
+ * host the same contract. Hosts that want the old behaviour declare the layer
+ * order above, which puts `mf-remote` where we can style ourselves again.
  *
  * `@property`, `@keyframes` and `@font-face` are hoisted back out. Layers do
  * not change how any of them register, and `@property` inside a layer is not
- * honoured in every browser.
+ * honoured in every browser. `@charset` is hoisted with them for tidiness; it
+ * is inert inside a `<style>` element either way.
+ *
+ * Known limit: hoisting inspects only the top level, so a `@keyframes` or
+ * `@property` nested inside `@media`/`@supports` stays in the layer. Nothing
+ * in `exact.css` does that today; recursing would mean splitting conditional
+ * group rules, which is a bigger change than the case warrants.
  */
 
-const HOISTED = /^@(?:property|(?:-webkit-)?keyframes|font-face|charset)\b/i;
+const HOISTED = /^@(?:property|(?:-webkit-|-moz-|-o-)?keyframes|font-face|charset)\b/i;
+
+/* `@import` cannot be layered by wrapping. Inside a `@layer` block it is
+ * invalid and the parser drops it silently, and hoisting it out would put a
+ * whole external sheet *above* the layer we just moved ourselves into —
+ * exactly the failure this module exists to prevent. Neither is a safe silent
+ * default, so a sheet carrying one is passed through untouched and noisily. */
+const UNLAYERABLE = /^@import\b/i;
+
+function bail(reason: string): void {
+  console.warn(
+    `[exact-remote] injected CSS left unlayered (${reason}); ` +
+      "the host's cascade layers will not contain this sheet.",
+  );
+}
 
 export function layerRemoteCss(css: string, layer = "mf-remote"): string {
+  const rules = topLevelRules(css);
+  // Parsing failed, so we cannot tell rules apart. Emitting a wrapper around
+  // a sheet we misread is worse than emitting the sheet: fall back to the
+  // pre-layer behaviour rather than corrupting the cascade.
+  if (rules === null) return css;
+
   const hoisted: string[] = [];
   const layered: string[] = [];
 
-  for (const rule of topLevelRules(css)) {
+  for (const rule of rules) {
     const start = rule.replace(/^(?:\s|\/\*[\s\S]*?\*\/)+/, "");
+    if (UNLAYERABLE.test(start)) {
+      bail("it contains an @import");
+      return css;
+    }
     (HOISTED.test(start) ? hoisted : layered).push(rule);
   }
 
@@ -45,8 +81,13 @@ export function layerRemoteCss(css: string, layer = "mf-remote"): string {
 /** Split a stylesheet into its top-level rules: balanced `{}`, or a `;` at
  *  depth zero. Comments and quoted strings are skipped rather than scanned —
  *  an apostrophe in a comment ("the host's own preflight") would otherwise
- *  open a string that swallows the rest of the file. */
-function topLevelRules(css: string): string[] {
+ *  open a string that swallows the rest of the file.
+ *
+ *  Returns `null` when the sheet does not parse as balanced, rather than
+ *  guessing. The split must also be lossless: the pieces are contiguous
+ *  slices, so `rules.join("") === css` is a cheap end-to-end check that no
+ *  future edit to this function can quietly drop or duplicate a byte. */
+function topLevelRules(css: string): string[] | null {
   const rules: string[] = [];
   let depth = 0;
   let start = 0;
@@ -69,7 +110,15 @@ function topLevelRules(css: string): string[] {
     }
     if (c === "/" && css[i + 1] === "*") {
       const end = css.indexOf("*/", i + 2);
-      i = end === -1 ? css.length : end + 1;
+      // A comment that never closes swallows whatever we append after it: the
+      // layer's own closing `}` would land inside it, leaving the `@layer`
+      // block unterminated and the browser dropping rules that the sheet as
+      // written still applies.
+      if (end === -1) {
+        bail("it has an unterminated comment");
+        return null;
+      }
+      i = end + 1;
       continue;
     }
     if (c === '"' || c === "'") {
@@ -77,8 +126,15 @@ function topLevelRules(css: string): string[] {
     } else if (c === "{") {
       depth++;
     } else if (c === "}") {
-      if (--depth <= 0) {
-        depth = 0;
+      // A close brace at depth zero means we lost track somewhere. The
+      // previous version clamped to zero and carried on, which pushed every
+      // remaining rule *outside* the layer — silently, and at higher priority
+      // than everything inside it.
+      if (depth === 0) {
+        bail("it has an unbalanced `}`");
+        return null;
+      }
+      if (--depth === 0) {
         rules.push(css.slice(start, i + 1));
         start = i + 1;
       }
@@ -89,5 +145,14 @@ function topLevelRules(css: string): string[] {
   }
 
   if (start < css.length) rules.push(css.slice(start));
+
+  if (depth !== 0 || quote !== null) {
+    bail(depth !== 0 ? "it has an unclosed `{`" : "it has an unterminated string");
+    return null;
+  }
+  if (rules.join("") !== css) {
+    bail("the rule split was not lossless");
+    return null;
+  }
   return rules;
 }

--- a/frontend/src/federation/types.ts
+++ b/frontend/src/federation/types.ts
@@ -188,3 +188,86 @@ export interface TrialMatchesProps {
   /** Called when the user opens a trial card / detail view. */
   onTrialSelect?: (trial: TrialMatch) => void;
 }
+
+/** Public props for the federated `./TrialMatchesBridge` export — the
+ *  framework-agnostic mount used by hosts that are not React.
+ *
+ *  Lives here rather than in `TrialMatchesBridge.tsx` so a TypeScript host can
+ *  type its `provider().render({ … })` call against the contract: `./types` is
+ *  exposed, the bridge module is loaded at runtime.
+ *
+ *  `apiClient` and `queryClient` are omitted deliberately — the host passes
+ *  data, not live objects, so it needs neither axios nor react-query. */
+export interface TrialMatchesBridgeProps
+  extends Omit<TrialMatchesProps, "apiClient" | "queryClient" | "personId"> {
+  /** As `TrialMatchesProps["personId"]`, but `null` is accepted and means the
+   *  same as omitting it: the hosts this bridge exists for have no types, and
+   *  `personId: pid ?? null` is how they spell "I do not have one". Normalised
+   *  before it reaches TrialMatches. */
+  personId?: string | number | null;
+  /** Service origin, e.g. `"https://exact-staging-….run.app"`. */
+  baseUrl: string;
+  /**
+   * PRomop origin. When given (and neither `patientInfo` nor `personId` is
+   * passed), the bridge loads the signed-in patient itself: PRomop's
+   * `/patient-info/me/` with the caller's own token, then EXACT's
+   * `/normalize-ctomop-row/`.
+   *
+   * That two-step is EXACT's business, not the host's, so it lives in the
+   * bridge rather than being reimplemented by every host. It also has to be
+   * the caller's token: EXACT's server-side `person_id` resolver is disabled
+   * by default because its CTOMOP service token is not bound to the caller and
+   * would let any `person_id` through (IDOR). Fetching "me" makes PRomop
+   * enforce access.
+   *
+   * Note that passing `patientInfo: null` explicitly counts as the host having
+   * answered ("this patient has no profile") and suppresses the fetch; omit
+   * the prop entirely to have the bridge resolve.
+   */
+  ctomopBaseUrl?: string;
+  /** Joined onto `baseUrl` to form the axios baseURL. Leading/trailing
+   *  slashes are normalised, so `"api"` and `"/api"` behave the same.
+   *
+   *  Defaults to `""`, i.e. EXACT's API is assumed to live at the origin
+   *  itself. Most deployments mount it under `/api` — pass it, or every call
+   *  404s behind the generic error card. */
+  apiBasePath?: string;
+  /** Joined onto `ctomopBaseUrl` the same way. Defaults to `"/api"`; set it
+   *  when PRomop is mounted elsewhere (e.g. `"/api/v1"`), otherwise the
+   *  `/patient-info/me/` call 404s behind the generic error card. */
+  ctomopApiBasePath?: string;
+  /**
+   * Resolves the caller's bearer token; the host owns authentication.
+   *
+   * The same token is sent to both `baseUrl` and `ctomopBaseUrl`, so it must
+   * be valid at both services — an EXACT-only, audience-scoped token is not
+   * enough when `ctomopBaseUrl` is set.
+   *
+   * Its *identity* is the session signal when no `sessionKey` is passed, in
+   * which case changing it re-runs the self-driven patient resolution. Pass a stable function (module-level,
+   * or memoised) so a re-render does not cost a redundant round trip — and do
+   * hand over a new one when the signed-in user changes, or a mount reused
+   * across a logout/login will keep showing the previous user's matches.
+   */
+  getToken?: () => Promise<string | null | undefined> | string | null | undefined;
+  /**
+   * Identifies the signed-in user. Change it and the bridge drops whatever it
+   * resolved and resolves again; keep it and the bridge holds what it has.
+   *
+   * A mount reused across a logout/login would otherwise keep showing the
+   * previous user's matches, so without a `sessionKey` the bridge falls back
+   * to `getToken`'s identity as the signal. That is safe but blunt: a host
+   * that builds `getToken` inline rebuilds it on every render, and each one
+   * sends the user back to the loading state, losing the filters and the
+   * query cache. Pass a `sessionKey` (a user id, a session id — any scalar
+   * that changes with the user) and `getToken` can be as unstable as you like.
+   *
+   * `null`, `""`, `NaN` and a boolean all count as not passing one, and fall back to the
+   * `getToken` signal rather than pinning every user to the same key: they are
+   * what `auth.userId ?? null`, `user?.id ?? ""` and `Number(sub)` produce
+   * when there is nothing to read, not user ids. Pass a scalar, and one that
+   * is stable within a session — an object is a new value on every render, so
+   * every render would reset the mount and re-resolve the patient.
+   */
+  sessionKey?: string | number | null;
+}


### PR DESCRIPTION
Applies the findings from the two-part self-review on #414 ([comment](https://github.com/healthkey-ai/exact/pull/414#issuecomment-5599585830)). Based on `feat/mf-bridge-trialmatches` so #414 keeps its own history; merge this into it rather than into `main`.

Scope is #414's own three commits — the bridge, the CSS layer wrapper, and the contract a host integrates against. Nothing here touches the four inherited stack commits.

## The two that are worth reading

**The published mount contract didn't unmount anything.** `createBridgeComponent` returns `() => { const rootMap = new Map(); … }`, so the documented `provider().render(…)` / `provider().destroy(…)` pair gave each call its own map and `destroy` no-opped. Measured against the installed package: one root created, none unmounted. A host navigating away left the React tree running — `popstate` listener, QueryClient and all — and the next mount called `createRoot()` on a container that already had a live root. The factory is now memoised, so the contract holds as written.

**The bridge could show one patient's data to another.** Three separate ways, all now closed:

- `ready ? fetched : prop` pinned the first resolved patient for the life of the mount, so a host that switched profile or started impersonating kept matching against whoever loaded first.
- Resolution is keyed on the session. Without that, a mount reused across a logout/login kept the previous user's profile. The reset happens **during render**, not in an effect — a passive effect runs after the commit, which is one painted frame of somebody else's PHI, and long enough for react-query to render its cached list.
- Each resolution builds its own clients and its token reader aborts once cancelled, so a row fetched as one user can never leave under another's credentials.

## Also

- **The error path logged the whole `AxiosError`** — which carries `config.headers.Authorization` (a live bearer token) and, on the normalise call, `config.data` (the entire patient row). This remote runs inside somebody else's page, where console-instrumenting SDKs ship console arguments off-box by default. Now scalars only: status, code, url.
- **`cssLayer` failed silently in two ways**, both confirmed by asserting the old function's output before changing it: a stray `}` was clamped to depth zero and pushed every remaining rule *outside* the layer (`.a{color:red}}.b{…}` → `.b` above everything the layer contains — the exact failure the module exists to prevent, reintroduced by its own recovery path), and an unterminated comment swallowed the layer's closing brace (`.a{color:red}/*` → `@layer mf-remote{.a{color:red}/*}`, a block that never closes). `@import` was wrapped into the layer where it is invalid and silently dropped. All now bail to the pre-layer behaviour with a warning, plus a losslessness invariant so a future edit to the parser can't quietly drop a byte.
- **`sessionKey` rejects the spellings an untyped host actually writes.** `auth.userId ?? null`, `user?.id ?? ""`, `auth.ready && auth.userId` and `Number(sub)` are what these hosts produce when there is nothing to read. Taken literally the first three pin the signal to one value for every user and silently disable the session guard — the quietest failure available, since a stuck signal never trips the thrash warning either — and `NaN` never equals itself, so the render-phase reset would fire every pass and take the remote's subtree down with "Too many re-renders".
- **The error card gained a retry.** Resolutions fail for reasons that go away — a token that hadn't arrived, a service restarting, a `getToken` replaced within the same session — and none of them re-run the effect. The only escape was a page reload. Offered on 401/403 too: signing in is the host's job, but the bridge has no way to hear that it happened.
- No request timeout on the resolution (it blocks the whole screen) → 10s. The client handed to `TrialMatches` deliberately gets none: `/trials/` runs the matcher over the whole corpus behind a service that cold-starts, and its QueryClient carries no `defaultOptions`, so react-query's three retries multiply any per-attempt ceiling by four.
- PRomop's base path was hardcoded `/api` while EXACT's was a prop, and this same branch puts the PHR portal at `/api/v1` → `ctomopApiBasePath`. `apiBasePath: "api"` concatenated to `https://hostapi` → both joins normalise.
- A known-empty profile fell through to `TrialMatches`' developer notice — "Pass a `patientInfo` payload or `personId`", with literal `<code>` tags — which every user who hadn't finished onboarding would have seen.
- `apiClient` moved after the `{...rest}` spread so an untyped host can't replace the bridge's authenticated client; `TrialMatchesBridgeProps` moved into the exposed `./types` so a TS host can type its `render({…})` call; README documents the bridge, the `@layer` host requirement and the Bearer-vs-Token divergence between the two exports.

## Tests

34 → 83. The decisions that pick **which patient reaches the matcher** and **what a patient with no profile sees** are now pure functions in `bridgeState.ts` with tests — there is no jsdom or `@testing-library` here, so a branch left inside the component is a branch nothing checks. `buildClient` is exported and tested because it is where the credential is attached. Each new test was checked against the pre-fix code or by mutation, so none of them passes vacuously; one test runs the parser over the sheet this remote actually ships, since every other cssLayer test is a synthetic string and a bail-out would otherwise leave the suite green while production went unlayered.

## Known gaps

The component itself is still unexercised — no jsdom, no host harness, nothing in the repo mounts the bridge in a browser. The render-phase reset, the two diagnostics and the four screens are argued from the code and tested only at the pure-function layer. The constants are pinned by value but nothing pins that the component passes each to the right call site.

Reviewed with `codex review` and independent fresh-context reviews, run to convergence: eight rounds, each of which found something in the previous round's fix — including the console log leaking PHI, a one-frame window showing the previous patient, and the `NaN` crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RCfnBjgPjApVRZFHYzCFnV
