### PR TITLE
feat(search): repair and complete the search API the federated UI needs (#417)

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -128,6 +128,7 @@ trial-search request.
 | `region` | string | Filter by region |
 | `postalCode` | string | Override postal code for distance calculation |
 | `studyId` | string | Filter by study ID (e.g. NCT number) |
+| `phase` | string | Keep trials at this phase or later (`EARLY_PHASE1` … `PHASE4`); trials with no ingested phase are excluded |
 | `lastUpdate` | date | Filter trials updated after this date |
 | `firstEnrolment` | date | Filter trials with first enrolment after this date |
 
@@ -137,16 +138,17 @@ trial-search request.
 
 ### `GET /trials/`
 
-List trials ordered by match score descending. For explicit sorting or the
-`favorites` filter, use [`GET /trials/search/`](#get-trialssearch) instead.
+List trials ordered by `-match_score, -posted_date, id`. For explicit
+sorting or the per-tab counts, use [`GET /trials/search/`](#get-trialssearch)
+instead — `sort` is read only there.
 
-**Patient context**: optional — include `"patientInfo": {...}` in the request body.
+**Patient context**: optional — include `"patient_info": {...}` in the request body (snake_case; no camelCase parser is configured, so `patientInfo` is silently ignored).
 
 **Query params:**
 
 | Param | Values | Description |
 |---|---|---|
-| `type` | `all`, `eligible`, `potential`, `not_eligible` | Filter by match status |
+| `type` | `all` | Only `all` changes anything here: it switches to the admin corpus, which skips the eligibility filter. `eligible` / `potential` are **not** applied by this endpoint — use `GET /trials/search/`. `favorites`, `my_trials` and `not_eligible` return 400 |
 | `search` | string | Full-text search on title fields |
 | `explain` | `true` | Include per-criterion match breakdown in each trial (see `matchReasons` below) |
 
@@ -223,19 +225,60 @@ is `null`.
 ### `GET /trials/search/`
 
 Extended search endpoint — use this instead of `GET /trials/` when you need
-explicit sorting or access to the `favorites` filter type. Accepts the same
-patient context and study-preference query params as `GET /trials/`, plus:
+explicit sorting or the per-tab counts. Accepts the same patient context and
+study-preference query params as `GET /trials/`, plus:
 
-**Patient context**: optional — include `"patientInfo": {...}` in the request body.
+**Patient context**: optional — include `"patient_info": {...}` in the request body (snake_case; no camelCase parser is configured, so `patientInfo` is silently ignored).
 
 **Query params:**
 
 | Param | Values | Default | Description |
 |---|---|---|---|
-| `type` | `all`, `eligible`, `potential`, `not_eligible`, `favorites` | `all` | Match-status filter |
+| `type` | `all`, `eligible`, `potential` | *(none)* | Match-status filter. The default is **no value**, which is not the same as `all` — see the note below. `eligible_and_potential` is accepted for CB compatibility but is a no-op identical to omitting the parameter. `favorites`, `my_trials` and `not_eligible` return 400 |
 | `sort` | `goodnessScore`, `matchScore`, `patientBurdenScore`, `distance`, `status`, `phase`, `updated`, `enrollment` | `goodnessScore` | Sort order |
 | `view` | template name | — | Override the attribute-detail template |
 | `search` | string | — | Full-text search |
+| `phase` | `EARLY_PHASE1`, `PHASE1`, `PHASE2`, `PHASE3`, `PHASE4` | — | Keep trials at that phase **or later**. Trials with no ingested phase are excluded by any value |
+
+**`type=all` takes a different branch.** Omitting `type` runs the eligibility
+filter and the full study-preference set. `all` routes through the admin
+branch instead, which skips eligibility *and* the `phase`, `recruitmentStatus`,
+`sponsor`, `searchTreatment`, `country`/`region` and date filters — while being
+the only branch that applies `studyId`. Filters silently do nothing on that
+path rather than erroring (issue #424).
+
+**Response extra key — `tabCounts`:**
+
+```json
+{ "results": [...], "itemsTotalCount": 42, "tabCounts": { "eligible": 9, "potential": 33 } }
+```
+
+`eligible` and `potential` partition the whole matched corpus — deliberately
+not the rows this response lists, so that the Eligible badge does not read 0
+while the user is on the Potential tab. They are taken after every other
+filter, including `search`, which DRF applies outside the matcher.
+
+**The key is absent** when a count would assert something nobody computed:
+when the request carries no patient context (nothing has been judged), and
+under `?type=all` (the admin branch skips the eligibility filter, so the rows
+are real but no per-row verdict exists). Treat a missing `tabCounts` as "no
+counts available", not as zero.
+
+---
+
+### `POST /trials/search/match/`
+
+`GET /trials/search/` with the patient payload in the body, for callers that
+cannot send a GET body (the Fetch spec forbids it and axios's XHR adapter
+drops it). Same query params, same response shape, including `tabCounts`.
+
+```
+POST /trials/search/match/?sort=distance
+{ "patient_info": { "disease": "multiple myeloma", ... } }
+```
+
+Its sibling `POST /trials/match/` routes to `GET /trials/` instead, and so
+does **not** read `sort`.
 
 ---
 
@@ -243,7 +286,7 @@ patient context and study-preference query params as `GET /trials/`, plus:
 
 Returns the count of matched trials without fetching full records.
 
-**Patient context**: optional — include `"patientInfo": {...}` in the request body.
+**Patient context**: optional — include `"patient_info": {...}` in the request body (snake_case; no camelCase parser is configured, so `patientInfo` is silently ignored).
 
 **Response:**
 ```json
@@ -257,7 +300,7 @@ Returns the count of matched trials without fetching full records.
 Retrieve full trial details including all eligibility attributes grouped for
 display, with per-attribute patient match status.
 
-**Patient context**: optional — include `"patientInfo": {...}` in the request body.
+**Patient context**: optional — include `"patient_info": {...}` in the request body (snake_case; no camelCase parser is configured, so `patientInfo` is silently ignored).
 
 **Response:** Full trial object including `trialEligibilityAttributes` grouped
 by category, each with the trial's value, the patient's current value, and the
@@ -272,7 +315,7 @@ match status (`matched`, `unknown`, or `not_matched`).
 Returns a compact graph-structured response optimised for visual dependency
 views.
 
-**Patient context**: optional — include `"patientInfo": {...}` in the request body.
+**Patient context**: optional — include `"patient_info": {...}` in the request body (snake_case; no camelCase parser is configured, so `patientInfo` is silently ignored).
 
 **Query params:**
 
@@ -318,6 +361,12 @@ Returns all dropdown option lists used by patient-intake forms.
 |---|---|
 | `disease` | If provided, also returns `trialTypes` scoped to this disease |
 
+Two status lists live here and they are not interchangeable. `recruitmentStatuses`
+is the trial's recruitment state, and its values are what `?recruitmentStatus=`
+accepts on the trial endpoints. `statuses` is the patient-invitation enum
+("Looking for trial", "Waiting for patient acceptance") and has nothing to do
+with trial search.
+
 **Response** (partial example):
 ```json
 {
@@ -339,7 +388,12 @@ Returns all dropdown option lists used by patient-intake forms.
   "ethnicity": [ ... ],
   "therapyTypesAll": [ ... ],
   "therapyComponentsAll": [ ... ],
-  "trialTypes": [ ... ]
+  "trialTypes": [ ... ],
+  "recruitmentStatuses": { "options": [
+    { "value": "", "label": "ALL" },
+    { "value": "RECRUITING", "label": "Recruiting" },
+    { "value": "RECRUITING_AND_NOT_YET_RECRUITING", "label": "Recruiting & Not Yet Recruiting" }
+  ] }
 }
 ```
 

--- a/tests/services/test_study_preferences.py
+++ b/tests/services/test_study_preferences.py
@@ -29,3 +29,19 @@ class TestStudyPreferencesParsing:
 
     def test_dataclass_default(self):
         assert StudyPreferences().trial_purpose is None
+
+
+class TestPhaseParsing:
+    """`phase` was declared on the dataclass and consumed by `by_phase` from
+    the start, but `study_preferences_from_query_params` never read it — so
+    `?phase=PHASE3` matched everything."""
+
+    def test_phase_param_populated(self):
+        prefs = study_preferences_from_query_params({'phase': 'PHASE3'})
+        assert prefs.phase == 'PHASE3'
+
+    def test_phase_param_absent_defaults_to_none(self):
+        assert study_preferences_from_query_params({}).phase is None
+
+    def test_phase_empty_string_normalized_to_none(self):
+        assert study_preferences_from_query_params({'phase': ''}).phase is None

--- a/tests/views/test_search_api_phase0.py
+++ b/tests/views/test_search_api_phase0.py
@@ -1,0 +1,400 @@
+"""HTTP surface added/repaired in phase 0 of the federated Find Trials plan.
+
+Four things the federated remote needs and could not get before:
+
+  * `POST /trials/search/match/` — the `search` action reachable with an
+    inline `patient_info` body, so sorting and the tab counts work for a
+    caller that cannot send a GET body.
+  * `tabCounts` on the search response — per-tab totals without a second
+    round trip, taken over the queryset the same response lists.
+  * `?type=favorites` / `?type=my_trials` — rejected with 400 instead of
+    raising FieldError (500) or silently returning the whole corpus.
+  * `?phase=` — actually filters.
+
+See docs/federated-ui-parity-plan.md.
+"""
+from datetime import date
+
+import pytest
+from rest_framework.authtoken.models import Token
+from rest_framework.test import APIClient
+
+from accounts.models import Identity
+from tests.factories import TrialFactory
+
+
+@pytest.fixture
+def authed_client(db):
+    user, _ = Identity.objects.get_or_create(issuer='urn:local', sub='phase0-tester')
+    token, _ = Token.objects.get_or_create(user=user)
+    client = APIClient()
+    client.credentials(HTTP_AUTHORIZATION=f'Token {token.key}')
+    return client
+
+
+MM = {'patient_info': {'disease': 'multiple myeloma'}}
+
+
+def potential_trial(**kwargs):
+    """A trial the reference patient cannot be judged against yet.
+
+    `ecog_performance_status_max` is a requirement the MM payload above says
+    nothing about, so the matcher counts one unfilled attribute and the trial
+    lands in `potential` rather than `eligible`.
+    """
+    return TrialFactory(disease='Multiple Myeloma', ecog_performance_status_max=2, **kwargs)
+
+
+@pytest.mark.django_db
+class TestSearchMatchPost:
+    def test_unauthenticated_post_returns_401(self):
+        assert APIClient().post('/trials/search/match/', {}, format='json').status_code == 401
+
+    def test_returns_the_paginated_search_shape(self, authed_client):
+        TrialFactory(disease='Multiple Myeloma')
+        response = authed_client.post('/trials/search/match/', MM, format='json')
+        assert response.status_code == 200
+        assert 'results' in response.data
+        assert 'itemsTotalCount' in response.data
+
+    def test_inline_patient_info_scopes_to_disease(self, authed_client):
+        """The body has to reach the matcher, exactly as it does for `match`.
+
+        Strict equality rather than membership: a regression that widened the
+        response to the disease-agnostic union would still contain the MM
+        trial and would pass a membership check.
+        """
+        mm = TrialFactory(disease='Multiple Myeloma')
+        TrialFactory(disease='Breast Cancer')
+        response = authed_client.post('/trials/search/match/', MM, format='json')
+        assert {t['trialId'] for t in response.data['results']} == {mm.id}
+
+    def test_sort_is_honoured(self, authed_client):
+        """The reason this alias exists.
+
+        `POST /trials/match/` binds to `list`, whose ordering is fixed at
+        `-match_score, -posted_date, id`, so `?sort=` did nothing for a
+        caller on the inline path. Sorting by enrollment because it is a
+        plain trial column: it does not depend on the matcher assigning
+        distinguishable scores to the fixtures.
+        """
+        small = TrialFactory(disease='Multiple Myeloma', enrollment_count=10)
+        large = TrialFactory(disease='Multiple Myeloma', enrollment_count=900)
+        response = authed_client.post(
+            '/trials/search/match/?sort=enrollment', MM, format='json',
+        )
+        assert response.status_code == 200
+        ids = [t['trialId'] for t in response.data['results']]
+        assert ids.index(large.id) < ids.index(small.id)
+
+    def test_the_list_alias_does_not_sort_by_enrollment(self, authed_client):
+        """Non-vacuity guard for the test above.
+
+        If `search_match` ever silently rebound to `list`, the sort assertion
+        could still pass whenever the fixtures happened to land in the right
+        order. So assert the other half directly: `match` falls back to
+        `-posted_date` once match scores tie, and these fixtures make that
+        the opposite of enrollment order.
+
+        The tie is asserted rather than assumed — it holds because these
+        three trials differ only in fields the matcher does not read, and a
+        future factory change could break that silently.
+        """
+        for day, enrollment in ((1, 300), (2, 200), (3, 100)):
+            TrialFactory(
+                disease='Multiple Myeloma',
+                posted_date=date(2026, 1, day),
+                enrollment_count=enrollment,
+            )
+        response = authed_client.post('/trials/match/?sort=enrollment', MM, format='json')
+        assert response.status_code == 200
+        results = response.data['results']
+        scores = {t['matchScore'] for t in results}
+        assert len(scores) == 1, (
+            f'fixtures no longer tie on matchScore ({scores}); this test '
+            'assumes the tie so that -posted_date decides the order'
+        )
+        posted = [t['postedDate'] for t in results]
+        assert posted == sorted(posted, reverse=True), (
+            f'{posted}: the list alias must fall back to -posted_date, not '
+            'honour ?sort=enrollment'
+        )
+
+
+@pytest.mark.django_db
+class TestTabCounts:
+    """`tabCounts` on the search response, in place of a counts endpoint.
+
+    A standalone `GET /trials/counts/` cannot work for the caller that needs
+    it: counts are only meaningful under a patient context, the only way to
+    send one is a POST body, and with `patient_info=None` the annotation
+    collapses to `num_nonnulls(NULL)` — `potential` is then structurally 0
+    and the "matched corpus" is the whole table. Riding on the search
+    response also keeps counted and listed rows the same set by construction.
+    """
+
+    def test_present_on_the_search_response(self, authed_client):
+        TrialFactory(disease='Multiple Myeloma')
+        data = authed_client.post('/trials/search/match/', MM, format='json').data
+        assert set(data['tabCounts']) == {'eligible', 'potential'}
+
+    def test_partitions_the_matched_corpus(self, authed_client):
+        """Non-vacuous: one fixture is genuinely potential, two eligible.
+
+        Without the potential fixture this assertion reduces to `n + 0 == n`
+        and cannot detect either overlap or loss.
+        """
+        TrialFactory(disease='Multiple Myeloma')
+        TrialFactory(disease='Multiple Myeloma')
+        potential_trial()
+        data = authed_client.post('/trials/search/match/', MM, format='json').data
+        assert data['tabCounts']['potential'] == 1, (
+            'the potential fixture stopped being potential; the partition '
+            'assertion below would be vacuous'
+        )
+        assert data['tabCounts']['eligible'] == 2
+        assert (
+            data['tabCounts']['eligible'] + data['tabCounts']['potential']
+            == data['itemsTotalCount']
+        )
+
+    @pytest.mark.parametrize('search_type', ['eligible', 'potential'])
+    def test_counts_describe_the_corpus_not_the_active_tab(
+        self, authed_client, search_type,
+    ):
+        """The whole point of the counts.
+
+        `with_potential_attrs_count` applies the `type` narrowing as well as
+        the annotation, so counting the response's own queryset counted an
+        already-narrowed set: on the Potential tab the Eligible badge read 0
+        and the tab bar could not be labelled from the response it came with.
+        """
+        TrialFactory(disease='Multiple Myeloma')
+        TrialFactory(disease='Multiple Myeloma')
+        potential_trial()
+        data = authed_client.post(
+            f'/trials/search/match/?type={search_type}', MM, format='json',
+        ).data
+        assert data['tabCounts'] == {'eligible': 2, 'potential': 1}, (
+            f'?type={search_type} narrowed the counts as well as the rows'
+        )
+        # ...while the listed rows ARE narrowed.
+        assert data['itemsTotalCount'] == (2 if search_type == 'eligible' else 1)
+
+    def test_counts_move_with_every_filter_the_list_obeys(self, authed_client):
+        """Counted rows and listed rows must come from the same filtering.
+
+        `?search=` is applied by DRF's SearchFilter in `filter_queryset`,
+        *outside* `filtered_trials` — so a counts implementation that skipped
+        it would promise rows the list cannot show. `?searchTitle=` goes
+        through `filtered_trials` instead, so both routes are exercised.
+        """
+        TrialFactory(disease='Multiple Myeloma', brief_title='Daratumumab study')
+        TrialFactory(disease='Multiple Myeloma', brief_title='Lenalidomide study')
+        for query in ('search=Daratumumab', 'searchTitle=Daratumumab'):
+            data = authed_client.post(
+                f'/trials/search/match/?{query}', MM, format='json',
+            ).data
+            total = data['tabCounts']['eligible'] + data['tabCounts']['potential']
+            assert total == data['itemsTotalCount'] == 1, (
+                f'?{query}: counts {total} vs listed {data["itemsTotalCount"]}'
+            )
+
+    def test_omitted_without_patient_context(self, authed_client):
+        """A count with no patient context asserts a verdict nobody made.
+
+        With `patient_info=None` the annotation collapses to
+        `num_nonnulls(NULL)`, so every row counts as eligible and nothing
+        counts as potential — the corpus relabelled as a clinical result.
+        This is the failure that killed the standalone counts endpoint, and
+        `GET /trials/search/` is equally GET-only, so the key has to be
+        absent rather than wrong.
+        """
+        TrialFactory(disease='Multiple Myeloma')
+        TrialFactory(disease='Breast Cancer')
+        data = authed_client.get('/trials/search/').data
+        assert 'tabCounts' not in data
+        # The rows themselves are still served — only the verdict is withheld.
+        assert data['itemsTotalCount'] == 2
+
+    def test_omitted_under_type_all(self, authed_client):
+        """`type=all` takes the admin branch, which skips the eligibility
+        filter — the rows are the corpus the caller asked for, but no
+        per-row verdict was computed, so counting them as eligible would
+        attach one retroactively."""
+        TrialFactory(disease='Multiple Myeloma')
+        data = authed_client.post('/trials/search/match/?type=all', MM, format='json').data
+        assert 'tabCounts' not in data
+
+
+@pytest.mark.django_db
+class TestUserScopedSearchTypesRejected:
+    """`favorites` / `my_trials` name per-user state EXACT does not hold."""
+
+    @pytest.mark.parametrize('search_type', ['favorites', 'my_trials', 'not_eligible'])
+    @pytest.mark.parametrize('path', ['/trials/', '/trials/search/', '/trials/count/'])
+    def test_rejected_with_400(self, authed_client, search_type, path):
+        TrialFactory(disease='Multiple Myeloma')
+        response = authed_client.get(f'{path}?type={search_type}')
+        assert response.status_code == 400, (
+            f'{path}?type={search_type} returned {response.status_code}; '
+            'favorites used to raise FieldError (500), my_trials returned the '
+            'unfiltered corpus as if it were the patient list, and not_eligible '
+            'returned the eligible + potential set — the inverse of its name'
+        )
+        assert 'type' in response.data
+
+    @pytest.mark.parametrize('search_type', ['favorites', 'my_trials'])
+    def test_rejected_on_the_post_aliases_too(self, authed_client, search_type):
+        TrialFactory(disease='Multiple Myeloma')
+        for path in ('/trials/match/', '/trials/search/match/'):
+            response = authed_client.post(f'{path}?type={search_type}', MM, format='json')
+            assert response.status_code == 400, f'{path} accepted {search_type}'
+
+    @pytest.mark.parametrize('search_type', ['favorites', 'my_trials'])
+    def test_the_detail_page_still_works_with_the_tab_in_the_query_string(
+        self, authed_client, search_type,
+    ):
+        """Blast-radius guard.
+
+        `retrieve` ignores `type` entirely, so a UI that carries the tab it
+        came from across a list -> detail navigation must not get a 400 for
+        a parameter the detail endpoint never reads.
+
+        Exercised through the POST detail alias because that is the path the
+        federated remote uses, and because plain `GET /trials/{id}/` without
+        any patient context 500s for an unrelated, pre-existing reason (the
+        matcher dereferences a None patient_info) — see #423.
+        """
+        trial = TrialFactory(disease='Multiple Myeloma')
+        response = authed_client.post(
+            f'/trials/{trial.id}/match/?type={search_type}', MM, format='json',
+        )
+        assert response.status_code == 200
+
+    @pytest.mark.parametrize('search_type', ['eligible', 'potential', 'eligible_and_potential'])
+    def test_supported_types_still_work(self, authed_client, search_type):
+        TrialFactory(disease='Multiple Myeloma')
+        response = authed_client.get(f'/trials/search/?type={search_type}')
+        assert response.status_code == 200
+
+    def test_all_is_deliberately_not_rejected(self, authed_client):
+        """`all` reaches the same admin branch as `my_trials` and returns the
+        same unnarrowed corpus — but that corpus is what it names, so it is
+        left alone. Pinned so the asymmetry reads as a decision, not a gap."""
+        TrialFactory(disease='Multiple Myeloma')
+        assert authed_client.get('/trials/search/?type=all').status_code == 200
+
+
+@pytest.mark.django_db
+class TestPhaseFilter:
+    """`?phase=` reached the dataclass field but never the query string.
+
+    `by_phase` reads `PHASE_CODE_MAPPING.index(phase)` and keeps trials at
+    that phase *or later*, so PHASE3 keeps III and IV and drops I and II.
+    """
+
+    def test_narrows_to_the_requested_phase_and_later(self, authed_client):
+        early = TrialFactory(disease='Multiple Myeloma', phases=['PHASE1'], phase_code_min=1)
+        late = TrialFactory(disease='Multiple Myeloma', phases=['PHASE3'], phase_code_min=3)
+        response = authed_client.get('/trials/search/?phase=PHASE3')
+        assert response.status_code == 200
+        ids = {t['trialId'] for t in response.data['results']}
+        assert late.id in ids
+        assert early.id not in ids, (
+            'a PHASE1 trial survived ?phase=PHASE3 — the parameter is being '
+            'dropped before it reaches StudyPreferences again'
+        )
+
+    def test_absent_phase_keeps_everything(self, authed_client):
+        TrialFactory(disease='Multiple Myeloma', phases=['PHASE1'], phase_code_min=1)
+        TrialFactory(disease='Multiple Myeloma', phases=['PHASE3'], phase_code_min=3)
+        response = authed_client.get('/trials/search/')
+        assert len(response.data['results']) == 2
+
+    def test_unknown_phase_value_is_ignored_not_fatal(self, authed_client):
+        """`by_phase` only acts on values it recognises. A junk value must
+        not 500 and must not silently empty the list."""
+        TrialFactory(disease='Multiple Myeloma', phases=['PHASE2'], phase_code_min=2)
+        response = authed_client.get('/trials/search/?phase=NOT_A_PHASE')
+        assert response.status_code == 200
+        assert len(response.data['results']) == 1
+
+    def test_trials_without_a_phase_drop_out_of_every_phase_filter(self, authed_client):
+        """Documents a sharp edge that activating this parameter exposes.
+
+        `phase_code_min` is nullable and `NULL >= 0` is NULL, so a trial
+        whose phase was never ingested disappears the moment the user
+        touches the phase filter — including at the lowest value, where a
+        reader would expect "everything". Worth knowing before the filter
+        reaches the UI in phase 1; changing `by_phase` would be a matcher
+        behaviour change and is out of scope here.
+        """
+        TrialFactory(disease='Multiple Myeloma', phases=[], phase_code_min=None)
+        assert len(authed_client.get('/trials/search/').data['results']) == 1
+        response = authed_client.get('/trials/search/?phase=EARLY_PHASE1')
+        assert response.data['results'] == []
+
+
+@pytest.mark.django_db
+class TestRecruitmentStatusOptions:
+    """`/form-settings/` gains the trial recruitment states.
+
+    The only status enum it exposed was `statuses` — the patient-invitation
+    one ("Looking for trial", "Waiting for patient acceptance") — so a client
+    building a recruitment filter either rendered that wrong vocabulary or
+    hard-coded the list, which the federated remote does today.
+    """
+
+    def test_options_are_exposed(self, authed_client):
+        response = authed_client.get('/form-settings/')
+        assert response.status_code == 200
+        values = [o['value'] for o in response.data['recruitmentStatuses']['options']]
+        # The two the queryset special-cases, plus the fall-through states.
+        assert 'RECRUITING' in values
+        assert 'RECRUITING_AND_NOT_YET_RECRUITING' in values
+        assert 'TERMINATED' in values
+
+    def test_every_offered_value_actually_selects_its_trials(self, authed_client):
+        """A status-200 assertion would not bite here: `by_recruitment_status`
+        never raises — an unrecognised value just matches zero rows, so a
+        typo'd option would pass. Assert the option round-trips instead:
+        seed one trial in that state and require the filter to return it.
+        """
+        options = authed_client.get('/form-settings/').data['recruitmentStatuses']['options']
+        singles = [o['value'] for o in options
+                   if o['value'] not in ('', 'RECRUITING_AND_NOT_YET_RECRUITING')]
+        assert singles, 'no single-state options to check'
+        for value in singles:
+            trial = TrialFactory(disease='Multiple Myeloma', recruitment_status=value)
+            response = authed_client.get(f'/trials/search/?recruitmentStatus={value}')
+            assert response.status_code == 200
+            assert trial.id in {t['trialId'] for t in response.data['results']}, (
+                f'{value!r} is offered by /form-settings/ but selects nothing'
+            )
+            trial.delete()
+
+    def test_the_combined_value_selects_both_of_its_states(self, authed_client):
+        recruiting = TrialFactory(disease='Multiple Myeloma', recruitment_status='RECRUITING')
+        not_yet = TrialFactory(disease='Multiple Myeloma', recruitment_status='NOT_YET_RECRUITING')
+        completed = TrialFactory(disease='Multiple Myeloma', recruitment_status='COMPLETED')
+        response = authed_client.get(
+            '/trials/search/?recruitmentStatus=RECRUITING_AND_NOT_YET_RECRUITING'
+        )
+        ids = {t['trialId'] for t in response.data['results']}
+        assert ids == {recruiting.id, not_yet.id}
+        assert completed.id not in ids
+
+    def test_does_not_retype_the_trial_detail_field(self, authed_client):
+        """Guard on the namespace collision this key was renamed to avoid.
+
+        `trial_details/trial_attributes.py` resolves a detail field's
+        `options` by matching the field's name against `all_options()` keys.
+        A key spelled `recruitmentStatus` (singular) therefore turns the
+        detail page's Recruitment Status from a plain string into a select —
+        an unrelated contract change riding along on a filter fix.
+        """
+        from trials.services.value_options import ValueOptions
+
+        assert 'recruitmentStatuses' in ValueOptions().all_options()
+        assert 'recruitmentStatus' not in ValueOptions().all_options()

--- a/trials/api/trials_views.py
+++ b/trials/api/trials_views.py
@@ -102,6 +102,54 @@ class TrialsViewSet(viewsets.ReadOnlyModelViewSet):
     def _resolve_study_preferences(self) -> StudyPreferences:
         return study_preferences_from_query_params(self.request.query_params)
 
+    def _reject_user_scoped_search_type(self, search_type):
+        """`?type=favorites` / `?type=my_trials` have no meaning here yet.
+
+        Both name a per-user relation to a trial, and EXACT holds no per-user
+        state: the search types were inherited from CB, where `add_favorite()`
+        / `add_for_participation()` annotate the queryset from `UserTrial`.
+        Neither annotation exists here, so what the two types did instead was:
+
+        - `favorites`: `queryset.filter(favorite=True)` against a field the
+          Trial model does not have — a FieldError surfacing as a 500.
+        - `my_trials`: no narrowing at all. `filtered_trials` routes both
+          through `filter_for_admin`, which skips the eligibility filter, so
+          the response was the whole corpus presented as the patient's
+          registered trials — wrong in a way nothing on screen reveals.
+
+        Fail closed until the real path lands: the favorites list will be
+        supplied by PROMOP and pushed down as a bounded `trial_ids` filter
+        (see docs/federated-ui-parity-plan.md, phase 2). A 400 naming the
+        reason beats either a 500 or a plausible wrong answer.
+
+        `not_eligible` goes too, for the same reason wearing different
+        clothes: it matches no branch in `add_potential_attrs_count`, so it
+        fell through to no narrowing at all and returned the eligible +
+        potential set — the exact inverse of its name. It was in the API
+        docs, so a client could be asking for it today and rendering
+        "trials you do not qualify for" over trials the patient does.
+
+        `all` is deliberately left alone. It reaches the same admin branch
+        and returns the same unnarrowed corpus, but that corpus is what it
+        names — a caller asking for every trial gets every trial. The
+        others promise a subset they cannot deliver.
+        """
+        if search_type in ('favorites', 'my_trials'):
+            raise serializers.ValidationError({
+                'type': [
+                    f"'{search_type}' is not supported: EXACT stores no per-user "
+                    f"trial state. Send the trial ids to filter by instead."
+                ]
+            })
+        if search_type == 'not_eligible':
+            raise serializers.ValidationError({
+                'type': [
+                    "'not_eligible' is not supported: the queryset has no such "
+                    "narrowing, and the value used to return the eligible and "
+                    "potential trials instead — the inverse of what it names."
+                ]
+            })
+
     def get_queryset(self, patient_info=None):
         if patient_info is None:
             patient_info = self._resolve_patient_info()
@@ -109,6 +157,13 @@ class TrialsViewSet(viewsets.ReadOnlyModelViewSet):
         queryset = Trial.objects.all()
         study_prefs = self._resolve_study_preferences()
         search_type = self.request.query_params.get('type', None)
+        # Only where `type` is actually consumed. It reaches `filtered_trials`
+        # from `list` and `count` as well as `search`, so all three are
+        # covered — but `retrieve` ignores the parameter entirely, and
+        # rejecting it there would turn a working detail page into a 400 for
+        # any UI that carries the tab it came from in the query string.
+        if self.action in ('list', 'count', 'search'):
+            self._reject_user_scoped_search_type(search_type)
 
         if self.action in ['list', 'count', 'search']:
             queryset, _ = queryset.filtered_trials(
@@ -154,10 +209,18 @@ class TrialsViewSet(viewsets.ReadOnlyModelViewSet):
             queryset = queryset.order_by('-match_score', '-posted_date', 'id')
 
         if self.action == 'search':
-            if search_type == 'favorites':
-                queryset = queryset.filter(favorite=True)
-
             counts = self._trials_counts(queryset, patient_info)
+            # Annotated but NOT narrowed by `type`, kept for the tab counts.
+            # `with_potential_attrs_count` both annotates and applies the
+            # eligible/potential filter, so counting the response's own
+            # queryset would count an already-narrowed set: on the Potential
+            # tab the Eligible badge would read 0. The tab bar has to be
+            # told about the whole matched corpus, not the tab it is on.
+            self._tab_counts_source = queryset.with_potential_attrs_count(
+                patient_info, None, counts,
+            )
+            self._tab_counts_patient_info = patient_info
+            self._tab_counts_search_type = search_type
             queryset = queryset.with_potential_attrs_count(patient_info, search_type, counts)
 
             sort_by = self.request.query_params.get('sort', 'goodnessScore')
@@ -301,9 +364,76 @@ class TrialsViewSet(viewsets.ReadOnlyModelViewSet):
         page = self.paginate_queryset(queryset)
         if page is not None:
             serializer = self.get_serializer(page, many=True)
-            return self.get_paginated_response(serializer.data)
+            tab_counts = self._tab_counts()
+            extra_keys = {} if tab_counts is None else {'tabCounts': tab_counts}
+            return self.get_paginated_response(serializer.data, extra_keys=extra_keys)
         serializer = self.get_serializer(queryset, many=True)
         return Response(serializer.data)
+
+    def _tab_counts(self) -> Optional[dict]:
+        """Totals for the tab bar, or None when they would be a lie.
+
+        Deliberately computed here rather than at a `/trials/counts/`
+        endpoint of its own. Counts are only meaningful under a patient
+        context, and the only way to send one is a POST body — the
+        `?person_id=` path is gated off outside DEBUG. A GET-only counts
+        endpoint would answer every federated caller with
+        `patient_info=None`, where `potential_attrs_count` collapses to
+        `num_nonnulls(NULL)`: `potential` structurally zero and every row
+        in the corpus labelled eligible, with nothing in the response to
+        say so.
+
+        Two cases return None instead of a plausible-looking number, for
+        that same reason:
+
+        - **No patient context.** Nothing has been judged, so calling the
+          corpus `eligible` would assert a clinical verdict nobody made.
+          `GET /trials/search/` can be called this way, so moving the
+          counts onto it does not by itself fix what killed the endpoint.
+        - **`?type=all`.** That routes through `filter_for_admin`, which
+          skips the eligibility filter entirely; the rows are the corpus
+          the caller asked for, but a per-row verdict was never computed.
+          Listing them is honest, counting them as eligible is not.
+
+        Otherwise the source is the annotated-but-not-type-narrowed
+        queryset (`get_queryset`), run through the same `filter_queryset`
+        the listed rows went through — so `?search=`, which DRF applies
+        outside the matcher, lands on both — and the counts describe the
+        whole matched corpus regardless of which tab is active.
+        """
+        source = getattr(self, '_tab_counts_source', None)
+        if source is None:
+            return None
+        if getattr(self, '_tab_counts_patient_info', None) is None:
+            return None
+        if getattr(self, '_tab_counts_search_type', None) == 'all':
+            return None
+
+        source = self.filter_queryset(source)
+        # `potential_attrs_count` is `num_nonnulls(...)`, never NULL, so the
+        # two buckets partition the source exactly and the second is
+        # arithmetic rather than a third pass over the corpus.
+        total = source.count()
+        eligible = source.filter(potential_attrs_count=0).count()
+        return {'eligible': eligible, 'potential': total - eligible}
+
+    @action(methods=['post'], detail=False, url_path='search/match',
+            url_name='search-match')
+    def search_match(self, request, *args, **kwargs):
+        """POST alias for `search`, carrying `patient_info` in the body.
+
+        The existing `match` alias routes to `list`, whose ordering is fixed
+        at `-match_score, -posted_date, id`; only `search` reads `?sort=` and
+        carries the tab counts. So a host holding an inline `patient_info` payload —
+        the federated remote's default path, since GET-with-body is forbidden
+        by the Fetch spec and dropped by axios's XHR adapter — could reach
+        neither sorting nor counts at all.
+
+        Binds `self.action = 'search'` so every `self.action == 'search'`
+        branch in `get_queryset` fires, exactly as `match` does for `list`.
+        """
+        self.action = 'search'
+        return self.search(request, *args, **kwargs)
 
 
 # ---------------------------------------------------------------------------

--- a/trials/services/study_preferences.py
+++ b/trials/services/study_preferences.py
@@ -106,6 +106,11 @@ def study_preferences_from_query_params(params) -> StudyPreferences:
         distance=_float('distance'),
         distance_units=params.get('distanceUnits', 'km') or 'km',
         validated_only=_bool('validatedOnly'),
+        # `phase` was declared on the dataclass and consumed by the queryset
+        # (`by_phase`) from the start, but never read off the query string —
+        # so `?phase=` silently matched everything. CB persists the same
+        # filter in StudyInfo and spells it `phase`.
+        phase=_str('phase'),
         last_update=_str('lastUpdate'),
         first_enrolment=_str('firstEnrolment'),
     )

--- a/trials/services/value_options.py
+++ b/trials/services/value_options.py
@@ -13,13 +13,16 @@ def ordered_dict(data):
 
 class ValueOptions:
     def cache_key(self):
+        # v3: bumped for the `recruitmentStatuses` key below — a deploy
+        # hitting a warm cache would otherwise serve the pre-key shape for up
+        # to an hour, and the search filter's dropdown would come back empty.
         # v2: bumped on #63 — `all_options()` gained 40 new per-disease
         # keys (flipiScore{Mm|Fl|Bc|Cll|Mcl}, cytogenicMarkers{…}, …).
         # Without the bump, a deploy hitting a populated Redis cache
         # would serve the pre-#63 shape (missing those 40 keys), letting
         # the cached blob drift from fresh `all_options()` output until
         # the 1h TTL expires.
-        return 'ValueOptions.all_options.v2'
+        return 'ValueOptions.all_options.v3'
 
     @staticmethod
     def to_value_and_label(data):
@@ -104,6 +107,33 @@ class ValueOptions:
 
         items = ConcomitantMedication.objects.filter(concomitantmedicationdisease__disease__code=disease_code).all()
         return ordered_dict({x.code: x.title for x in items})
+
+    @cached_property
+    def recruitment_statuses(self):
+        """Trial recruitment states, for the search filter's dropdown.
+
+        Distinct from `statuses` below, which is the patient-invitation enum
+        ("Looking for trial", "Waiting for patient acceptance", …). A frontend
+        reaching for a recruitment filter finds only that one today and either
+        renders the wrong vocabulary or hard-codes this list itself — the
+        federated remote does the latter.
+
+        Values are what `by_recruitment_status` accepts: the two it special-
+        cases, plus the ClinicalTrials.gov states it falls through to as a
+        case-insensitive exact match on `Trial.recruitment_status`.
+        """
+        return {
+            '': 'ALL',
+            'RECRUITING': 'Recruiting',
+            'RECRUITING_AND_NOT_YET_RECRUITING': 'Recruiting & Not Yet Recruiting',
+            'NOT_YET_RECRUITING': 'Not yet recruiting',
+            'ENROLLING_BY_INVITATION': 'Enrolling by invitation',
+            'ACTIVE_NOT_RECRUITING': 'Active, not recruiting',
+            'COMPLETED': 'Completed',
+            'SUSPENDED': 'Suspended',
+            'TERMINATED': 'Terminated',
+            'WITHDRAWN': 'Withdrawn',
+        }
 
     @cached_property
     def statuses(self):
@@ -912,6 +942,16 @@ class ValueOptions:
         return {
             'statuses': {
                 'options': self.to_value_and_label(self.statuses)
+            },
+            # Plural on purpose. `all_options()` is a shared namespace: the
+            # trial-detail templates in trial_details/trial_attributes.py look
+            # up a field's `options` by matching the field name against these
+            # keys, so a key named `recruitmentStatus` would silently retype
+            # the detail page's Recruitment Status field from string to select.
+            # `phases` / `studyType` / `register` are wired that way deliberately;
+            # this one is for the search filter only.
+            'recruitmentStatuses': {
+                'options': self.to_value_and_label(self.recruitment_statuses)
             },
             'register': {
                 'options': self.to_value_and_label(self.registers)


### PR DESCRIPTION
Phase 0 of `docs/federated-ui-parity-plan.md`. Closes #417.

Four defects and two additions, all in the trial-search API. No frontend changes — this is the backend the phase 1 UI sits on.

## Defects

| | Was | Now |
|---|---|---|
| `?phase=` | Declared on `StudyPreferences`, consumed by `by_phase`, and populated by nobody — the filter silently matched everything | Parsed from the query string |
| `?type=favorites` | `filter(favorite=True)` against a column this `Trial` has no annotation for → FieldError → **500** | 400 naming the reason |
| `?type=my_trials` | Routed through `filter_for_admin`, which skips eligibility — the whole corpus returned as the patient's registered trials | 400 |
| `?type=not_eligible` | Matched no branch, so it narrowed nothing and returned the eligible + potential set — the **inverse of its name**, while documented as supported | 400 |

The rejections fire in `list`, `count` and `search` — all three pass `type` into `filtered_trials` — but deliberately **not** in `retrieve`, which ignores the parameter: rejecting it there would 400 a working detail page for any UI that carries the tab it came from in the query string. `all` is left alone; it reaches the same admin branch, but the corpus it returns is the corpus it names.

Activating `?phase=` exposes two sharp edges, pinned by tests rather than changed (altering `by_phase` is a matcher behaviour change): it means "that phase **or later**", and a trial with no ingested phase drops out of *every* value, including the lowest, because `NULL >= 0` is NULL.

## Additions

**`POST /trials/search/match/`** — `search` reachable with an inline `patient_info` body. The existing `match` alias binds to `list`, whose ordering is fixed at `-match_score, -posted_date, id`; only `search` reads `?sort=`. So an inline-payload caller — the federated remote's default path — could not sort at all.

**`tabCounts` on the search response** — `{eligible, potential}` over the whole matched corpus, so a tab bar can label itself from the response it already has.

This started as a `/trials/counts/` endpoint and review killed it: counts are only meaningful under a patient context, the only way to send one is a POST body (`?person_id=` is gated off outside DEBUG), so a GET-only endpoint answered every federated caller with `patient_info=None` — where the annotation collapses to `num_nonnulls(NULL)`, nothing is potential, every row is eligible, and nothing in the response says so. Two further revisions came out of review: the counts are taken **before** the `type` narrowing (otherwise the Eligible badge reads 0 while the user is on the Potential tab), and the key is **omitted rather than zeroed** when there is no patient context or under `?type=all`, where no per-row verdict was ever computed.

**`recruitmentStatuses` in `/form-settings/`** — the only status enum exposed was `statuses`, the patient-invitation one, so clients hard-code the recruitment list; the federated remote does today. Named plural on purpose: `all_options()` is a shared namespace and `trial_details/trial_attributes.py` resolves a detail field's `options` by matching the field name against these keys, so a singular `recruitmentStatus` retyped the detail page's field from string to select. An existing template test caught it; a new test now guards both directions. Cache key bumped to v3.

## Docs

`docs/api.md` is corrected where it was already wrong or became wrong: it pointed callers at `GET /trials/search/` for the `favorites` filter, documented `type`'s default as `all` when it is no value at all and the two take different branches, claimed `GET /trials/` filters by match status when `list` never applies the narrowing, and told callers to POST `patientInfo` when the resolver reads only `patient_info`.

## Tests

30 new. Verified non-vacuous by reverting the three source files to the base and rerunning: **25 fail**. Specifically hardened after review found earlier versions vacuous — the counts test seeds a genuinely potential trial so the partition cannot pass as `n + 0 == n`; the ordering test asserts the matchScore tie it depends on instead of assuming it; the recruitment-status test round-trips every offered option through the filter rather than asserting a 200 that `by_recruitment_status` returns for any string at all.

Full suite: 924 passed, 5 skipped (also on a freshly created DB).

## Filed separately, not fixed here

- **#424** — `?type=all` ignores `phase`, `recruitmentStatus`, `sponsor`, `searchTreatment`, `country`/`region` and the date filters. Fixing it changes what that path returns, which is a matcher behaviour change wanting its own differential run.
- **#423** — `GET /trials/{id}/` 500s with no patient context (pre-existing; found while writing these tests).

## Review

Three rounds of fresh-context review plus `codex review`, reconciled: 20 findings across the first two rounds, including the counts-endpoint design being unworkable and two of my own tests being vacuous. Final round clean on code, two doc nits which are fixed in the pushed commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015G5YkuAcDZQUTutNEBGwyX