### PR TITLE
feat(search): filter the match by a bounded list of trial ids (#419)

### DIFF
--- a/docs/federated-ui-parity-plan.md
+++ b/docs/federated-ui-parity-plan.md
@@ -108,6 +108,8 @@ Data: `POST /trials/match/` with an inline payload, or `GET /trials/?person_id=`
 
 > **Why the body, not the query string.** The id list can get long, and the inline patient payload already travels in the body. A cap on the list length is mandatory and validated on entry: without it this is a ready-made vector for a request that expands into thousands of WHERE clauses.
 
+> **Do not attach `trial_ids` to the detail request.** `match_detail` shares `get_queryset`, so an id list that excludes the trial being opened turns its detail page into a 404. That is the right behaviour for a filter, and a live footgun for a host that keeps the favorites ids in a store and lets an interceptor add them to every match POST: every non-bookmarked trial would stop opening. The list request carries them; the detail request does not.
+
 > **Inline editing: write OMOP facts, not PatientRecord.** In PROMOP, `PatientRecord` is a read-only projection re-derived by a signal from the OMOP tables. There are two sanctioned write paths: granular CRUD on the OMOP tables (`/api/v1/measurements/`, `/conditions/`, …) and `PATCH /api/v1/patient-records/{person_id}/`, which does *not* write to the projection but translates each field into the matching OMOP table write and triggers the re-derivation. Inline editing should use the second — but every form field needs to be checked for an existing OMOP mapping; fields without one stay read-only rather than "saving" into nothing.
 
 ---

--- a/tests/views/test_trial_ids_filter.py
+++ b/tests/views/test_trial_ids_filter.py
@@ -1,0 +1,224 @@
+"""`trial_ids` — how the federated UI's Favorites tab narrows the match.
+
+The bookmarks live in PROMOP, which knows nothing about matching. The ids
+come down in the request body and the narrowing happens inside EXACT's
+queryset, because that is the only place that can sort and paginate them
+alongside the match scores and produce a total that agrees with the rows it
+listed. Phase 2 of docs/federated-ui-parity-plan.md.
+"""
+import pytest
+from rest_framework.authtoken.models import Token
+from rest_framework.test import APIClient
+
+from accounts.models import Identity
+from tests.factories import TrialFactory
+
+
+@pytest.fixture
+def authed_client(db):
+    user, _ = Identity.objects.get_or_create(issuer='urn:local', sub='trial-ids-tester')
+    token, _ = Token.objects.get_or_create(user=user)
+    client = APIClient()
+    client.credentials(HTTP_AUTHORIZATION=f'Token {token.key}')
+    return client
+
+
+MM = {'disease': 'multiple myeloma'}
+
+
+def post(client, ids=None, path='/trials/search/match/', **extra):
+    body = {'patient_info': MM, **extra}
+    if ids is not None:
+        body['trial_ids'] = ids
+    return client.post(path, body, format='json')
+
+
+@pytest.mark.django_db
+class TestNarrowing:
+    def test_keeps_only_the_ids_asked_for(self, authed_client):
+        wanted = TrialFactory(disease='Multiple Myeloma')
+        TrialFactory(disease='Multiple Myeloma')
+        response = post(authed_client, [wanted.id])
+        assert response.status_code == 200
+        assert [t['trialId'] for t in response.data['results']] == [wanted.id]
+
+    def test_the_total_agrees_with_the_narrowed_set(self, authed_client):
+        """Narrowing has to happen before the matcher, or `itemsTotalCount`
+        counts a corpus the response does not list."""
+        wanted = TrialFactory(disease='Multiple Myeloma')
+        for _ in range(3):
+            TrialFactory(disease='Multiple Myeloma')
+        response = post(authed_client, [wanted.id])
+        assert response.data['itemsTotalCount'] == 1
+
+    def test_the_tab_counts_describe_the_narrowed_set_too(self, authed_client):
+        eligible = TrialFactory(disease='Multiple Myeloma')
+        TrialFactory(disease='Multiple Myeloma')
+        response = post(authed_client, [eligible.id])
+        counts = response.data['tabCounts']
+        assert counts['eligible'] + counts['potential'] == 1
+
+    def test_an_id_that_does_not_match_the_patient_is_still_dropped(self, authed_client):
+        """The filter narrows, it does not override. A bookmarked trial for
+        another disease must not reappear because its id was sent."""
+        bc = TrialFactory(disease='Breast Cancer')
+        mm = TrialFactory(disease='Multiple Myeloma')
+        response = post(authed_client, [bc.id, mm.id])
+        assert [t['trialId'] for t in response.data['results']] == [mm.id]
+
+    def test_sorting_still_applies_within_the_narrowed_set(self, authed_client):
+        small = TrialFactory(disease='Multiple Myeloma', enrollment_count=10)
+        large = TrialFactory(disease='Multiple Myeloma', enrollment_count=900)
+        response = post(
+            authed_client, [small.id, large.id],
+            path='/trials/search/match/?sort=enrollment',
+        )
+        ids = [t['trialId'] for t in response.data['results']]
+        assert ids.index(large.id) < ids.index(small.id)
+
+    def test_it_also_applies_to_the_detail_endpoint_path(self, authed_client):
+        """`match_detail` shares `get_queryset`. A caller sending both an id
+        in the URL and a `trial_ids` list that excludes it must get a 404,
+        not a trial the filter said to leave out."""
+        trial = TrialFactory(disease='Multiple Myeloma')
+        other = TrialFactory(disease='Multiple Myeloma')
+        response = authed_client.post(
+            f'/trials/{trial.id}/match/',
+            {'patient_info': MM, 'trial_ids': [other.id]},
+            format='json',
+        )
+        assert response.status_code == 404
+
+
+@pytest.mark.django_db
+class TestEmptyIsNotAbsent:
+    def test_an_empty_list_returns_nothing(self, authed_client):
+        """The case that matters. `[]` means "my bookmarks, of which there
+        are none" — answering it with the whole corpus would show a reader
+        every trial under a Favorites tab they have not used."""
+        TrialFactory(disease='Multiple Myeloma')
+        TrialFactory(disease='Multiple Myeloma')
+        response = post(authed_client, [])
+        assert response.status_code == 200
+        assert response.data['results'] == []
+        assert response.data['itemsTotalCount'] == 0
+
+    def test_omitting_the_key_is_no_filter_at_all(self, authed_client):
+        TrialFactory(disease='Multiple Myeloma')
+        TrialFactory(disease='Multiple Myeloma')
+        response = post(authed_client)
+        assert response.data['itemsTotalCount'] == 2
+
+
+@pytest.mark.django_db
+class TestValidation:
+    def test_a_list_longer_than_the_cap_is_refused(self, authed_client):
+        """Every id becomes part of an `IN (...)`. Unbounded, this is a
+        request that expands into thousands of clauses."""
+        TrialFactory(disease='Multiple Myeloma')
+        response = post(authed_client, list(range(1, 502)))
+        assert response.status_code == 400
+        assert 'trial_ids' in response.data
+
+    def test_the_cap_itself_is_accepted(self, authed_client):
+        trial = TrialFactory(disease='Multiple Myeloma')
+        ids = [trial.id] + list(range(10_000, 10_499))
+        assert len(ids) == 500
+        assert post(authed_client, ids).status_code == 200
+
+    @pytest.mark.parametrize('payload', ['1,2,3', 42, {'id': 1}])
+    def test_a_non_list_is_refused(self, authed_client, payload):
+        response = post(authed_client, payload)
+        assert response.status_code == 400
+
+    @pytest.mark.parametrize('bad', ['abc', None, 3.5, [1]])
+    def test_an_unparseable_id_is_refused(self, authed_client, bad):
+        response = post(authed_client, [1, bad])
+        assert response.status_code == 400
+
+    def test_a_boolean_is_not_a_trial_id(self, authed_client):
+        """`True` is an `int` in Python and would silently become trial 1."""
+        response = post(authed_client, [True])
+        assert response.status_code == 400
+
+    def test_numeric_strings_are_accepted(self, authed_client):
+        """JSON from a browser often carries ids as strings."""
+        trial = TrialFactory(disease='Multiple Myeloma')
+        response = post(authed_client, [str(trial.id)])
+        assert [t['trialId'] for t in response.data['results']] == [trial.id]
+
+    def test_the_rejected_favorites_type_now_names_the_real_path(self, authed_client):
+        TrialFactory(disease='Multiple Myeloma')
+        response = authed_client.get('/trials/search/?type=favorites')
+        assert response.status_code == 400
+        assert 'trial_ids' in str(response.data['type'])
+
+
+@pytest.mark.django_db
+class TestIdsThatLookNumericButAreNot:
+    """`str.isdigit()` is not "is an integer literal".
+
+    Guarding with it and converting afterwards is the bug: for some
+    characters the guard passes and `int()` then raises, which leaves the
+    view as a 500 rather than the 400 every other bad id gets.
+    """
+
+    @pytest.mark.parametrize('value', ['²', '³', '¹'])
+    def test_a_superscript_digit_is_a_400_not_a_500(self, authed_client, value):
+        response = post(authed_client, [value])
+        assert response.status_code == 400
+
+    @pytest.mark.parametrize('value', ['--5', '- 5', '+5'])
+    def test_a_malformed_sign_is_refused(self, authed_client, value):
+        response = post(authed_client, [value])
+        assert response.status_code == 400
+
+    def test_fullwidth_digits_are_refused(self, authed_client):
+        """`int('１２３')` succeeds and yields 123 — a different trial from
+        the literal text the caller sent."""
+        assert post(authed_client, ['１２３']).status_code == 400
+
+    def test_a_negative_id_is_refused(self, authed_client):
+        """A primary key is never negative, and admitting a sign is what let
+        `'--5'` through."""
+        assert post(authed_client, [-1]).status_code == 400
+        assert post(authed_client, ['-1']).status_code == 400
+
+    def test_an_absurdly_long_digit_string_is_a_400(self, authed_client):
+        """Python refuses to parse an int past a digit limit, which would
+        have escaped as a 500 too."""
+        assert post(authed_client, ['9' * 5000]).status_code == 400
+
+    def test_the_largest_id_the_column_can_hold_is_just_a_miss(self, authed_client):
+        TrialFactory(disease='Multiple Myeloma')
+        response = post(authed_client, [2 ** 63 - 1])
+        assert response.status_code == 200
+        assert response.data['itemsTotalCount'] == 0
+
+    @pytest.mark.parametrize('value', [2 ** 63, 10 ** 18 * 10, '9999999999999999999'])
+    def test_an_id_beyond_the_bigint_range_is_refused(self, authed_client, value):
+        """Not pedantry about a value that would not match anyway: above the
+        bigint range PostgreSQL types the constant as `numeric`, coerces the
+        `id` column to compare it, and gives up the primary-key index. A
+        list of 500 of those is a table scan in the shape of a bookmarks
+        lookup."""
+        assert post(authed_client, [value]).status_code == 400
+
+
+@pytest.mark.django_db
+class TestQueryStringIsNotTheChannel:
+    def test_trial_ids_in_the_query_string_is_refused(self, authed_client):
+        """Ignored, it answers a bookmarks question with the whole corpus —
+        the same wrong answer an empty list is guarded against, reached
+        through a different door. The body is the channel."""
+        TrialFactory(disease='Multiple Myeloma')
+        response = authed_client.get('/trials/search/?trial_ids=1,2')
+        assert response.status_code == 400
+        assert 'trial_ids' in response.data
+
+    def test_the_body_still_works_with_a_query_string_present(self, authed_client):
+        trial = TrialFactory(disease='Multiple Myeloma')
+        response = post(
+            authed_client, [trial.id], path='/trials/search/match/?sort=distance'
+        )
+        assert response.status_code == 200

--- a/trials/api/trials_views.py
+++ b/trials/api/trials_views.py
@@ -1,4 +1,5 @@
 import logging
+import re
 from typing import TYPE_CHECKING, Optional
 
 from django.db.models import F, Prefetch, QuerySet
@@ -18,6 +19,23 @@ from trials.services.study_preferences import StudyPreferences, study_preference
 from trials.services.value_options import ValueOptions
 
 logger = logging.getLogger(__name__)
+
+#: A trial id as it may appear in a JSON string: ASCII digits, nothing else,
+#: and at most as many as a bigint can hold. `str.isdigit()` is not
+#: equivalent — see `TrialsViewSet._trial_id`.
+#:
+#: The length bound is not cosmetic: Python refuses to parse an integer past
+#: a digit limit (4300 by default), so an unbounded match sends a 5000-digit
+#: string into `int()` and the `ValueError` escapes the view as a 500 — the
+#: same failure the ASCII match was added to close.
+_TRIAL_ID_RE = re.compile(r'\d{1,19}', re.ASCII)
+
+#: The largest value the `id` column can hold (`BigAutoField` -> signed
+#: bigint). Anything above it is not merely a miss: PostgreSQL types the
+#: constant as `numeric`, which coerces the column in the `IN` comparison and
+#: gives up the primary-key index — so 500 such ids turn a bookmarks lookup
+#: into a table scan.
+_MAX_TRIAL_ID = 2 ** 63 - 1
 
 if TYPE_CHECKING:
     from trials.services.patient_info.patient_info import PatientInfo
@@ -138,7 +156,8 @@ class TrialsViewSet(viewsets.ReadOnlyModelViewSet):
             raise serializers.ValidationError({
                 'type': [
                     f"'{search_type}' is not supported: EXACT stores no per-user "
-                    f"trial state. Send the trial ids to filter by instead."
+                    f"trial state. POST the ids to filter by as `trial_ids` "
+                    f"instead — see /trials/search/match/."
                 ]
             })
         if search_type == 'not_eligible':
@@ -150,7 +169,122 @@ class TrialsViewSet(viewsets.ReadOnlyModelViewSet):
                 ]
             })
 
+    #: The most bookmarks one request may filter by. Every id becomes part
+    #: of an `IN (...)`, so an unbounded list is a request that expands into
+    #: thousands of clauses — and a caller with that many bookmarks needs a
+    #: different feature, not a longer query.
+    MAX_TRIAL_IDS = 500
+
+    def _resolve_trial_ids(self):
+        """The `trial_ids` filter from the request body, or None.
+
+        This is how the federated UI's Favorites tab works: the bookmarks
+        live in PROMOP, which knows nothing about matching, so the ids come
+        down here and the narrowing happens inside the queryset — the only
+        place that can sort and paginate them alongside the match scores,
+        and produce a total that agrees with what it listed.
+
+        Body, not query string: the list can be long and the patient payload
+        is already travelling in the body on this path.
+
+        `None` means "no such filter". An EMPTY LIST does not: it means the
+        caller asked for their bookmarks and has none, so the honest answer
+        is no trials. Treating `[]` as absent would answer an empty
+        Favorites tab with the entire corpus.
+        """
+        # In the query string it is a mistake, and a quiet one: ignored, the
+        # request answers a bookmarks question with the whole corpus — the
+        # same wrong answer `[]` is guarded against, through another door.
+        if 'trial_ids' in self.request.query_params:
+            raise serializers.ValidationError({
+                'trial_ids': [
+                    'send trial_ids in the request body, not the query string '
+                    '— see POST /trials/search/match/.'
+                ]
+            })
+
+        data = getattr(self.request, 'data', None)
+        if not isinstance(data, dict) or 'trial_ids' not in data:
+            return None
+
+        raw = data.get('trial_ids')
+        if not isinstance(raw, (list, tuple)):
+            raise serializers.ValidationError(
+                {'trial_ids': ['must be a list of trial ids.']}
+            )
+        if len(raw) > self.MAX_TRIAL_IDS:
+            raise serializers.ValidationError({
+                'trial_ids': [
+                    f'at most {self.MAX_TRIAL_IDS} ids may be sent; got {len(raw)}.'
+                ]
+            })
+
+        ids = []
+        for value in raw:
+            ids.append(self._trial_id(value))
+        return ids
+
+    @staticmethod
+    def _trial_id(value):
+        """One id, or a 400.
+
+        Strict on purpose — every loose parse here turns into a filter the
+        caller did not ask for:
+
+        - `True` is an `int` in Python, so `int(True)` is trial 1.
+        - `int(3.5)` is 3, so a float silently becomes a DIFFERENT trial
+          rather than being refused.
+        - `str.isdigit()` is true for characters `int()` then refuses —
+          `'²'`, `'³'` — so guarding with it and converting afterwards
+          raises `ValueError` out of the view as a 500, not a 400.
+        - It is also true for fullwidth digits, where `int('１２３')` does
+          succeed and quietly yields a different trial than the literal
+          text the caller sent.
+
+        Hence an explicit ASCII-digits match rather than a character
+        predicate. Numeric strings are accepted because JSON from a browser
+        routinely carries ids that way; a negative one is refused because a
+        primary key is never negative, and admitting a sign is what let
+        `'--5'` through the old guard.
+        """
+        if isinstance(value, bool) or isinstance(value, float):
+            raise serializers.ValidationError(
+                {'trial_ids': [f'{value!r} is not a trial id.']}
+            )
+        if isinstance(value, int):
+            return TrialsViewSet._in_range(value, value)
+        if isinstance(value, str) and _TRIAL_ID_RE.fullmatch(value.strip()):
+            return TrialsViewSet._in_range(int(value), value)
+        raise serializers.ValidationError(
+            {'trial_ids': [f'{value!r} is not a trial id.']}
+        )
+
+    @staticmethod
+    def _in_range(number, original):
+        """Refuse an id the `id` column could not hold.
+
+        Not pedantry about a value that simply would not match: above the
+        bigint range PostgreSQL types the constant as `numeric`, coerces the
+        column to compare, and stops using the primary-key index. A list of
+        500 of those is a table scan wearing the shape of a bookmarks
+        lookup.
+
+        Negative is refused for its own reason — a primary key is never
+        negative, and admitting a sign is what let `'--5'` past an earlier
+        version of this guard.
+        """
+        if 0 <= number <= _MAX_TRIAL_ID:
+            return number
+        raise serializers.ValidationError(
+            {'trial_ids': [f'{original!r} is not a trial id.']}
+        )
+
     def get_queryset(self, patient_info=None):
+        # Before `_resolve_patient_info`, which can be a round trip to
+        # PROMOP: a malformed body should not pay for that to be told it is
+        # malformed.
+        trial_ids = self._resolve_trial_ids()
+
         if patient_info is None:
             patient_info = self._resolve_patient_info()
 
@@ -164,6 +298,12 @@ class TrialsViewSet(viewsets.ReadOnlyModelViewSet):
         # any UI that carries the tab it came from in the query string.
         if self.action in ('list', 'count', 'search'):
             self._reject_user_scoped_search_type(search_type)
+
+        if trial_ids is not None:
+            # Before the matcher, not after: narrowing first means the
+            # scores, the ordering and `itemsTotalCount` are all computed
+            # over the set the caller asked about.
+            queryset = queryset.filter(id__in=trial_ids)
 
         if self.action in ['list', 'count', 'search']:
             queryset, _ = queryset.filtered_trials(


### PR DESCRIPTION
Phase 2 of `docs/federated-ui-parity-plan.md`, EXACT side. Pairs with healthkey-ai/promop#1174, which holds the bookmarks.

## What

`trial_ids` in the body of the POST `match` actions. This is how the federated UI's Favorites tab works: the bookmarks live in PROMOP, which knows nothing about matching, so the ids come down here and the narrowing happens inside EXACT's queryset — the only place that can sort and paginate them alongside the match scores and produce a total that agrees with the rows it listed.

Applied **before** `filtered_trials`, so the scores, the ordering, `itemsTotalCount` and `tabCounts` all describe the set the caller asked about. A test pins that by moving the filter after the tab-count source and watching the counts disagree with the rows.

**An empty list is not an absent one.** `[]` means "my bookmarks, of which there are none". Answering that with the whole corpus would show a reader every trial in the registry under a Favorites tab they have not used. The absence check is `'trial_ids' not in data`, the application check is `is not None`, and there is no truthiness test on the path. A `trial_ids` in the *query string* is now a 400 for the same reason: silently ignored, it produces exactly that wrong answer through another door.

## Validation

Each of these was found by review, and each is a case where a loose parse becomes either a filter the caller did not ask for or a 500:

| Input | Was | Now |
|---|---|---|
| `true` | trial 1 (`int(True)` is 1) | 400 |
| `3.5` | trial 3 (`int(3.5)` truncates) | 400 |
| `"²"`, `"³"` | **500** — `str.isdigit()` is true, `int()` then raises | 400 |
| `"--5"` | **500** — `lstrip('-')` admitted it | 400 |
| `"１２３"` | trial 123 — fullwidth digits convert fine | 400 |
| `"9"*5000` | **500** — Python refuses to parse an int past a digit limit | 400 |
| `2**63` | accepted, and PostgreSQL then types the constant `numeric`, coerces the `id` column and abandons the primary-key index — 500 of those is a table scan in the shape of a bookmarks lookup | 400 |

So: an explicit ASCII-digit match with a length bound, plus a range check against what the column can hold. The list is capped at 500 — checked on the length before any element is parsed, so a hostile list is rejected without parsing it — and validation runs before `_resolve_patient_info`, so a malformed body does not pay for a round trip to PROMOP to be told it is malformed.

## A warning the review earned

`match_detail` shares `get_queryset`, so a host that keeps the favorites ids in a store and lets an interceptor attach them to every match POST would 404 the detail page of every trial the reader has not bookmarked. The list request carries them; the detail request must not. Written into the plan doc.

## Verification

959 tests. An adversarial pass put 57 hostile values through the endpoint — non-ASCII digits of a dozen scripts, signs, unicode whitespace, nested structures, `inf`/`NaN`, oversized literals — and found **no 5xx**. Mutating the parse back to `isdigit()` and removing the range guard fails 9 named tests and reproduces the 500s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015G5YkuAcDZQUTutNEBGwyX