### PR TITLE
feat(federation): the per-user state seam, and the tabs that stand on it (#419)

### DIFF
--- a/frontend/src/federation/Tabs.tsx
+++ b/frontend/src/federation/Tabs.tsx
@@ -1,9 +1,12 @@
 // Tab bar over the trial list, mirroring CB's `TabButton` row on Your
 // Trials. Structure lives in `exact.css` (`.exact-tabs*`).
-import { TABS, tabCount, type TabValue } from "./listChrome";
+import { tabCount, type TabDef, type TabValue } from "./listChrome";
 import type { TabCounts } from "./types";
 
 interface Props {
+  /** The bar to render — which tabs exist depends on whether the host gave
+   *  the component somewhere to keep bookmarks. */
+  tabs: TabDef[];
   active: TabValue;
   onChange: (tab: TabValue) => void;
   /** Server-side totals over the whole matched corpus. Absent when the
@@ -13,9 +16,20 @@ interface Props {
    *  default tab when the server sent no counts and that tab is the one
    *  being listed. */
   activeTabTotal: number | null;
+  /** Totals for the state-backed tabs, counted by whoever holds the state —
+   *  how many the patient saved, which is true whether or not those trials
+   *  still match today. */
+  stateCounts?: { favorites?: number; registered?: number };
 }
 
-export function Tabs({ active, onChange, counts, activeTabTotal }: Props) {
+export function Tabs({
+  tabs,
+  active,
+  onChange,
+  counts,
+  activeTabTotal,
+  stateCounts,
+}: Props) {
   // Plain buttons in a <nav>, not role="tablist"/"tab". The ARIA tab pattern
   // promises arrow-key navigation, a roving tabindex, and an associated
   // tabpanel; announcing "tab, 1 of 3" and then not moving on ← / → is worse
@@ -23,7 +37,7 @@ export function Tabs({ active, onChange, counts, activeTabTotal }: Props) {
   // filters over one list, and `aria-current` says which one is applied.
   return (
     <nav className="exact-tabs" aria-label="Filter trials by match status">
-      {TABS.map((tab) => {
+      {tabs.map((tab) => {
         const isActive = tab.value === active;
         const count = tabCount(
           tab.value,
@@ -32,6 +46,7 @@ export function Tabs({ active, onChange, counts, activeTabTotal }: Props) {
           // labelling an inactive tab with the active tab's count would be
           // a plain lie.
           isActive ? activeTabTotal : null,
+          stateCounts,
         );
         return (
           <button

--- a/frontend/src/federation/TrialCard.tsx
+++ b/frontend/src/federation/TrialCard.tsx
@@ -13,9 +13,23 @@ interface Props {
   trial: TrialMatch;
   onSelect?: (trial: TrialMatch) => void;
   isSelected?: boolean;
+  /** Whether this trial is bookmarked. `undefined` means not known yet —
+   *  the ids are still loading — and renders nothing rather than an
+   *  un-bookmarked star that would flip under the reader's eye. */
+  isFavorite?: boolean;
+  /** Omitted when the host supplied no state adapter, in which case no
+   *  control is drawn: a bookmark button with nowhere to write is a button
+   *  that forgets. */
+  onToggleFavorite?: (next: boolean) => void;
 }
 
-export function TrialCard({ trial, onSelect, isSelected }: Props) {
+export function TrialCard({
+  trial,
+  onSelect,
+  isSelected,
+  isFavorite,
+  onToggleFavorite,
+}: Props) {
   const distance =
     trial.distance != null
       ? `${trial.distance} ${trial.distanceUnits ?? ""}`.trim()
@@ -82,6 +96,26 @@ export function TrialCard({ trial, onSelect, isSelected }: Props) {
         </div>
 
         <div className="exact-card__action">
+          {onToggleFavorite && isFavorite !== undefined ? (
+            <button
+              type="button"
+              className={`exact-fav${isFavorite ? " is-on" : ""}`}
+              aria-pressed={isFavorite}
+              aria-label={
+                isFavorite
+                  ? `Remove ${trial.briefTitle} from favorites`
+                  : `Add ${trial.briefTitle} to favorites`
+              }
+              onClick={(e) => {
+                // The card is itself a click target; without this, bookmarking
+                // would also open the trial.
+                e.stopPropagation();
+                onToggleFavorite(!isFavorite);
+              }}
+            >
+              {isFavorite ? "★" : "☆"}
+            </button>
+          ) : null}
           {onSelect ? (
             <button
               type="button"

--- a/frontend/src/federation/TrialMatches.test.tsx
+++ b/frontend/src/federation/TrialMatches.test.tsx
@@ -450,3 +450,584 @@ describe("a trial type picked before the patient is known", () => {
     expect(last.params.trialType).toBeUndefined();
   });
 });
+
+describe("without a state adapter", () => {
+  it("renders neither the state tabs nor a bookmark control", async () => {
+    // They would be a tab that cannot answer and a button that forgets.
+    const api = fakeApi();
+    renderTrialMatches(api);
+    await waitFor(() => expect(listed(api).length).toBe(1));
+    expect(screen.queryByRole("button", { name: /^Favorites/ })).toBeNull();
+    expect(screen.queryByRole("button", { name: /^Registered/ })).toBeNull();
+    expect(screen.queryByRole("button", { name: /favorites$/i })).toBeNull();
+  });
+
+  it("sends no trial_ids at all", async () => {
+    const api = fakeApi();
+    renderTrialMatches(api);
+    await waitFor(() => expect(listed(api).length).toBe(1));
+    expect(listed(api)[0].body).toEqual({
+      patient_info: { disease: "multiple myeloma" },
+    });
+  });
+});
+
+describe("with a state adapter", () => {
+  const makeState = (favorites: string[] = [], registered: string[] = []) => {
+    const calls: { setFavorite: [string, boolean][] } = { setFavorite: [] };
+    const state = {
+      listFavoriteIds: vi.fn(async () => favorites),
+      listRegisteredIds: vi.fn(async () => registered),
+      setFavorite: vi.fn(async (id: string, on: boolean) => {
+        calls.setFavorite.push([id, on]);
+        if (on) favorites.push(id);
+        else favorites = favorites.filter((f) => f !== id);
+      }),
+      setRegistered: vi.fn(async () => undefined),
+      getPreferences: vi.fn(async () => ({})),
+      savePreferences: vi.fn(async () => undefined),
+      resetPreferences: vi.fn(async () => undefined),
+    };
+    return { state, calls };
+  };
+
+  const renderWithState = (api: ReturnType<typeof fakeApi>, state: unknown) => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, refetchOnWindowFocus: false } },
+    });
+    return render(
+      <QueryClientProvider client={queryClient}>
+        <TrialMatches
+          apiClient={api.client}
+          queryClient={queryClient}
+          patientInfo={{ disease: "multiple myeloma" }}
+          state={state as never}
+        />
+      </QueryClientProvider>,
+    );
+  };
+
+  it("offers the Favorites and Registered tabs, counted from the adapter", async () => {
+    const api = fakeApi();
+    const { state } = makeState(["1", "2"], ["3"]);
+    renderWithState(api, state);
+    await screen.findByRole("button", { name: "Favorites, 2 trials" });
+    await screen.findByRole("button", { name: "Registered, 1 trials" });
+  });
+
+  it("narrows the list by the saved ids when the tab is opened", async () => {
+    const api = fakeApi();
+    const { state } = makeState(["11", "12"]);
+    renderWithState(api, state);
+    await waitFor(() => expect(listed(api).length).toBe(1));
+
+    await userEvent.click(await screen.findByRole("button", { name: /^Favorites/ }));
+    await waitFor(() => expect(listed(api).length).toBe(2));
+    expect((listed(api)[1].body as { trial_ids: string[] }).trial_ids).toEqual([
+      "11",
+      "12",
+    ]);
+  });
+
+  it("asks for nothing — not for everything — when there are no bookmarks", async () => {
+    // The failure this guards: `[]` collapsing into "no filter" answers an
+    // empty Favorites tab with the whole registry.
+    const api = fakeApi();
+    const { state } = makeState([]);
+    renderWithState(api, state);
+    await waitFor(() => expect(listed(api).length).toBe(1));
+
+    await userEvent.click(await screen.findByRole("button", { name: /^Favorites/ }));
+    await waitFor(() => expect(listed(api).length).toBe(2));
+    expect((listed(api)[1].body as { trial_ids: string[] }).trial_ids).toEqual([]);
+  });
+
+  it("shows no rows under the tab until its ids have arrived", async () => {
+    // Not a request that can be prevented — while the ids are unknown
+    // `trialIds` is `undefined`, which is the DEFAULT tab's query key, so
+    // React Query answers from cache without asking anyone. What must not
+    // happen is the render: the eligible list under a Favorites heading
+    // says those trials are bookmarked.
+    const api = fakeApi();
+    let release: (ids: string[]) => void = () => {};
+    const pending = new Promise<string[]>((resolve) => {
+      release = resolve;
+    });
+    const state = {
+      listFavoriteIds: vi.fn(() => pending),
+      listRegisteredIds: vi.fn(async () => []),
+      setFavorite: vi.fn(async () => undefined),
+      setRegistered: vi.fn(async () => undefined),
+      getPreferences: vi.fn(async () => ({})),
+      savePreferences: vi.fn(async () => undefined),
+      resetPreferences: vi.fn(async () => undefined),
+    };
+    renderWithState(api, state);
+    await userEvent.click(await screen.findByRole("button", { name: /^Favorites/ }));
+
+    const before = listed(api).length;
+    await new Promise((r) => setTimeout(r, 50));
+    expect(listed(api).length).toBe(before);
+    // The previous tab's rows are gone, not relabelled.
+    expect(screen.queryByText("Trial 1")).toBeNull();
+    expect(screen.getByText("Loading trials…")).toBeInTheDocument();
+
+    release(["42"]);
+    await waitFor(() => expect(listed(api).length).toBe(before + 1));
+    const last = listed(api)[listed(api).length - 1];
+    expect((last.body as { trial_ids: string[] }).trial_ids).toEqual(["42"]);
+  });
+
+  it("bookmarks a trial from its card", async () => {
+    const api = fakeApi();
+    const { state, calls } = makeState([]);
+    renderWithState(api, state);
+    await waitFor(() => expect(listed(api).length).toBe(1));
+
+    await userEvent.click(await screen.findByRole("button", { name: /Add .* to favorites/ }));
+    await waitFor(() => expect(calls.setFavorite).toEqual([["1", true]]));
+  });
+
+  it("does not open the trial when the bookmark is clicked", async () => {
+    // The card is itself a click target, so the toggle has to stop the event.
+    const api = fakeApi();
+    const { state } = makeState([]);
+    renderWithState(api, state);
+    await waitFor(() => expect(listed(api).length).toBe(1));
+
+    await userEvent.click(await screen.findByRole("button", { name: /Add .* to favorites/ }));
+    expect(screen.queryByText("Back to all trials")).toBeNull();
+  });
+});
+
+describe("the state tabs under failure and transition", () => {
+  const stateWith = (overrides: Record<string, unknown>) => ({
+    listFavoriteIds: vi.fn(async () => ["11"]),
+    listRegisteredIds: vi.fn(async () => []),
+    setFavorite: vi.fn(async () => undefined),
+    setRegistered: vi.fn(async () => undefined),
+    getPreferences: vi.fn(async () => ({})),
+    savePreferences: vi.fn(async () => undefined),
+    resetPreferences: vi.fn(async () => undefined),
+    ...overrides,
+  });
+
+  const renderWith = (api: ReturnType<typeof fakeApi>, state: unknown) => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, refetchOnWindowFocus: false } },
+    });
+    return render(
+      <QueryClientProvider client={queryClient}>
+        <TrialMatches
+          apiClient={api.client}
+          queryClient={queryClient}
+          patientInfo={{ disease: "multiple myeloma" }}
+          state={state as never}
+        />
+      </QueryClientProvider>,
+    );
+  };
+
+  it("returns to the first page when a state tab is opened", async () => {
+    // `queryFilters.type` is undefined for the default tab AND for both
+    // state tabs, and JSON.stringify drops undefined keys — so all three
+    // hashed identically and the page never reset. A reader on page 2 asked
+    // for page 2 of their bookmarks.
+    const api = fakeApi({ count: 3, itemsTotalCount: 25 });
+    renderWith(api, stateWith({}));
+    await waitFor(() => expect(listed(api).length).toBe(1));
+
+    await userEvent.click(await screen.findByRole("button", { name: "2" }));
+    await waitFor(() => expect(listed(api).length).toBe(2));
+    expect(listed(api)[1].params.page).toBe("2");
+
+    await userEvent.click(await screen.findByRole("button", { name: /^Favorites/ }));
+    await waitFor(() => expect(listed(api).length).toBe(3));
+    expect(listed(api)[2].params.page).toBeUndefined();
+  });
+
+  it("says so when the saved ids cannot be loaded", async () => {
+    // A rejected fetch also has no data, so treating that as "still
+    // loading" left the tab on "Loading trials…" for ever — with the trials
+    // query disabled, so even its own error branch could not speak.
+    const api = fakeApi();
+    const state = stateWith({
+      listFavoriteIds: vi.fn(async () => {
+        throw new Error("promop unreachable");
+      }),
+    });
+    renderWith(api, state);
+    await waitFor(() => expect(listed(api).length).toBe(1));
+
+    await userEvent.click(await screen.findByRole("button", { name: /^Favorites/ }));
+    await screen.findByText(/Couldn't load your saved trials/);
+    expect(screen.queryByText("Loading trials…")).toBeNull();
+  });
+
+  it("never paints another tab's rows under a state tab", async () => {
+    // The window `waitingForIds` did not cover: once the ids arrive it goes
+    // false in the same render that changes the query key, and
+    // `keepPreviousData` hands back the PREVIOUS key's rows. The eligible
+    // list was painted under the Favorites heading — and on a second visit,
+    // with the ids already cached, from the very first render.
+    const api = fakeApi({ results: [trial(1)] });
+    renderWith(api, stateWith({ listFavoriteIds: vi.fn(async () => ["99"]) }));
+    await screen.findByText("Trial 1");
+
+    let leaked = false;
+    const watch = setInterval(() => {
+      const onFavorites = screen
+        .queryByRole("button", { name: /^Favorites/ })
+        ?.getAttribute("aria-current");
+      if (onFavorites === "true" && screen.queryByText("Trial 1")) leaked = true;
+    }, 2);
+
+    await userEvent.click(screen.getByRole("button", { name: /^Favorites/ }));
+    await waitFor(() => expect(listed(api).length).toBe(2));
+    await new Promise((r) => setTimeout(r, 40));
+    clearInterval(watch);
+
+    expect(leaked).toBe(false);
+  });
+
+  it("says so when a bookmark cannot be saved", async () => {
+    // The star is painted from the server's list, so a rejected PATCH
+    // leaves it exactly where it was — indistinguishable from a click that
+    // never registered.
+    const api = fakeApi();
+    const state = stateWith({
+      listFavoriteIds: vi.fn(async () => []),
+      setFavorite: vi.fn(async () => {
+        throw new Error("nope");
+      }),
+    });
+    renderWith(api, state);
+    await waitFor(() => expect(listed(api).length).toBe(1));
+
+    await userEvent.click(await screen.findByRole("button", { name: /Add .* to favorites/ }));
+    await screen.findByRole("alert");
+  });
+});
+
+describe("when the host takes the adapter away", () => {
+  it("moves the reader to a tab that still exists", async () => {
+    // On logout, or an adapter reconfiguration. Falling back only in the
+    // lookup would list the default tab's trials while no tab in the bar is
+    // marked current — the reader would be somewhere the UI cannot name.
+    const api = fakeApi();
+    const state = {
+      listFavoriteIds: vi.fn(async () => ["1"]),
+      listRegisteredIds: vi.fn(async () => []),
+      setFavorite: vi.fn(async () => undefined),
+      setRegistered: vi.fn(async () => undefined),
+      getPreferences: vi.fn(async () => ({})),
+      savePreferences: vi.fn(async () => undefined),
+      resetPreferences: vi.fn(async () => undefined),
+    };
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, refetchOnWindowFocus: false } },
+    });
+    const ui = (withState: boolean) => (
+      <QueryClientProvider client={queryClient}>
+        <TrialMatches
+          apiClient={api.client}
+          queryClient={queryClient}
+          patientInfo={{ disease: "multiple myeloma" }}
+          state={withState ? (state as never) : undefined}
+        />
+      </QueryClientProvider>
+    );
+    const view = render(ui(true));
+    await userEvent.click(await screen.findByRole("button", { name: /^Favorites/ }));
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /^Favorites/ })).toHaveAttribute(
+        "aria-current",
+        "true",
+      ),
+    );
+
+    view.rerender(ui(false));
+
+    expect(screen.queryByRole("button", { name: /^Favorites/ })).toBeNull();
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /^Eligible/ })).toHaveAttribute(
+        "aria-current",
+        "true",
+      ),
+    );
+  });
+});
+
+describe("when a patient has saved more than the server will filter by", () => {
+  it("says so instead of sending a request that is refused", async () => {
+    // EXACT caps `trial_ids` at 500 — every id joins an `IN (...)`. Sending
+    // 501 means the tab never loads while its badge reports 501 saved, so
+    // the reader sees a count and an empty list with no explanation.
+    const api = fakeApi();
+    const many = Array.from({ length: 501 }, (_, i) => String(i + 1));
+    const state = {
+      listFavoriteIds: vi.fn(async () => many),
+      listRegisteredIds: vi.fn(async () => []),
+      setFavorite: vi.fn(async () => undefined),
+      setRegistered: vi.fn(async () => undefined),
+      getPreferences: vi.fn(async () => ({})),
+      savePreferences: vi.fn(async () => undefined),
+      resetPreferences: vi.fn(async () => undefined),
+    };
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, refetchOnWindowFocus: false } },
+    });
+    render(
+      <QueryClientProvider client={queryClient}>
+        <TrialMatches
+          apiClient={api.client}
+          queryClient={queryClient}
+          patientInfo={{ disease: "multiple myeloma" }}
+          state={state as never}
+        />
+      </QueryClientProvider>,
+    );
+    await waitFor(() => expect(listed(api).length).toBe(1));
+
+    await userEvent.click(await screen.findByRole("button", { name: /^Favorites/ }));
+    await screen.findByText(/can show at most 500 at a time/);
+    // And no request went out carrying the oversized list.
+    expect(listed(api).length).toBe(1);
+  });
+});
+
+describe("counts while a state tab is active", () => {
+  const state = () => ({
+    listFavoriteIds: vi.fn(async () => ["1"]),
+    listRegisteredIds: vi.fn(async () => []),
+    setFavorite: vi.fn(async () => undefined),
+    setRegistered: vi.fn(async () => undefined),
+    getPreferences: vi.fn(async () => ({})),
+    savePreferences: vi.fn(async () => undefined),
+    resetPreferences: vi.fn(async () => undefined),
+  });
+
+  const renderIt = (api: ReturnType<typeof fakeApi>, adapter: unknown) => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, refetchOnWindowFocus: false } },
+    });
+    return render(
+      <QueryClientProvider client={queryClient}>
+        <TrialMatches
+          apiClient={api.client}
+          queryClient={queryClient}
+          patientInfo={{ disease: "multiple myeloma" }}
+          state={adapter as never}
+        />
+      </QueryClientProvider>,
+    );
+  };
+
+  it("does not label the match tabs with counts from a narrowed response", async () => {
+    // Those counts came back from a request filtered to the saved ids, so
+    // they describe the bookmarks. On the Eligible / Fully matched /
+    // Potential badges they would read as the corpus — "Fully matched, 1"
+    // for a reader with one bookmarked eligible trial and many matching.
+    const api = fakeApi({ tabCounts: { eligible: 1, potential: 0 } });
+    renderIt(api, state());
+    await screen.findByRole("button", { name: "Fully matched, 1 trials" });
+
+    await userEvent.click(screen.getByRole("button", { name: /^Favorites/ }));
+    await waitFor(() =>
+      expect(screen.queryByRole("button", { name: /Fully matched, / })).toBeNull(),
+    );
+    // The state tab's own count still comes from the adapter.
+    await screen.findByRole("button", { name: "Favorites, 1 trials" });
+  });
+
+  it("runs no matcher query behind a failed saved-ids read", async () => {
+    const api = fakeApi();
+    const adapter = {
+      ...state(),
+      listFavoriteIds: vi.fn(async () => {
+        throw new Error("promop unreachable");
+      }),
+    };
+    renderIt(api, adapter);
+    await waitFor(() => expect(listed(api).length).toBe(1));
+
+    await userEvent.click(await screen.findByRole("button", { name: /^Favorites/ }));
+    await screen.findByText(/Couldn't load your saved trials/);
+    await new Promise((r) => setTimeout(r, 40));
+    // Still just the first tab's request: nothing ran behind the error.
+    expect(listed(api).length).toBe(1);
+  });
+});
+
+describe("two more ways the state tabs could contradict themselves", () => {
+  const adapterWith = (overrides: Record<string, unknown>) => ({
+    listFavoriteIds: vi.fn(async () => []),
+    listRegisteredIds: vi.fn(async () => []),
+    setFavorite: vi.fn(async () => undefined),
+    setRegistered: vi.fn(async () => undefined),
+    getPreferences: vi.fn(async () => ({})),
+    savePreferences: vi.fn(async () => undefined),
+    resetPreferences: vi.fn(async () => undefined),
+    ...overrides,
+  });
+
+  const renderIt = (api: ReturnType<typeof fakeApi>, adapter: unknown) => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, refetchOnWindowFocus: false } },
+    });
+    return render(
+      <QueryClientProvider client={queryClient}>
+        <TrialMatches
+          apiClient={api.client}
+          queryClient={queryClient}
+          patientInfo={{ disease: "multiple myeloma" }}
+          state={adapter as never}
+        />
+      </QueryClientProvider>,
+    );
+  };
+
+  it("does not also say 'No trials found' over the cap message", async () => {
+    // Two answers to one question: the tab explains it cannot show that
+    // many, and then reports that there are none.
+    const api = fakeApi();
+    const many = Array.from({ length: 501 }, (_, i) => String(i + 1));
+    renderIt(api, adapterWith({ listFavoriteIds: vi.fn(async () => many) }));
+    await userEvent.click(await screen.findByRole("button", { name: /^Favorites/ }));
+    await screen.findByText(/can show at most 500 at a time/);
+    expect(screen.queryByText("No trials found")).toBeNull();
+  });
+
+  it("explains why bookmarking is unavailable on the ordinary tabs", async () => {
+    // The star is painted from the favorites list, so a failed read hides
+    // every one of them — on every tab — and the reader would conclude the
+    // feature had been taken away.
+    const api = fakeApi();
+    renderIt(
+      api,
+      adapterWith({
+        listFavoriteIds: vi.fn(async () => {
+          throw new Error("promop unreachable");
+        }),
+      }),
+    );
+    await waitFor(() => expect(listed(api).length).toBe(1));
+    // Still on the default tab.
+    await screen.findByText(/bookmarking is unavailable/);
+    expect(screen.queryByRole("button", { name: /to favorites$/ })).toBeNull();
+  });
+});
+
+describe("two patients who look alike", () => {
+  it("does not serve one reader the other's bookmarks", async () => {
+    // The inline payload a host sends can be minimal — `{disease}` and
+    // nothing else — so two different people can produce the identical
+    // string. Keyed on that alone, the second reader is served the first
+    // one's saved trials for as long as they stay fresh.
+    const api = fakeApi();
+    const byPerson: Record<string, string[]> = { "1": ["11"], "2": ["22"] };
+    let current = "1";
+    const adapter = {
+      listFavoriteIds: vi.fn(async () => byPerson[current]),
+      listRegisteredIds: vi.fn(async () => []),
+      setFavorite: vi.fn(async () => undefined),
+      setRegistered: vi.fn(async () => undefined),
+      getPreferences: vi.fn(async () => ({})),
+      savePreferences: vi.fn(async () => undefined),
+      resetPreferences: vi.fn(async () => undefined),
+    };
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, refetchOnWindowFocus: false } },
+    });
+    const ui = (personId: string) => (
+      <QueryClientProvider client={queryClient}>
+        <TrialMatches
+          apiClient={api.client}
+          queryClient={queryClient}
+          // Identical for both readers, which is the point.
+          patientInfo={{ disease: "multiple myeloma" }}
+          personId={personId}
+          state={adapter as never}
+        />
+      </QueryClientProvider>
+    );
+    const view = render(ui("1"));
+    await screen.findByRole("button", { name: "Favorites, 1 trials" });
+
+    current = "2";
+    view.rerender(ui("2"));
+    await waitFor(() => expect(adapter.listFavoriteIds).toHaveBeenCalledTimes(2));
+
+    await userEvent.click(await screen.findByRole("button", { name: /^Favorites/ }));
+    await waitFor(() => expect(listed(api).length).toBeGreaterThan(1));
+    const last = listed(api)[listed(api).length - 1];
+    expect((last.body as { trial_ids: string[] }).trial_ids).toEqual(["22"]);
+  });
+});
+
+describe("the failure messages stand alone", () => {
+  const renderWith = (
+    api: ReturnType<typeof fakeApi>,
+    adapter: unknown,
+    initialFilters?: Record<string, unknown>,
+  ) => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, refetchOnWindowFocus: false } },
+    });
+    return render(
+      <QueryClientProvider client={queryClient}>
+        <TrialMatches
+          apiClient={api.client}
+          queryClient={queryClient}
+          patientInfo={{ disease: "multiple myeloma" }}
+          initialFilters={initialFilters as never}
+          state={
+            {
+              listRegisteredIds: async () => [],
+              setFavorite: async () => undefined,
+              setRegistered: async () => undefined,
+              getPreferences: async () => ({}),
+              savePreferences: async () => undefined,
+              resetPreferences: async () => undefined,
+              ...(adapter as object),
+            } as never
+          }
+        />
+      </QueryClientProvider>,
+    );
+  };
+
+  // The trigger: the state tab falls back to the default tab's query key,
+  // and when THAT key has no cached data a disabled query reports
+  // `isPlaceholderData` for ever. Mounting on another tab leaves it empty.
+  it("shows no loading line beside a failed saved-ids read", async () => {
+    const api = fakeApi();
+    renderWith(
+      api,
+      {
+        listFavoriteIds: async () => {
+          throw new Error("promop unreachable");
+        },
+      },
+      { type: "eligible" },
+    );
+    await waitFor(() => expect(listed(api).length).toBe(1));
+
+    await userEvent.click(await screen.findByRole("button", { name: /^Favorites/ }));
+    await screen.findByText(/Couldn't load your saved trials/);
+    await new Promise((r) => setTimeout(r, 40));
+    expect(screen.queryByText("Loading trials…")).toBeNull();
+  });
+
+  it("shows no loading line beside the over-the-cap message", async () => {
+    const api = fakeApi();
+    const many = Array.from({ length: 501 }, (_, i) => String(i + 1));
+    renderWith(api, { listFavoriteIds: async () => many }, { type: "eligible" });
+    await waitFor(() => expect(listed(api).length).toBe(1));
+
+    await userEvent.click(await screen.findByRole("button", { name: /^Favorites/ }));
+    await screen.findByText(/can show at most 500 at a time/);
+    await new Promise((r) => setTimeout(r, 40));
+    expect(screen.queryByText("Loading trials…")).toBeNull();
+  });
+});

--- a/frontend/src/federation/TrialMatches.tsx
+++ b/frontend/src/federation/TrialMatches.tsx
@@ -25,14 +25,15 @@ import { SortControl } from "./SortControl";
 import { Tabs } from "./Tabs";
 import { hasInlinePatient } from "./api";
 import { baselineFilters, countActiveFilters, countryFor } from "./filters";
+import { MAX_TRIAL_IDS } from "./state";
 import {
   DEFAULT_SORT,
   PAGE_SIZE,
-  TABS,
   tabValueForType,
+  tabsFor,
   type TabValue,
 } from "./listChrome";
-import { useTrials } from "./hooks";
+import { useSetTrialState, useStateIds, useTrials } from "./hooks";
 import { injectStyles } from "./injectStyles";
 import type { FilterState, TrialMatch, TrialMatchesProps } from "./types";
 
@@ -42,6 +43,7 @@ function TrialMatchesInner({
   personId,
   initialFilters,
   onTrialSelect,
+  state,
 }: Omit<TrialMatchesProps, "queryClient">) {
   useEffect(() => {
     injectStyles();
@@ -162,7 +164,62 @@ function TrialMatchesInner({
   const debouncedSponsor = useDebounced(filters.sponsor, 400);
   const debouncedDistance = useDebounced(filters.distance, 400);
   const debouncedDistanceUnits = useDebounced(filters.distanceUnits, 400);
-  const activeTabDef = TABS.find((t) => t.value === activeTab) ?? TABS[0];
+  // The bar depends on whether a host gave us somewhere to keep bookmarks.
+  const tabs = useMemo(() => tabsFor(state != null), [state]);
+  // A host can take the adapter away — on logout, or when reconfiguring it.
+  // The tab the reader was on then stops existing, and falling back only in
+  // `activeTabDef` would list the default tab's trials while no tab in the
+  // bar is marked current: the reader is somewhere the UI cannot name.
+  // Adjusting during render rather than in an effect, so the request that
+  // goes out is the one the visible tab describes.
+  if (!tabs.some((t) => t.value === activeTab)) {
+    setActiveTab(tabs[0].value);
+  }
+  const activeTabDef = tabs.find((t) => t.value === activeTab) ?? tabs[0];
+
+  // BOTH props, not the precedence winner.
+  //
+  // `patientIdentity` answers "which prop names this patient", which is the
+  // right question for the matcher and the wrong one for a cache key. With
+  // both supplied it resolves to the inline payload — so two readers whose
+  // payload is the same minimal `{disease}` share a key, and the second one
+  // is served the first one's bookmarks for as long as they stay fresh.
+  // A cache key wants maximum discrimination: any difference in either prop
+  // is a different key.
+  const stateKey = `${personId ?? ""}|${patientInfoKey ?? ""}`;
+  const favorites = useStateIds(state, "favorites", stateKey);
+  const registered = useStateIds(state, "registered", stateKey);
+  const setFavorite = useSetTrialState(state, "favorites", stateKey);
+
+  const stateCounts = {
+    favorites: favorites.data?.length,
+    registered: registered.data?.length,
+  };
+
+  // Which ids narrow the list, if the active tab is one of the state tabs.
+  //
+  // `undefined` while the ids are still loading — NOT `[]`, which the server
+  // reads as "none of them" and would answer with an empty list a moment
+  // before the real one arrives. The query waits instead.
+  const stateTab = activeTabDef.needsState;
+  const stateIdsQuery = stateTab === "registered" ? registered : favorites;
+  const savedIds = stateTab ? (stateIdsQuery.data as string[] | undefined) : undefined;
+  // The server refuses a list past its cap, so sending one means the tab
+  // simply never loads while its badge cheerfully reports the count. Say
+  // what happened instead — the plan called for an explicit degradation
+  // here and this is it.
+  const tooManySavedIds = savedIds != null && savedIds.length > MAX_TRIAL_IDS;
+  const trialIds = tooManySavedIds ? undefined : savedIds;
+  // `isPending`, not `data === undefined`: a rejected fetch also has no
+  // data, and treating that as "still loading" left the tab on
+  // "Loading trials…" for ever, with the trials query disabled so even its
+  // error branch could never speak.
+  const waitingForIds = stateTab != null && stateIdsQuery.isPending;
+  const idsFailed = stateTab != null && stateIdsQuery.isError;
+  // Mutually exclusive by construction: a query that has rejected is no
+  // longer pending. Guarding the loading line with `!idsFailed` as well
+  // would be a second mechanism for the same thing, and would make the
+  // first untestable — which is how it was written the first time.
   const queryFilters = useMemo(
     () => ({
       ...effectiveFilters,
@@ -193,9 +250,49 @@ function TrialMatchesInner({
     filters: queryFilters,
     page,
     limit: PAGE_SIZE,
+    trialIds,
+    // `!idsFailed` too: without it a failed Favorites read still fires an
+    // ordinary unfiltered search behind the error message — rows nobody
+    // shows, and a full matcher run to produce them.
+    enabled: !waitingForIds && !tooManySavedIds && !idsFailed,
   });
 
-  const trials = query.data?.results ?? [];
+  // While the ids are loading, the rows on screen belong to the previous
+  // tab. React Query is serving them from its cache — `trialIds` is still
+  // `undefined`, which is the *default* tab's query key — so this is not a
+  // request that can be prevented, it is a render that must not happen:
+  // showing the eligible list under the Favorites heading says those trials
+  // are bookmarked.
+  // On a state tab, rows are shown only when they are THIS tab's rows.
+  //
+  // `waitingForIds` alone closed just the first half of the window: once
+  // the ids arrive it goes false in the same render that changes the query
+  // key, and `keepPreviousData` then hands back the previous key's rows —
+  // so the eligible list was painted under the Favorites heading, which is
+  // precisely the claim it was written to prevent. Worse on a second visit,
+  // where the ids are already cached and the flag is false from the start.
+  // `isPlaceholderData` alone, and only while the query can still resolve.
+  //
+  // Two corrections live in this line. An earlier version also tested
+  // `isFetching`, added while the leak test was failing for an unrelated
+  // reason (the test's fake server ignored the id filter, so the right and
+  // wrong rows were identical). Once that was fixed the clause turned out
+  // to be unnecessary — nothing could be made to leak without it — and it
+  // is not free: it blanked the list on every background refetch, which
+  // includes the window-focus one real hosts have on and the one that
+  // follows every bookmark.
+  //
+  // And the two states that DISABLE the query are excluded, because a
+  // disabled query still resolves `keepPreviousData`: with no cached data
+  // under the fallback key, `isPlaceholderData` stays true for ever and
+  // nothing will ever fetch it, so "Loading trials…" sat next to the error
+  // message permanently.
+  const showingOtherTabsRows =
+    stateTab != null && !idsFailed && !tooManySavedIds && query.isPlaceholderData;
+  const trials =
+    waitingForIds || idsFailed || tooManySavedIds || showingOtherTabsRows
+      ? []
+      : query.data?.results ?? [];
   const totalCount = query.data?.itemsTotalCount ?? null;
   const tabCounts = query.data?.tabCounts;
   // The server's own page total (`count`), not `ceil(items / PAGE_SIZE)`:
@@ -214,7 +311,12 @@ function TrialMatchesInner({
   // Keyed on the debounced filters for the same reason: resetting the page
   // the instant a key is pressed would fire a request for page 1 of the
   // *previous* filter, which the user sees as a flash of unfiltered results.
-  const queryKey = JSON.stringify(queryFilters);
+  // The tab and the ids belong in this signature, not just the filters.
+  // `queryFilters.type` is `undefined` for the default tab AND for both
+  // state tabs — `JSON.stringify` drops undefined keys, so all three
+  // hashed identically and switching between them never reset the page.
+  // A reader on page 2 then asked for page 2 of their bookmarks.
+  const queryKey = JSON.stringify([queryFilters, activeTab, trialIds ?? null]);
   const [lastQueryKey, setLastQueryKey] = useState(queryKey);
   if (lastQueryKey !== queryKey) {
     setLastQueryKey(queryKey);
@@ -300,10 +402,18 @@ function TrialMatchesInner({
       <h1 className="exact-list__title">Your Trials</h1>
 
       <Tabs
+        tabs={tabs}
         active={activeTab}
         onChange={handleTabChange}
-        counts={tabCounts}
-        activeTabTotal={totalCount}
+        // Withheld while a state tab is active: those counts came back from
+        // a request narrowed to the saved ids, so they describe the
+        // bookmarks, not the corpus. Painted on the Eligible / Fully
+        // matched / Potential badges they would read as the corpus —
+        // "Fully matched, 1" for a reader who has one bookmarked eligible
+        // trial and two hundred matching ones.
+        counts={stateTab ? undefined : tabCounts}
+        activeTabTotal={stateTab ? null : totalCount}
+        stateCounts={stateCounts}
       />
 
       <div className="exact-list__controls">
@@ -334,8 +444,43 @@ function TrialMatchesInner({
         />
       ) : null}
 
-      {query.isLoading ? (
+      {query.isLoading || waitingForIds || showingOtherTabsRows ? (
         <p style={{ color: "var(--exact-color-text-muted)" }}>Loading trials…</p>
+      ) : null}
+
+      {tooManySavedIds ? (
+        <p style={{ color: "var(--exact-color-not-eligible)" }}>
+          You have saved {savedIds?.length} trials, and this view can show at
+          most {MAX_TRIAL_IDS} at a time. Remove a few, or use the other tabs
+          to find them.
+        </p>
+      ) : null}
+
+      {idsFailed ? (
+        <p style={{ color: "var(--exact-color-not-eligible)" }}>
+          Couldn't load your saved trials:{" "}
+          {(stateIdsQuery.error as Error)?.message ?? "unknown error"}
+        </p>
+      ) : null}
+
+      {/* The bookmark control is painted from the favorites list, so when
+          that read fails every star vanishes — on EVERY tab, not just the
+          Favorites one, and with nothing on screen to say why. The reader
+          would conclude the feature had been removed. */}
+      {favorites.isError && !idsFailed ? (
+        <p style={{ color: "var(--exact-color-not-eligible)" }}>
+          Couldn't load your favorites, so bookmarking is unavailable right
+          now.
+        </p>
+      ) : null}
+
+      {/* (4) A write that failed has to say so. The star is painted from
+          the server's list, so a rejected PATCH leaves it exactly where it
+          was — indistinguishable from a click that never registered. */}
+      {setFavorite.isError ? (
+        <p style={{ color: "var(--exact-color-not-eligible)" }} role="alert">
+          Couldn't update your favorites. Please try again.
+        </p>
       ) : null}
 
       {query.isError ? (
@@ -364,7 +509,19 @@ function TrialMatchesInner({
         aria-busy={query.isPlaceholderData || undefined}
       >
         {trials.map((t) => (
-          <TrialCard key={t.trialId} trial={t} onSelect={handleSelect} />
+          <TrialCard
+            key={t.trialId}
+            trial={t}
+            onSelect={handleSelect}
+            isFavorite={
+              favorites.data ? favorites.data.includes(String(t.trialId)) : undefined
+            }
+            onToggleFavorite={
+              state
+                ? (on) => setFavorite.mutate({ trialId: String(t.trialId), on })
+                : undefined
+            }
+          />
         ))}
       </div>
 
@@ -376,6 +533,10 @@ function TrialMatchesInner({
       ) : null}
 
       {!query.isLoading &&
+      !waitingForIds &&
+      !idsFailed &&
+      !tooManySavedIds &&
+      !showingOtherTabsRows &&
       (patientInfo != null || personId != null) &&
       trials.length === 0 ? (
         <p style={{ color: "var(--exact-color-text-muted)" }}>No trials found</p>

--- a/frontend/src/federation/api.test.ts
+++ b/frontend/src/federation/api.test.ts
@@ -238,3 +238,44 @@ describe("filterStateToParams — distance", () => {
     expect(filterStateToParams({ distance: -1 })).toEqual({});
   });
 });
+
+describe("fetchTrials — trial_ids", () => {
+  it("sends an empty list as an empty list, not as no filter", () => {
+    // The case the whole feature turns on: `[]` means "my bookmarks, of
+    // which there are none". Collapsing it into "no filter" answers an
+    // empty Favorites tab with every trial in the registry.
+    const apiClient = fakeClient();
+    return fetchTrials({
+      apiClient,
+      patientInfo: { disease: "mm" },
+      trialIds: [],
+    }).then(() => {
+      expect(apiClient.post).toHaveBeenCalledWith(
+        "/trials/search/match/",
+        { patient_info: { disease: "mm" }, trial_ids: [] },
+        { params: {} },
+      );
+    });
+  });
+
+  it("omits the key entirely when there is no id filter", async () => {
+    const apiClient = fakeClient();
+    await fetchTrials({ apiClient, patientInfo: { disease: "mm" } });
+    expect(apiClient.post).toHaveBeenCalledWith(
+      "/trials/search/match/",
+      { patient_info: { disease: "mm" } },
+      { params: {} },
+    );
+  });
+
+  it("posts on the person_id path too, because ids only travel in a body", async () => {
+    const apiClient = fakeClient();
+    await fetchTrials({ apiClient, personId: 9001, trialIds: ["7"] });
+    expect(apiClient.get).not.toHaveBeenCalled();
+    expect(apiClient.post).toHaveBeenCalledWith(
+      "/trials/search/match/",
+      { trial_ids: ["7"] },
+      { params: { person_id: "9001" } },
+    );
+  });
+});

--- a/frontend/src/federation/api.ts
+++ b/frontend/src/federation/api.ts
@@ -35,6 +35,14 @@ interface FetchTrialsArgs {
   page?: number;
   /** Rows per page. CB shows 10; the server default is 20. */
   limit?: number;
+  /** Narrow to these trial ids — how the Favorites and Registered tabs
+   *  work, since the ids live outside EXACT (#419).
+   *
+   *  `undefined` is "no such filter"; an EMPTY ARRAY is not. `[]` means the
+   *  patient asked for their bookmarks and has none, and the server reads
+   *  it the same way — collapsing the two would answer an empty Favorites
+   *  tab with the whole corpus. */
+  trialIds?: string[];
 }
 
 /** Fetch the trial-match list. Two paths depending on inputs:
@@ -75,14 +83,33 @@ export async function fetchTrials({
   filters,
   page,
   limit,
+  trialIds,
 }: FetchTrialsArgs): Promise<TrialsResponse> {
   const params = filterStateToParams(filters);
   if (page != null && page > 1) params.page = String(page);
   if (limit != null) params.limit = String(limit);
+  // `!== undefined`, never a truthiness test: `[]` is a filter that matches
+  // nothing, not the absence of one.
+  const body: Record<string, unknown> =
+    trialIds !== undefined ? { trial_ids: trialIds } : {};
+
   if (hasInlinePatient(patientInfo)) {
     const response = await apiClient.post<TrialsResponse>(
       "/trials/search/match/",
-      { patient_info: patientInfo },
+      { patient_info: patientInfo, ...body },
+      { params },
+    );
+    return response.data;
+  }
+
+  if (trialIds !== undefined) {
+    // The id list only travels in a body, and the `person_id` path is a GET.
+    // Posting the alias with no patient payload still reaches `search`, and
+    // the server resolves the patient from the query param.
+    if (personId != null) params.person_id = String(personId);
+    const response = await apiClient.post<TrialsResponse>(
+      "/trials/search/match/",
+      body,
       { params },
     );
     return response.data;

--- a/frontend/src/federation/exact.css
+++ b/frontend/src/federation/exact.css
@@ -886,3 +886,26 @@
   outline: 2px solid var(--exact-color-primary);
   outline-offset: 1px;
 }
+
+/* Bookmark toggle on a trial card. A star rather than CB's bookmark glyph
+   because the remote ships no icon set and must not pull one into its host;
+   the accessible name carries the meaning either way. */
+.exact-root .exact-fav {
+  border: none;
+  background: none;
+  padding: 0.25rem;
+  font-size: 1.25rem;
+  line-height: 1;
+  color: var(--exact-color-text-tertiary);
+  cursor: pointer;
+}
+
+.exact-root .exact-fav.is-on {
+  color: var(--exact-color-primary);
+}
+
+.exact-root .exact-fav:focus-visible {
+  outline: 2px solid var(--exact-color-primary);
+  outline-offset: 1px;
+  border-radius: 0.25rem;
+}

--- a/frontend/src/federation/hooks.ts
+++ b/frontend/src/federation/hooks.ts
@@ -9,13 +9,68 @@ import {
 } from "@tanstack/react-query";
 import type { AxiosInstance } from "axios";
 
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
 import { fetchFormSettings, fetchTrialDetail, fetchTrials } from "./api";
+import type { TrialId, TrialStateAdapter } from "./state";
 import type {
   FilterState,
   PatientInfo,
   TrialDetailResponse,
   TrialsResponse,
 } from "./types";
+
+/** The bookmarked / registered ids, or nothing while there is no adapter.
+ *
+ *  Keyed on the PATIENT, not on the adapter object. Deliberately: a host
+ *  that builds its adapter inline — `state={createPromopState(...)}`, the
+ *  obvious way to write it — hands over a new object every render, and an
+ *  identity-keyed cache would refetch on each one. The cost of that choice
+ *  is that swapping transports for the SAME patient keeps the previous
+ *  adapter's ids until they go stale; a host doing that should change the
+ *  patient key or remount.
+ */
+export function useStateIds(
+  state: TrialStateAdapter | undefined,
+  kind: "favorites" | "registered",
+  key: string,
+): UseQueryResult<TrialId[]> {
+  return useQuery({
+    queryKey: ["exact-state-ids", kind, key],
+    queryFn: () =>
+      kind === "favorites"
+        ? state!.listFavoriteIds()
+        : state!.listRegisteredIds(),
+    enabled: state != null,
+    staleTime: 30_000,
+  });
+}
+
+/** Toggle one trial's bookmark or registration.
+ *
+ *  Invalidates the id lists rather than patching them by hand: the lists
+ *  drive a tab count and a tab's contents, and a hand-patched cache that
+ *  drifts from the server shows a Favorites tab that disagrees with the
+ *  bookmark on the card. The trial list itself is invalidated too, because
+ *  on the Favorites tab the row set IS the id list.
+ */
+export function useSetTrialState(
+  state: TrialStateAdapter | undefined,
+  kind: "favorites" | "registered",
+  key: string,
+) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ trialId, on }: { trialId: TrialId; on: boolean }) =>
+      kind === "favorites"
+        ? state!.setFavorite(trialId, on)
+        : state!.setRegistered(trialId, on),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["exact-state-ids", kind, key] });
+      queryClient.invalidateQueries({ queryKey: ["exact-trials"] });
+    },
+  });
+}
 
 interface UseTrialsArgs {
   apiClient: AxiosInstance;
@@ -26,6 +81,8 @@ interface UseTrialsArgs {
   page?: number;
   /** Rows per page. */
   limit?: number;
+  /** Narrow to these ids; `[]` means "none", not "no filter". */
+  trialIds?: string[];
   /** Skip the query until the host has a patient context. Without
    *  patient context the response would be a public/unscoped trial
    *  list — usually not what a TrialMatches mount wants. */
@@ -39,6 +96,7 @@ export function useTrials({
   filters,
   page = 1,
   limit,
+  trialIds,
   enabled = true,
 }: UseTrialsArgs): UseQueryResult<TrialsResponse> {
   return useQuery({
@@ -49,9 +107,12 @@ export function useTrials({
       filters ?? null,
       page,
       limit ?? null,
+      // `?? null` rather than a spread or a truthiness test: `[]` and
+      // `undefined` are different questions and must be different keys.
+      trialIds ?? null,
     ],
     queryFn: () =>
-      fetchTrials({ apiClient, patientInfo, personId, filters, page, limit }),
+      fetchTrials({ apiClient, patientInfo, personId, filters, page, limit, trialIds }),
     // Paged, not infinite: CB paginates by number and so does this now, and
     // an infinite list cannot show per-tab totals or jump to a page. Previous
     // data is kept across page/filter changes so the list does not blank out

--- a/frontend/src/federation/listChrome.test.ts
+++ b/frontend/src/federation/listChrome.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   SORT_OPTIONS,
   TABS,
+  tabsFor,
   getPageNumbers,
   sortOptionsFor,
   tabCount,
@@ -152,5 +153,54 @@ describe("sortOptionsFor", () => {
       value: "updated",
       label: "Sorted by updated",
     });
+  });
+});
+
+describe("tabsFor", () => {
+  it("offers CB's match tabs without a state adapter", () => {
+    expect(tabsFor(false).map((t) => t.value)).toEqual([
+      "eligible_and_potential",
+      "eligible",
+      "potential",
+    ]);
+  });
+
+  it("adds Registered and Favorites once there is somewhere to keep them", () => {
+    expect(tabsFor(true).map((t) => t.value)).toEqual([
+      "eligible_and_potential",
+      "eligible",
+      "potential",
+      "registered",
+      "favorites",
+    ]);
+  });
+
+  it("marks the state tabs so they are narrowed by ids, not by ?type=", () => {
+    // The server rejects `?type=favorites` outright; these are narrowed by
+    // a `trial_ids` list instead.
+    const byIds = tabsFor(true).filter((t) => t.needsState);
+    expect(byIds.map((t) => t.value)).toEqual(["registered", "favorites"]);
+    expect(byIds.every((t) => t.param === undefined)).toBe(true);
+  });
+});
+
+describe("tabCount for the state tabs", () => {
+  const counts = { eligible: 7, potential: 12 };
+
+  it("counts what the patient saved, not what the matcher found", () => {
+    // A bookmark stays a bookmark whether or not the trial still matches
+    // today, so the matcher's counts cannot answer for these tabs.
+    expect(tabCount("favorites", counts, null, { favorites: 3 })).toBe(3);
+    expect(tabCount("registered", counts, null, { registered: 2 })).toBe(2);
+  });
+
+  it("shows nothing while the ids are unknown", () => {
+    expect(tabCount("favorites", counts, 40, undefined)).toBeNull();
+    expect(tabCount("favorites", counts, 40, {})).toBeNull();
+  });
+
+  it("shows zero when the patient really has none", () => {
+    // Distinct from unknown: `0` is an answer, and the tab should say so.
+    expect(tabCount("favorites", counts, null, { favorites: 0 })).toBe(0);
   });
 });

--- a/frontend/src/federation/listChrome.ts
+++ b/frontend/src/federation/listChrome.ts
@@ -7,37 +7,64 @@ import type { TabCounts } from "./types";
 /** Rows per page. CB shows 10; the server's own default is 20. */
 export const PAGE_SIZE = 10;
 
-/** The tabs CB offers, minus the two that need per-user state.
+/** CB's tab bar, as far as this remote can honestly reproduce it.
  *
- *  CB's bar is Eligible / All Trials (admin) / Registered / Favorites.
- *  Registered and Favorites are per-user relations EXACT does not hold —
- *  the server rejects `?type=favorites` and `?type=my_trials` outright
- *  (EXACT #417) — so they arrive with the PROMOP-backed state adapter in
- *  phase 2 rather than being rendered as tabs that cannot work.
+ *  CB's is Eligible / All Trials (admin) / Registered / Favorites. The last
+ *  two are per-user relations EXACT does not hold — the server rejects
+ *  `?type=favorites` and `?type=my_trials` outright (EXACT #417) — so they
+ *  are narrowed a different way: the ids come from the state adapter and go
+ *  down as `trial_ids`, which EXACT applies inside the queryset (#419).
+ *
+ *  They are therefore CONDITIONAL on a host having supplied that adapter.
+ *  Rendered without one they would be a tab that cannot answer, and a
+ *  bookmark control that forgets.
  *
  *  `eligible_and_potential` is CB's default tab. It is a no-op server-side,
  *  identical to sending no `type` at all, so it maps to `undefined` here
  *  rather than to a parameter that would suggest it narrows something. */
-export type TabValue = "eligible_and_potential" | "eligible" | "potential" | "all";
+export type TabValue =
+  | "eligible_and_potential"
+  | "eligible"
+  | "potential"
+  | "all"
+  | "favorites"
+  | "registered";
 
 export interface TabDef {
   value: TabValue;
   label: string;
   /** What goes on the wire; `undefined` means "send no `type`". */
   param?: "eligible" | "potential" | "all";
+  /** Narrowed by a list of ids from the state adapter rather than by
+   *  `?type=`, and hidden entirely when there is no adapter. */
+  needsState?: "favorites" | "registered";
 }
 
-export const TABS: TabDef[] = [
+const MATCH_TABS: TabDef[] = [
   { value: "eligible_and_potential", label: "Eligible" },
   { value: "eligible", label: "Fully matched", param: "eligible" },
   { value: "potential", label: "Potential", param: "potential" },
 ];
 
+const STATE_TABS: TabDef[] = [
+  { value: "registered", label: "Registered", needsState: "registered" },
+  { value: "favorites", label: "Favorites", needsState: "favorites" },
+];
+
+/** The bar to render. Without a state adapter it is CB's bar minus the two
+ *  tabs that would have nothing behind them. */
+export function tabsFor(hasState: boolean): TabDef[] {
+  return hasState ? [...MATCH_TABS, ...STATE_TABS] : MATCH_TABS;
+}
+
+/** @deprecated Prefer `tabsFor`; kept as the no-adapter bar. */
+export const TABS: TabDef[] = MATCH_TABS;
+
 /** The tab whose `param` matches a `type` the host passed in `initialFilters`.
  *  Falls back to the default tab for `undefined` and for values that are not
  *  tabs (`all` is a supported server value but is not offered as a tab). */
 export function tabValueForType(type: string | undefined): TabValue {
-  const match = TABS.find((tab) => tab.param === type);
+  const match = MATCH_TABS.find((tab) => tab.param === type);
   return match ? match.value : "eligible_and_potential";
 }
 
@@ -51,7 +78,13 @@ export function tabCount(
   tab: TabValue,
   counts: TabCounts | undefined,
   itemsTotalCount: number | null,
+  stateCounts?: { favorites?: number; registered?: number },
 ): number | null {
+  // The state tabs are counted by whoever holds the state, not by the
+  // matcher: their totals are how many the patient saved, which is true
+  // whether or not those trials still match today.
+  if (tab === "favorites") return stateCounts?.favorites ?? null;
+  if (tab === "registered") return stateCounts?.registered ?? null;
   if (tab === "eligible_and_potential") {
     if (counts) return counts.eligible + counts.potential;
     // Without counts the total is only the whole corpus when this tab is

--- a/frontend/src/federation/state.test.ts
+++ b/frontend/src/federation/state.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it, vi } from "vitest";
+import type { AxiosInstance } from "axios";
+
+import { createPromopState } from "./state";
+
+function fakeClient(data: unknown = {}) {
+  const get = vi.fn().mockResolvedValue({ data });
+  const patch = vi.fn().mockResolvedValue({ data: {} });
+  return { get, patch } as unknown as AxiosInstance & {
+    get: ReturnType<typeof vi.fn>;
+    patch: ReturnType<typeof vi.fn>;
+  };
+}
+
+const adapter = (client: AxiosInstance) =>
+  createPromopState({ client, personId: 9001 });
+
+describe("reading the ids", () => {
+  it("asks for the bookmarked ones", async () => {
+    const client = fakeClient({ trial_ids: ["1", "2"], count: 2 });
+    expect(await adapter(client).listFavoriteIds()).toEqual(["1", "2"]);
+    expect(client.get).toHaveBeenCalledWith("/api/v1/trial-enrollments/ids/", {
+      params: { person_id: "9001", is_favorite: "true" },
+    });
+  });
+
+  it("asks for the registered ones by status, not by a second endpoint", async () => {
+    const client = fakeClient({ trial_ids: ["3"], count: 1 });
+    expect(await adapter(client).listRegisteredIds()).toEqual(["3"]);
+    expect(client.get).toHaveBeenCalledWith("/api/v1/trial-enrollments/ids/", {
+      params: { person_id: "9001", status: "registered" },
+    });
+  });
+
+  it("reads an absent list as empty rather than undefined", async () => {
+    // The caller distinguishes `[]` (none) from "not loaded yet"; a missing
+    // key must not be allowed to look like the latter.
+    const client = fakeClient({});
+    expect(await adapter(client).listFavoriteIds()).toEqual([]);
+  });
+});
+
+describe("writing", () => {
+  it("bookmarks through the upsert, which creates the row if needed", async () => {
+    // A patient may bookmark a trial they were never enrolled in, and the
+    // POST that would create an enrollment is closed to them — PATCH on this
+    // action is the only route (promop#1142).
+    const client = fakeClient();
+    await adapter(client).setFavorite("7", true);
+    expect(client.patch).toHaveBeenCalledWith(
+      "/api/v1/trial-enrollments/upsert/",
+      { trial_id: "7", is_favorite: true },
+      { params: { person_id: "9001" } },
+    );
+  });
+
+  it("un-bookmarks by sending false, not by deleting anything", async () => {
+    const client = fakeClient();
+    await adapter(client).setFavorite("7", false);
+    expect(client.patch.mock.calls[0][1]).toEqual({
+      trial_id: "7",
+      is_favorite: false,
+    });
+  });
+
+  it("registers interest as a status", async () => {
+    const client = fakeClient();
+    await adapter(client).setRegistered("7", true);
+    expect(client.patch.mock.calls[0][1]).toEqual({
+      trial_id: "7",
+      status: "registered",
+    });
+  });
+
+  it("withdraws rather than erasing the fact of having registered", async () => {
+    // PROMOP's enum carries `withdrawn` precisely so the record survives
+    // the patient changing their mind. Deleting the row, or flipping back
+    // to `interested`, would lose that a registration ever happened.
+    const client = fakeClient();
+    await adapter(client).setRegistered("7", false);
+    expect(client.patch.mock.calls[0][1]).toEqual({
+      trial_id: "7",
+      status: "withdrawn",
+    });
+  });
+
+  it("sends only the field it is changing", async () => {
+    // The server leaves untouched what it is not sent, so a bookmark must
+    // not carry a status along with it and silently reset one.
+    const client = fakeClient();
+    await adapter(client).setFavorite("7", true);
+    expect(Object.keys(client.patch.mock.calls[0][1] as object)).toEqual([
+      "trial_id",
+      "is_favorite",
+    ]);
+  });
+});
+
+describe("the saved filters", () => {
+  it("reads the first row's payload", async () => {
+    const client = fakeClient({ results: [{ preferences: { phase: "PHASE3" } }] });
+    expect(await adapter(client).getPreferences()).toEqual({ phase: "PHASE3" });
+  });
+
+  it("reads a bare list response too", async () => {
+    // The endpoint answers with a plain array today; a page wrapper later
+    // should not silently return "no filters".
+    const client = fakeClient([{ preferences: { phase: "PHASE3" } }]);
+    expect(await adapter(client).getPreferences()).toEqual({ phase: "PHASE3" });
+  });
+
+  it("reads no row at all as no filters", async () => {
+    expect(await adapter(fakeClient({ results: [] })).getPreferences()).toEqual({});
+  });
+
+  it("saves through upsert, which creates the row on first use", async () => {
+    const client = fakeClient();
+    await adapter(client).savePreferences({ phase: "PHASE3" });
+    expect(client.patch).toHaveBeenCalledWith(
+      "/api/v1/trial-search-preferences/upsert/",
+      { preferences: { phase: "PHASE3" } },
+      { params: { person_id: "9001" } },
+    );
+  });
+
+  it("resets through its own call, not by saving an empty object", async () => {
+    // A partial update merges, so saving `{}` would leave every key in place
+    // — the reset would appear to do nothing.
+    const client = fakeClient();
+    await adapter(client).resetPreferences();
+    expect(client.patch).toHaveBeenCalledWith(
+      "/api/v1/trial-search-preferences/reset/",
+      {},
+      { params: { person_id: "9001" } },
+    );
+  });
+});
+
+describe("the base path", () => {
+  it("can be moved for a host that mounts the API elsewhere", async () => {
+    const client = fakeClient({ trial_ids: [] });
+    const state = createPromopState({ client, personId: 5, basePath: "/promop" });
+    await state.listFavoriteIds();
+    expect(client.get.mock.calls[0][0]).toBe("/promop/trial-enrollments/ids/");
+  });
+});

--- a/frontend/src/federation/state.ts
+++ b/frontend/src/federation/state.ts
@@ -1,0 +1,128 @@
+// The per-user state seam.
+//
+// EXACT holds no per-user trial state and is not going to: it is stateless
+// about patients by design. Bookmarks, registered interest and saved filters
+// live in PROMOP. But this remote runs in two hosts that reach PROMOP
+// differently — HealthTree PHR mints an OAuth token, CB runs the promop apps
+// in-process behind its own endpoint — so the component takes an interface
+// and the host supplies the transport.
+//
+// Everything here is optional. A host that passes no `state` gets the list,
+// the filters and the detail page exactly as before; what disappears is the
+// Favorites and Registered tabs and the bookmark control, because those
+// cannot work without somewhere to keep the answer. Rendering them against
+// nothing would be a button that forgets.
+
+import type { AxiosInstance } from "axios";
+
+import type { FilterState } from "./types";
+
+/** Trial ids, as PROMOP stores them — strings, because they are opaque keys
+ *  to it. EXACT's `trial_ids` filter accepts numeric strings. */
+export type TrialId = string;
+
+/** The most ids EXACT will accept in one `trial_ids` filter.
+ *
+ *  The server's number, mirrored here so the UI can say something useful
+ *  instead of sending a request it knows will be refused. Each id becomes
+ *  part of an `IN (...)`, which is why there is a cap at all (EXACT #419).
+ */
+export const MAX_TRIAL_IDS = 500;
+
+export interface TrialStateAdapter {
+  /** The patient's bookmarked trial ids. */
+  listFavoriteIds(): Promise<TrialId[]>;
+  /** Bookmark or un-bookmark one trial. */
+  setFavorite(trialId: TrialId, isFavorite: boolean): Promise<void>;
+  /** The trials the patient has registered interest in. */
+  listRegisteredIds(): Promise<TrialId[]>;
+  /** Register (or withdraw) interest in one trial. */
+  setRegistered(trialId: TrialId, registered: boolean): Promise<void>;
+  /** The patient's saved search filters, or `{}` when they have none. */
+  getPreferences(): Promise<FilterState>;
+  /** Store the filters. */
+  savePreferences(filters: FilterState): Promise<void>;
+  /** Clear them. Deliberately not `savePreferences({})`: the server merges
+   *  a partial update, so "reset" has to be its own call. */
+  resetPreferences(): Promise<void>;
+}
+
+interface PromopStateArgs {
+  /** Axios instance the host has already authenticated against PROMOP.
+   *  HT mints an OAuth token for it; CB points it at its own endpoint over
+   *  the in-process plugin. */
+  client: AxiosInstance;
+  /** Whose state this is. */
+  personId: string | number;
+  /** Base path, for a host that mounts the API elsewhere. */
+  basePath?: string;
+}
+
+/** The default adapter, speaking PROMOP's REST API (promop#1142).
+ *
+ *  A host with a plain PROMOP client can use this directly; one that reaches
+ *  the same data another way implements `TrialStateAdapter` instead. */
+export function createPromopState({
+  client,
+  personId,
+  basePath = "/api/v1",
+}: PromopStateArgs): TrialStateAdapter {
+  const person = String(personId);
+  const enrollments = `${basePath}/trial-enrollments`;
+  const preferences = `${basePath}/trial-search-preferences`;
+
+  const ids = async (params: Record<string, string>): Promise<TrialId[]> => {
+    const response = await client.get<{ trial_ids: TrialId[]; count: number }>(
+      `${enrollments}/ids/`,
+      { params: { person_id: person, ...params } },
+    );
+    return response.data.trial_ids ?? [];
+  };
+
+  // One endpoint sets either field; what is not sent is not touched
+  // (promop#1142). PATCH rather than POST because a session-authenticated
+  // patient is granted safe methods and PATCH only.
+  const upsert = (trialId: TrialId, body: Record<string, unknown>) =>
+    client
+      .patch(`${enrollments}/upsert/`, { trial_id: trialId, ...body }, {
+        params: { person_id: person },
+      })
+      .then(() => undefined);
+
+  return {
+    listFavoriteIds: () => ids({ is_favorite: "true" }),
+    setFavorite: (trialId, isFavorite) => upsert(trialId, { is_favorite: isFavorite }),
+    // `registered` exactly, which means a patient a coordinator has moved
+    // to `entered` drops off the Registered tab — at the moment they most
+    // want to see the trial. Whether the label should cover the later
+    // states is a product question, filed as EXACT #434; answering it also
+    // needs PROMOP's `?status=` to accept more than one value.
+    listRegisteredIds: () => ids({ status: "registered" }),
+    // Withdrawing is a status of its own rather than a deletion: the row is
+    // the record that the patient was once interested, and PROMOP's enum
+    // has `withdrawn` precisely so that fact survives.
+    setRegistered: (trialId, registered) =>
+      upsert(trialId, { status: registered ? "registered" : "withdrawn" }),
+
+    getPreferences: async () => {
+      const response = await client.get<{ results?: { preferences?: FilterState }[] }>(
+        `${preferences}/`,
+        { params: { person_id: person } },
+      );
+      const rows = response.data?.results ?? (response.data as unknown as
+        { preferences?: FilterState }[]);
+      const first = Array.isArray(rows) ? rows[0] : undefined;
+      return first?.preferences ?? {};
+    },
+    savePreferences: (filters) =>
+      client
+        .patch(`${preferences}/upsert/`, { preferences: filters }, {
+          params: { person_id: person },
+        })
+        .then(() => undefined),
+    resetPreferences: () =>
+      client
+        .patch(`${preferences}/reset/`, {}, { params: { person_id: person } })
+        .then(() => undefined),
+  };
+}

--- a/frontend/src/federation/types.ts
+++ b/frontend/src/federation/types.ts
@@ -10,6 +10,8 @@
 import type { AxiosInstance } from "axios";
 import type { QueryClient } from "@tanstack/react-query";
 
+import type { TrialStateAdapter } from "./state";
+
 /** Sparse, schema-tolerant patient payload — mirrors EXACT's stateless
  *  `PatientInfo` Python class. Keys are camelCase as sent over the wire.
  *  See `trials/services/patient_info/patient_info.py`. */
@@ -212,4 +214,15 @@ export interface TrialMatchesProps {
   initialFilters?: FilterState;
   /** Called when the user opens a trial card / detail view. */
   onTrialSelect?: (trial: TrialMatch) => void;
+  /** Where the patient's bookmarks, registrations and saved filters live.
+   *
+   *  Optional, and its absence is not a degraded mode so much as a smaller
+   *  one: without it the Favorites and Registered tabs and the bookmark
+   *  control are not rendered at all, because they would be controls with
+   *  nowhere to write. Everything else works unchanged.
+   *
+   *  `createPromopState` builds the default implementation from an
+   *  authenticated PROMOP client; a host that reaches the same data another
+   *  way implements the interface instead. */
+  state?: TrialStateAdapter;
 }

--- a/frontend/src/test/renderTrialMatches.tsx
+++ b/frontend/src/test/renderTrialMatches.tsx
@@ -101,7 +101,7 @@ export function fakeApi(initial: Partial<TrialsResponse> = {}): FakeApi {
   };
   let failWith: number | null = null;
 
-  const respond = (url: string) => {
+  const respond = (url: string, body?: unknown) => {
     if (url.includes("form-settings")) return Promise.resolve({ data: FORM_SETTINGS });
     if (failWith != null) {
       const status = failWith;
@@ -111,6 +111,18 @@ export function fakeApi(initial: Partial<TrialsResponse> = {}): FakeApi {
           response: { status },
         }),
       );
+    }
+    // Honour `trial_ids` the way the server does. Returning the same rows
+    // for a narrowed request makes the fake agree with any implementation,
+    // including one that ignores the filter — a test asserting "the wrong
+    // rows are not shown" then cannot fail.
+    const ids = (body as { trial_ids?: string[] } | undefined)?.trial_ids;
+    if (ids !== undefined) {
+      const wanted = new Set(ids.map(String));
+      const results = response.results.filter((t) => wanted.has(String(t.trialId)));
+      return Promise.resolve({
+        data: { ...response, results, itemsTotalCount: results.length },
+      });
     }
     return Promise.resolve({ data: response });
   };
@@ -123,7 +135,7 @@ export function fakeApi(initial: Partial<TrialsResponse> = {}): FakeApi {
       params: config?.params ?? {},
       body: method === "post" ? a : undefined,
     });
-    return respond(url);
+    return respond(url, method === "post" ? a : undefined);
   };
 
   const client = {

--- a/frontend/vite.remote.config.ts
+++ b/frontend/vite.remote.config.ts
@@ -71,6 +71,12 @@ export default defineConfig(({ mode }) => {
         exposes: {
           "./TrialMatches": "./src/federation/TrialMatches.tsx",
           "./types": "./src/federation/types.ts",
+          // The default per-user state adapter. Documented as "the
+          // implementation a host with a PROMOP client can just use" — and
+          // unusable as such while the build did not hand it over, which
+          // left a host to reimplement six methods against an API it would
+          // have to read this repository to learn.
+          "./state": "./src/federation/state.ts",
         },
         // Same singletons as SoC / hk-labs so a host that loads multiple
         // remotes shares one React tree and one query cache. No


### PR DESCRIPTION
Phase 2 of `docs/federated-ui-parity-plan.md`, remote side. Pairs with healthkey-ai/promop#1174 (the storage) and #433 (the `trial_ids` filter, already merged).

## The seam

EXACT holds no per-user trial state and is not going to. Bookmarks, registered interest and saved filters live in PROMOP — but this remote runs in two hosts that reach PROMOP differently, so `TrialMatches` takes a `state` adapter and the host supplies the transport. `createPromopState` is the default implementation, exposed as `./state` from the federation build.

**Its absence is a smaller UI, not a broken one.** No adapter → no Favorites/Registered tabs and no bookmark control, because those would be a tab that cannot answer and a button that forgets. Everything else is unchanged.

The state tabs are narrowed by ids, not by `?type=`: the server rejects `?type=favorites` outright, so the ids go down as `trial_ids` and EXACT applies them inside its queryset — sorting, paging and the total then describe the bookmarked set.

## Eleven review findings, and what they were

Worth listing, because most were in code that looked finished:

| | |
|---|---|
| **Rows leaked across tabs** | The eligible list painted under the Favorites heading, saying those trials were bookmarked. Fixed three times: the first guard covered only the window before the ids arrive, and the test written for it could not fail because the harness's fake server ignored the id filter — the right and wrong rows were identical. |
| **Two readers who look alike shared a cache** | The key used the precedence winner (inline payload), which for a minimal `{disease}` is identical for different people. Now both props. |
| **`createPromopState` was unreachable** | Documented as the default implementation; the federation build exposed only `./TrialMatches` and `./types`, so a host could not import it. |
| **Page never reset on a state tab** | `type` is `undefined` for the default tab *and* both state tabs, and `JSON.stringify` drops undefined keys — all three hashed the same, so page 2 of Eligible became page 2 of Favorites. |
| **Corpus counts on a narrowed response** | The match-tab badges showed counts computed after the `trial_ids` filter: "Fully matched, 1" for a reader with one bookmarked eligible trial and many matching. |
| **Four failure states could contradict each other** | "Loading trials…" sat permanently beside the error and the over-cap messages (a *disabled* query still resolves `keepPreviousData`, so `isPlaceholderData` stays true for ever); "No trials found" printed under the over-cap explanation. |
| **Silent failures** | A rejected id read hung the tab for ever with the trials query disabled so its own error branch could not speak; a rejected bookmark write moved nothing, indistinguishable from a click that never registered; a failed favorites read hid every star on every tab with no explanation. |
| **Over the server's 500-id cap** | Sent anyway, so the tab never loaded while its badge cheerfully reported 501 saved. |
| **Adapter removed mid-session** | Left the reader on a tab that no longer existed, with no tab marked current. |

One clause was **removed** rather than added: the leak guard also tested `isFetching`, which I had put in while the test was failing for the unrelated reason above. Once the fake was fixed, nothing could be made to leak without it — and it blanked the list on every background refetch, including window-focus and the one after every bookmark.

## Deliberately not done

- The id cache is keyed on the patient, not the adapter object: a host building its adapter inline hands over a new object every render, and an identity-keyed cache would refetch on each one. Noted in code.
- `listRegisteredIds` asks for `status=registered` exactly, so a patient a coordinator has advanced to `entered` drops off the tab — at the moment they most want to see it. That is a product question, filed as #434.

## Tests

44 new, 136 in the suite; `tsc -b --force` clean and the remote build green. Mutation-checked: the cache key, the counts withholding, the `[]`-vs-`undefined` handling, the disabled-state exclusion and the row suppression each fail a named test.

**Review status, stated exactly:** three fresh-context rounds plus several `codex review` passes. codex hit its usage limit before it could see the last commit — the delta it has not reviewed is the narrowed row-leak guard and its two tests. The fresh-context pass did review that state, and it is the finding that produced it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015G5YkuAcDZQUTutNEBGwyX