### PR TITLE
feat(federation): the two controls that write, on the detail page (#419)

### DIFF
--- a/frontend/src/federation/TrialCard.tsx
+++ b/frontend/src/federation/TrialCard.tsx
@@ -6,7 +6,14 @@
 // its own `/t/:id`; the remote owns the detail view itself).
 import type { KeyboardEvent } from "react";
 
-import { EyeIcon, Field, ScorePill, SUITABILITY_HREF, asText } from "./bits";
+import {
+  EyeIcon,
+  FavoriteToggle,
+  Field,
+  ScorePill,
+  SUITABILITY_HREF,
+  asText,
+} from "./bits";
 import type { TrialMatch } from "./types";
 
 interface Props {
@@ -21,6 +28,8 @@ interface Props {
    *  control is drawn: a bookmark button with nowhere to write is a button
    *  that forgets. */
   onToggleFavorite?: (next: boolean) => void;
+  /** A bookmark write for this trial is on the wire. */
+  busy?: boolean;
 }
 
 export function TrialCard({
@@ -29,6 +38,7 @@ export function TrialCard({
   isSelected,
   isFavorite,
   onToggleFavorite,
+  busy,
 }: Props) {
   const distance =
     trial.distance != null
@@ -96,26 +106,12 @@ export function TrialCard({
         </div>
 
         <div className="exact-card__action">
-          {onToggleFavorite && isFavorite !== undefined ? (
-            <button
-              type="button"
-              className={`exact-fav${isFavorite ? " is-on" : ""}`}
-              aria-pressed={isFavorite}
-              aria-label={
-                isFavorite
-                  ? `Remove ${trial.briefTitle} from favorites`
-                  : `Add ${trial.briefTitle} to favorites`
-              }
-              onClick={(e) => {
-                // The card is itself a click target; without this, bookmarking
-                // would also open the trial.
-                e.stopPropagation();
-                onToggleFavorite(!isFavorite);
-              }}
-            >
-              {isFavorite ? "★" : "☆"}
-            </button>
-          ) : null}
+          <FavoriteToggle
+            title={trial.briefTitle}
+            isFavorite={isFavorite}
+            onToggle={onToggleFavorite}
+            busy={busy}
+          />
           {onSelect ? (
             <button
               type="button"

--- a/frontend/src/federation/TrialDetailPage.tsx
+++ b/frontend/src/federation/TrialDetailPage.tsx
@@ -4,16 +4,69 @@
 // in-place by `TrialMatches` when a trial is selected — the remote owns the
 // detail view rather than re-using the host's router. Data: `GET /trials/{id}/`
 // (or `POST /trials/{id}/match/` for the inline-payload path) via
-// `useTrialDetail`. v1 is read-only: editing a patient value (CB's pencil
-// controls) and the host action buttons (I'm Interested / bookmark / share /
-// SoC) are deliberately out of scope.
+// `useTrialDetail`.
+//
+// The two controls that write live here too — the bookmark and CB's
+// "I'm Interested" — but only their rendering: everything they write goes
+// through the `state` adapter `TrialMatches` holds, which is why they arrive
+// as a `trialState` bundle of values and callbacks rather than as an adapter
+// this page talks to itself. Without one, neither is drawn.
+//
+// Still out of scope: editing a patient value (CB's pencil controls, phase 4)
+// and CB's share / Standard-of-Care buttons.
 import { useEffect } from "react";
 
-import { Field, FieldTooltip, ScorePill, SUITABILITY_HREF, asText, renderMd } from "./bits";
+import {
+  FavoriteToggle,
+  Field,
+  FieldTooltip,
+  ScorePill,
+  SUITABILITY_HREF,
+  asText,
+  renderMd,
+} from "./bits";
 import { useTrialDetail } from "./hooks";
 import { injectStyles } from "./injectStyles";
 import { FIELD_TOOLTIPS } from "./tooltips";
+import type { AdvancedStatus } from "./state";
 import type { FilterState, PatientInfo, TrialDetailField } from "./types";
+
+/** Everything the two writing controls need, as plain values and callbacks.
+ *
+ *  The page never sees the `state` adapter itself: `TrialMatches` owns the
+ *  queries and the mutations, so it is the only place that can keep the
+ *  card's star and this one showing the same thing. Each field here is a
+ *  distinct state the reader can be in, and every one of them has to be
+ *  distinguishable on screen — "not loaded", "failed to load" and "false"
+ *  all render as an empty star otherwise. */
+export interface TrialStateControls {
+  /** `undefined` = not known (still loading, or the read failed), which
+   *  draws no control at all rather than a star that flips later. */
+  isFavorite?: boolean;
+  onToggleFavorite?: (next: boolean) => void;
+  /** A bookmark write for this trial is on the wire. */
+  favoriteBusy?: boolean;
+  /** A bookmark write was rejected. The star is painted from the server's
+   *  list, so a failed write leaves it exactly where it was — which is what
+   *  a click that never registered looks like. */
+  favoriteFailed?: boolean;
+  /** The bookmark list could not be read, so there is no star to draw and
+   *  the reader is owed a reason. */
+  favoritesUnavailable?: boolean;
+  isRegistered?: boolean;
+  onToggleRegistered?: (next: boolean) => void;
+  /** A registration write is on the wire. The button says so and ignores
+   *  further clicks: the second one would race the first. */
+  registerPending?: boolean;
+  registerFailed?: boolean;
+  registeredUnavailable?: boolean;
+  /** Set when a study team has already moved this trial's enrollment past
+   *  "registered". The control then becomes a statement rather than a
+   *  button: `listRegisteredIds` asks for `status=registered` exactly, so
+   *  such a patient reads back as not registered, and "I'm Interested"
+   *  would write `registered` over `entered` (#434). */
+  advancedStatus?: AdvancedStatus;
+}
 
 interface Props {
   apiClient: import("axios").AxiosInstance;
@@ -23,6 +76,9 @@ interface Props {
   /** Same study preferences the list used, so detail scores/units agree. */
   filters?: FilterState;
   onBack: () => void;
+  /** Absent when the host supplied no state adapter — then neither the
+   *  bookmark nor the interest control is rendered. */
+  trialState?: TrialStateControls;
 }
 
 const BackArrow = () => (
@@ -113,8 +169,133 @@ function EligibilityRow({ field }: { field: TrialDetailField }) {
         {field.uunits ?? field.units ? (
           <span className="exact-elig__units">{field.uunits ?? field.units}</span>
         ) : null}
+        {/* A mismatch was marked in red and nowhere else, while the register
+            card below tells the reader the mismatches are marked above. For
+            anyone not seeing the colour that was a promise the page did not
+            keep.
+
+            After the units, where the matched cell puts its tick: before
+            them it split the value from its unit — "12 ✕ years", read out
+            as "12, does not match, years". */}
+        {notMatched ? (
+          <span className="exact-elig__mismatch" aria-label="does not match">
+            ✕
+          </span>
+        ) : null}
       </div>
     </div>
+  );
+}
+
+/** CB's RegisterInterestCard, with CB's promise removed.
+ *
+ *  CB tells the reader "a study coordinator will reach out to discuss next
+ *  steps". Here that would be false: registering writes a status onto the
+ *  patient's enrollment row in PROMOP and nothing else happens — no mail,
+ *  no queue, nobody notified. So the copy says what the click actually does
+ *  and says explicitly what it does not do. Whether it should eventually do
+ *  more is a product decision that has not been taken.
+ *
+ *  What IS kept from CB is #4669: when the matcher says not_eligible, the
+ *  card must not open by telling someone they may be eligible — and it goes
+ *  on saying so after they register, which is when it matters most.
+ */
+function RegisterInterest({
+  advancedStatus,
+  notEligible,
+  mismatchesShown,
+  isRegistered,
+  pending,
+  failed,
+  onToggle,
+}: {
+  advancedStatus?: AdvancedStatus;
+  notEligible: boolean;
+  /** Whether the table above actually lists a mismatched row.
+   *
+   *  It often does not: `matchingType` is decided over every mapped
+   *  attribute, while the table is the filtered "potential attributes"
+   *  view, which drops admin and general groups, blank values and select
+   *  values absent from their own options. Pointing at rows that are not
+   *  there — or at an empty table, which the endpoint does return — was a
+   *  claim the page could not keep. */
+  mismatchesShown: boolean;
+  isRegistered: boolean;
+  pending: boolean;
+  failed: boolean;
+  onToggle: (next: boolean) => void;
+}) {
+  if (advancedStatus) {
+    return (
+      <section className="exact-panel exact-register is-registered">
+        <h2 className="exact-panel__title">
+          {advancedStatus === "completed"
+            ? "Your participation in this trial is recorded as completed"
+            : "You are recorded as taking part in this trial"}
+        </h2>
+        <p className="exact-register__text">
+          Your study team keeps this up to date, so it is not something to
+          change here. Speak to them if it looks wrong.
+        </p>
+      </section>
+    );
+  }
+
+  const heading = isRegistered
+    ? "You registered interest in this trial"
+    : notEligible
+      ? "You may not meet this trial's eligibility criteria"
+      : "Interested in this trial?";
+
+  // Deliberately NOT "listed on the Registered tab": that tab asks for
+  // `status=registered` exactly, so a patient a coordinator has advanced to
+  // `entered` is no longer on it (#434). Note that the same narrow query
+  // decides `isRegistered`, so such a patient does not reach this branch at
+  // all — they are invited to register for a trial they are already in.
+  // That is #434 itself and is not fixed here; what is fixed is this
+  // sentence not adding a second false claim on top of it.
+  const state = isRegistered
+    ? "It is marked in your record, and you can withdraw at any time."
+    : "Registering marks this trial in your record, where you can find it again.";
+  const mismatch = !notEligible
+    ? ""
+    : mismatchesShown
+      ? " One or more of this trial's requirements does not match your profile — the ones listed above are marked."
+      : " One or more of this trial's requirements does not match your profile.";
+
+  return (
+    <section
+      className={`exact-panel exact-register${notEligible ? " is-warning" : ""}${
+        isRegistered ? " is-registered" : ""
+      }`}
+    >
+      <h2 className="exact-panel__title">{heading}</h2>
+      <p className="exact-register__text">
+        {state}
+        {mismatch} Nothing is sent to the trial's coordinators from here.
+      </p>
+      <button
+        type="button"
+        className={`exact-register__btn${isRegistered ? " is-on" : ""}`}
+        // `aria-disabled`, not `disabled`: a control that disables itself
+        // under the pointer is blurred by the browser, dropping a keyboard
+        // user to the document body in the middle of the action they just
+        // took. Announced here, enforced in one place — `TrialMatches`'s
+        // `write` drops a click for a trial whose write is still on the
+        // wire, and two PATCHes in flight are applied in whatever order
+        // they arrive.
+        aria-disabled={pending || undefined}
+        aria-busy={pending || undefined}
+        onClick={() => onToggle(!isRegistered)}
+      >
+        {pending ? "Saving…" : isRegistered ? "Withdraw" : "I'm Interested"}
+      </button>
+      {failed ? (
+        <p className="exact-register__error" role="alert">
+          Couldn't save that. Please try again.
+        </p>
+      ) : null}
+    </section>
   );
 }
 
@@ -125,6 +306,7 @@ export function TrialDetailPage({
   personId,
   filters,
   onBack,
+  trialState,
 }: Props) {
   // Idempotent: ensures the scoped stylesheet is present even if this page is
   // mounted without `TrialMatches` having run (it already injects on mount).
@@ -139,6 +321,12 @@ export function TrialDetailPage({
   const summary = data
     ? data.laySummary || data.briefSummary || data.participationCriteria || ""
     : "";
+
+  // CB's own rule (#4669), and the same field: the detail endpoint scores
+  // the trial with the conflict-aware matcher and can answer not_eligible.
+  const notEligible = data?.matchingType === "not_eligible";
+  const canRegister =
+    trialState?.onToggleRegistered != null && trialState.isRegistered !== undefined;
 
   return (
     <div className="exact-root exact-detail">
@@ -159,7 +347,30 @@ export function TrialDetailPage({
 
       {data ? (
         <>
-          <h1 className="exact-detail__title">{data.briefTitle}</h1>
+          <div className="exact-detail__head">
+            <h1 className="exact-detail__title">{data.briefTitle}</h1>
+            <FavoriteToggle
+              title={data.briefTitle}
+              isFavorite={trialState?.isFavorite}
+              onToggle={trialState?.onToggleFavorite}
+              busy={trialState?.favoriteBusy}
+            />
+          </div>
+
+          {/* Same three failures the list reports, and for the same reason:
+              painted from a server list, a rejected write and a rejected read
+              both look exactly like a control that does nothing. */}
+          {trialState?.favoritesUnavailable ? (
+            <p style={{ color: "var(--exact-color-not-eligible)" }}>
+              Couldn't load your favorites, so bookmarking is unavailable right
+              now.
+            </p>
+          ) : null}
+          {trialState?.favoriteFailed ? (
+            <p style={{ color: "var(--exact-color-not-eligible)" }} role="alert">
+              Couldn't update your favorites. Please try again.
+            </p>
+          ) : null}
 
           <div className="exact-detail__scores">
             <ScorePill score={data.matchScore} label="Matching Score" />
@@ -231,6 +442,27 @@ export function TrialDetailPage({
               )}
             </section>
           </div>
+
+          {canRegister ? (
+            <RegisterInterest
+              advancedStatus={trialState!.advancedStatus}
+              notEligible={notEligible}
+              mismatchesShown={eligibility.some(
+                (f) => f.matchingType === "not_matched",
+              )}
+              isRegistered={trialState!.isRegistered!}
+              pending={trialState?.registerPending ?? false}
+              failed={trialState?.registerFailed ?? false}
+              onToggle={trialState!.onToggleRegistered!}
+            />
+          ) : null}
+
+          {trialState?.registeredUnavailable ? (
+            <p style={{ color: "var(--exact-color-not-eligible)" }}>
+              Couldn't load whether you have registered interest in this trial,
+              so that control is unavailable right now.
+            </p>
+          ) : null}
         </>
       ) : null}
     </div>

--- a/frontend/src/federation/TrialMatches.test.tsx
+++ b/frontend/src/federation/TrialMatches.test.tsx
@@ -18,7 +18,8 @@ import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { TrialMatches } from "./TrialMatches";
-import { fakeApi, renderTrialMatches, trial } from "../test/renderTrialMatches";
+import type { TrialStateAdapter } from "./state";
+import { fakeApi, fakeState, renderTrialMatches, trial } from "../test/renderTrialMatches";
 
 const listed = (api: ReturnType<typeof fakeApi>) => api.listRequests();
 
@@ -473,52 +474,18 @@ describe("without a state adapter", () => {
 });
 
 describe("with a state adapter", () => {
-  const makeState = (favorites: string[] = [], registered: string[] = []) => {
-    const calls: { setFavorite: [string, boolean][] } = { setFavorite: [] };
-    const state = {
-      listFavoriteIds: vi.fn(async () => favorites),
-      listRegisteredIds: vi.fn(async () => registered),
-      setFavorite: vi.fn(async (id: string, on: boolean) => {
-        calls.setFavorite.push([id, on]);
-        if (on) favorites.push(id);
-        else favorites = favorites.filter((f) => f !== id);
-      }),
-      setRegistered: vi.fn(async () => undefined),
-      getPreferences: vi.fn(async () => ({})),
-      savePreferences: vi.fn(async () => undefined),
-      resetPreferences: vi.fn(async () => undefined),
-    };
-    return { state, calls };
-  };
-
-  const renderWithState = (api: ReturnType<typeof fakeApi>, state: unknown) => {
-    const queryClient = new QueryClient({
-      defaultOptions: { queries: { retry: false, refetchOnWindowFocus: false } },
-    });
-    return render(
-      <QueryClientProvider client={queryClient}>
-        <TrialMatches
-          apiClient={api.client}
-          queryClient={queryClient}
-          patientInfo={{ disease: "multiple myeloma" }}
-          state={state as never}
-        />
-      </QueryClientProvider>,
-    );
-  };
-
   it("offers the Favorites and Registered tabs, counted from the adapter", async () => {
     const api = fakeApi();
-    const { state } = makeState(["1", "2"], ["3"]);
-    renderWithState(api, state);
+    const state = fakeState({ favorites: ["1", "2"], registered: ["3"] });
+    renderTrialMatches(api, { state: state.adapter });
     await screen.findByRole("button", { name: "Favorites, 2 trials" });
     await screen.findByRole("button", { name: "Registered, 1 trials" });
   });
 
   it("narrows the list by the saved ids when the tab is opened", async () => {
     const api = fakeApi();
-    const { state } = makeState(["11", "12"]);
-    renderWithState(api, state);
+    const state = fakeState({ favorites: ["11", "12"] });
+    renderTrialMatches(api, { state: state.adapter });
     await waitFor(() => expect(listed(api).length).toBe(1));
 
     await userEvent.click(await screen.findByRole("button", { name: /^Favorites/ }));
@@ -533,8 +500,8 @@ describe("with a state adapter", () => {
     // The failure this guards: `[]` collapsing into "no filter" answers an
     // empty Favorites tab with the whole registry.
     const api = fakeApi();
-    const { state } = makeState([]);
-    renderWithState(api, state);
+    const state = fakeState();
+    renderTrialMatches(api, { state: state.adapter });
     await waitFor(() => expect(listed(api).length).toBe(1));
 
     await userEvent.click(await screen.findByRole("button", { name: /^Favorites/ }));
@@ -553,16 +520,10 @@ describe("with a state adapter", () => {
     const pending = new Promise<string[]>((resolve) => {
       release = resolve;
     });
-    const state = {
-      listFavoriteIds: vi.fn(() => pending),
-      listRegisteredIds: vi.fn(async () => []),
-      setFavorite: vi.fn(async () => undefined),
-      setRegistered: vi.fn(async () => undefined),
-      getPreferences: vi.fn(async () => ({})),
-      savePreferences: vi.fn(async () => undefined),
-      resetPreferences: vi.fn(async () => undefined),
-    };
-    renderWithState(api, state);
+    const state = fakeState({
+      overrides: { listFavoriteIds: vi.fn(() => pending) },
+    });
+    renderTrialMatches(api, { state: state.adapter });
     await userEvent.click(await screen.findByRole("button", { name: /^Favorites/ }));
 
     const before = listed(api).length;
@@ -580,19 +541,24 @@ describe("with a state adapter", () => {
 
   it("bookmarks a trial from its card", async () => {
     const api = fakeApi();
-    const { state, calls } = makeState([]);
-    renderWithState(api, state);
+    const state = fakeState();
+    renderTrialMatches(api, { state: state.adapter });
     await waitFor(() => expect(listed(api).length).toBe(1));
 
     await userEvent.click(await screen.findByRole("button", { name: /Add .* to favorites/ }));
-    await waitFor(() => expect(calls.setFavorite).toEqual([["1", true]]));
+    // The stored list, not only the spy: a call with the right arguments
+    // that the adapter drops on the floor is not a bookmark. And the call
+    // count with it — the store is idempotent, so a control that fires twice
+    // per click leaves the list looking exactly right.
+    await waitFor(() => expect(state.favorites).toEqual(["1"]));
+    expect(state.adapter.setFavorite).toHaveBeenCalledTimes(1);
+    expect(state.adapter.setFavorite).toHaveBeenCalledWith("1", true);
   });
 
   it("does not open the trial when the bookmark is clicked", async () => {
     // The card is itself a click target, so the toggle has to stop the event.
     const api = fakeApi();
-    const { state } = makeState([]);
-    renderWithState(api, state);
+    renderTrialMatches(api, { state: fakeState().adapter });
     await waitFor(() => expect(listed(api).length).toBe(1));
 
     await userEvent.click(await screen.findByRole("button", { name: /Add .* to favorites/ }));
@@ -601,32 +567,8 @@ describe("with a state adapter", () => {
 });
 
 describe("the state tabs under failure and transition", () => {
-  const stateWith = (overrides: Record<string, unknown>) => ({
-    listFavoriteIds: vi.fn(async () => ["11"]),
-    listRegisteredIds: vi.fn(async () => []),
-    setFavorite: vi.fn(async () => undefined),
-    setRegistered: vi.fn(async () => undefined),
-    getPreferences: vi.fn(async () => ({})),
-    savePreferences: vi.fn(async () => undefined),
-    resetPreferences: vi.fn(async () => undefined),
-    ...overrides,
-  });
-
-  const renderWith = (api: ReturnType<typeof fakeApi>, state: unknown) => {
-    const queryClient = new QueryClient({
-      defaultOptions: { queries: { retry: false, refetchOnWindowFocus: false } },
-    });
-    return render(
-      <QueryClientProvider client={queryClient}>
-        <TrialMatches
-          apiClient={api.client}
-          queryClient={queryClient}
-          patientInfo={{ disease: "multiple myeloma" }}
-          state={state as never}
-        />
-      </QueryClientProvider>,
-    );
-  };
+  const stateWith = (overrides: Partial<TrialStateAdapter>) =>
+    fakeState({ favorites: ["11"], overrides }).adapter;
 
   it("returns to the first page when a state tab is opened", async () => {
     // `queryFilters.type` is undefined for the default tab AND for both
@@ -634,7 +576,7 @@ describe("the state tabs under failure and transition", () => {
     // hashed identically and the page never reset. A reader on page 2 asked
     // for page 2 of their bookmarks.
     const api = fakeApi({ count: 3, itemsTotalCount: 25 });
-    renderWith(api, stateWith({}));
+    renderTrialMatches(api, { state: stateWith({}) });
     await waitFor(() => expect(listed(api).length).toBe(1));
 
     await userEvent.click(await screen.findByRole("button", { name: "2" }));
@@ -656,7 +598,7 @@ describe("the state tabs under failure and transition", () => {
         throw new Error("promop unreachable");
       }),
     });
-    renderWith(api, state);
+    renderTrialMatches(api, { state });
     await waitFor(() => expect(listed(api).length).toBe(1));
 
     await userEvent.click(await screen.findByRole("button", { name: /^Favorites/ }));
@@ -671,7 +613,9 @@ describe("the state tabs under failure and transition", () => {
     // list was painted under the Favorites heading — and on a second visit,
     // with the ids already cached, from the very first render.
     const api = fakeApi({ results: [trial(1)] });
-    renderWith(api, stateWith({ listFavoriteIds: vi.fn(async () => ["99"]) }));
+    renderTrialMatches(api, {
+      state: stateWith({ listFavoriteIds: vi.fn(async () => ["99"]) }),
+    });
     await screen.findByText("Trial 1");
 
     let leaked = false;
@@ -701,7 +645,7 @@ describe("the state tabs under failure and transition", () => {
         throw new Error("nope");
       }),
     });
-    renderWith(api, state);
+    renderTrialMatches(api, { state });
     await waitFor(() => expect(listed(api).length).toBe(1));
 
     await userEvent.click(await screen.findByRole("button", { name: /Add .* to favorites/ }));
@@ -715,15 +659,7 @@ describe("when the host takes the adapter away", () => {
     // lookup would list the default tab's trials while no tab in the bar is
     // marked current — the reader would be somewhere the UI cannot name.
     const api = fakeApi();
-    const state = {
-      listFavoriteIds: vi.fn(async () => ["1"]),
-      listRegisteredIds: vi.fn(async () => []),
-      setFavorite: vi.fn(async () => undefined),
-      setRegistered: vi.fn(async () => undefined),
-      getPreferences: vi.fn(async () => ({})),
-      savePreferences: vi.fn(async () => undefined),
-      resetPreferences: vi.fn(async () => undefined),
-    };
+    const state = fakeState({ favorites: ["1"] }).adapter;
     const queryClient = new QueryClient({
       defaultOptions: { queries: { retry: false, refetchOnWindowFocus: false } },
     });
@@ -733,7 +669,7 @@ describe("when the host takes the adapter away", () => {
           apiClient={api.client}
           queryClient={queryClient}
           patientInfo={{ disease: "multiple myeloma" }}
-          state={withState ? (state as never) : undefined}
+          state={withState ? state : undefined}
         />
       </QueryClientProvider>
     );
@@ -1029,5 +965,722 @@ describe("the failure messages stand alone", () => {
     await screen.findByText(/can show at most 500 at a time/);
     await new Promise((r) => setTimeout(r, 40));
     expect(screen.queryByText("Loading trials…")).toBeNull();
+  });
+});
+
+describe("the controls on the detail page", () => {
+  // Both write through the same adapter the list uses, which is why they
+  // live in this suite rather than in one of their own: the thing that can
+  // go wrong is not the button, it is the button and the card disagreeing.
+  /** Open the nth listed trial. Exact name: the card is itself a
+   *  `role="button"` whose accessible name contains the inner button's
+   *  text, so a regex would match both. */
+  const openDetail = async (api: ReturnType<typeof fakeApi>, nth = 0) => {
+    await waitFor(() => expect(listed(api).length).toBe(1));
+    const cards = await screen.findAllByRole("button", { name: "View Trial" });
+    await userEvent.click(cards[nth]);
+    await screen.findByText("Back to all trials");
+  };
+
+  it("draws the bookmark already on, for a trial that is bookmarked", async () => {
+    const api = fakeApi();
+    renderTrialMatches(api, { state: fakeState({ favorites: ["1"] }).adapter });
+    await openDetail(api);
+
+    const star = await screen.findByRole("button", {
+      name: "Remove Trial 1 from favorites",
+    });
+    expect(star).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("bookmarks from the detail page, through the same adapter as the card", async () => {
+    const api = fakeApi();
+    const state = fakeState();
+    renderTrialMatches(api, { state: state.adapter });
+    await openDetail(api);
+
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Add Trial 1 to favorites" }),
+    );
+    await waitFor(() => expect(state.favorites).toEqual(["1"]));
+  });
+
+  it("draws no bookmark while the favorites are unknown", async () => {
+    // The rule the card and the detail page have to share — one component
+    // now, because written twice they drift, and the second copy is the one
+    // that shows an empty star that fills itself in a moment later.
+    const api = fakeApi();
+    const state = fakeState({
+      overrides: {
+        listFavoriteIds: vi.fn(async () => {
+          throw new Error("promop unreachable");
+        }),
+      },
+    });
+    renderTrialMatches(api, { state: state.adapter });
+    await waitFor(() => expect(listed(api).length).toBe(1));
+    // Not on the card…
+    expect(screen.queryByRole("button", { name: /favorites$/ })).toBeNull();
+
+    await openDetail(api);
+    // …and not on the detail page either, which says why instead.
+    expect(screen.queryByRole("button", { name: /favorites$/ })).toBeNull();
+    await screen.findByText(/bookmarking is unavailable/);
+  });
+
+  it("registers interest, and withdraws it on a second click", async () => {
+    const api = fakeApi();
+    const state = fakeState();
+    renderTrialMatches(api, { state: state.adapter });
+    await openDetail(api);
+
+    await userEvent.click(await screen.findByRole("button", { name: "I'm Interested" }));
+    await waitFor(() => expect(state.registered).toEqual(["1"]));
+
+    // The label changes to the act, not to the state: a button that still
+    // said "I'm Interested" would be a second registration to the reader,
+    // and one that said "Registered" would withdraw without saying so.
+    await userEvent.click(await screen.findByRole("button", { name: "Withdraw" }));
+    await waitFor(() => expect(state.registered).toEqual([]));
+  });
+
+  it("re-reads the registered ids after a write, not the favorites", async () => {
+    // `useSetTrialState` takes the list it invalidates as a parameter, so a
+    // copy-paste of "favorites" there would leave the Registered tab and its
+    // count showing the state from before the click, with nothing on screen
+    // to suggest anything was stale.
+    const api = fakeApi();
+    const state = fakeState();
+    renderTrialMatches(api, { state: state.adapter });
+    await openDetail(api);
+    const before = state.reads.registered;
+
+    await userEvent.click(await screen.findByRole("button", { name: "I'm Interested" }));
+    await waitFor(() => expect(state.reads.registered).toBeGreaterThan(before));
+  });
+
+  it("refuses a second click while the write is on the wire", async () => {
+    // Two PATCHes in flight are applied in whatever order they arrive, so
+    // the older one can be the one that sticks — leaving the button
+    // disagreeing with the record behind it.
+    const api = fakeApi();
+    let release: () => void = () => {};
+    const state = fakeState({
+      overrides: {
+        setRegistered: vi.fn(
+          () => new Promise<void>((resolve) => {
+            release = resolve;
+          }),
+        ),
+      },
+    });
+    renderTrialMatches(api, { state: state.adapter });
+    await openDetail(api);
+
+    const button = await screen.findByRole("button", { name: "I'm Interested" });
+    await userEvent.click(button);
+    const saving = await screen.findByRole("button", { name: "Saving…" });
+    // `aria-disabled`, not `disabled`: the browser blurs a control that
+    // disables itself under the pointer, which drops a keyboard user to the
+    // document body in the middle of the action they just took.
+    expect(saving).toHaveAttribute("aria-disabled", "true");
+    expect(saving).not.toBeDisabled();
+    await userEvent.click(saving);
+    expect(state.adapter.setRegistered).toHaveBeenCalledTimes(1);
+
+    release();
+  });
+
+  it("says so when the registration cannot be saved", async () => {
+    const api = fakeApi();
+    const state = fakeState({
+      overrides: {
+        setRegistered: vi.fn(async () => {
+          throw new Error("nope");
+        }),
+      },
+    });
+    renderTrialMatches(api, { state: state.adapter });
+    await openDetail(api);
+
+    await userEvent.click(await screen.findByRole("button", { name: "I'm Interested" }));
+    // The text, not just `role="alert"`: both failure lines on this page are
+    // alerts, so the role alone would pass while a failed registration
+    // reported a favorites problem.
+    const alert = await screen.findByRole("alert");
+    expect(alert).toHaveTextContent("Couldn't save that");
+  });
+
+  it("draws no interest control when it cannot tell whether interest was registered", async () => {
+    // Drawn against an unknown answer it would open on "I'm Interested" for
+    // someone who has already registered, and a click would then withdraw
+    // the registration it appeared to be making.
+    const api = fakeApi();
+    const state = fakeState({
+      overrides: {
+        listRegisteredIds: vi.fn(async () => {
+          throw new Error("promop unreachable");
+        }),
+      },
+    });
+    renderTrialMatches(api, { state: state.adapter });
+    await openDetail(api);
+
+    expect(screen.queryByRole("button", { name: "I'm Interested" })).toBeNull();
+    await screen.findByText(/that control is unavailable/);
+  });
+
+  it("does not offer to register a trial the study team has already advanced", async () => {
+    // `listRegisteredIds` asks for `status=registered` exactly, so a patient
+    // a coordinator moved to `entered` reads back as NOT registered — and a
+    // button saying "I'm Interested" writes `registered` over that status
+    // when clicked. The control becomes a statement instead.
+    const api = fakeApi();
+    const state = fakeState({ advanced: { "1": "entered" } });
+    renderTrialMatches(api, { state: state.adapter });
+    await openDetail(api);
+
+    await screen.findByText(/You are recorded as taking part in this trial/);
+    expect(screen.queryByRole("button", { name: "I'm Interested" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Withdraw" })).toBeNull();
+    expect(state.adapter.setRegistered).not.toHaveBeenCalled();
+  });
+
+  it("says completed when that is what the record says", async () => {
+    const api = fakeApi();
+    renderTrialMatches(api, {
+      state: fakeState({ advanced: { "1": "completed" } }).adapter,
+    });
+    await openDetail(api);
+
+    await screen.findByText(/recorded as completed/);
+  });
+
+  it("draws no interest control until it knows whether the trial was advanced", async () => {
+    // Drawn against an unknown answer it is exactly the control that
+    // overwrites the advanced status.
+    const api = fakeApi();
+    const state = fakeState({
+      overrides: { listAdvancedEnrollments: vi.fn(() => new Promise<never>(() => {})) },
+    });
+    renderTrialMatches(api, { state: state.adapter });
+    await openDetail(api);
+
+    await screen.findByText("Trial 1");
+    expect(screen.queryByRole("button", { name: "I'm Interested" })).toBeNull();
+  });
+
+  it("says so when the advanced statuses cannot be read", async () => {
+    const api = fakeApi();
+    const state = fakeState({
+      overrides: {
+        listAdvancedEnrollments: vi.fn(async () => {
+          throw new Error("promop unreachable");
+        }),
+      },
+    });
+    renderTrialMatches(api, { state: state.adapter });
+    await openDetail(api);
+
+    await screen.findByText(/that control is unavailable/);
+    expect(screen.queryByRole("button", { name: "I'm Interested" })).toBeNull();
+  });
+
+  it("withholds the interest control from an adapter that cannot answer", async () => {
+    // The method is required by the interface, but a host may be plain
+    // JavaScript. Unchecked, it throws a TypeError inside the query — the
+    // right outcome by a confusing route, and one retry-shaped detour from
+    // a control that should never have been offered.
+    const state = fakeState();
+    delete (state.adapter as Partial<typeof state.adapter>).listAdvancedEnrollments;
+    const api = fakeApi();
+    renderTrialMatches(api, { state: state.adapter });
+    await openDetail(api);
+
+    expect(screen.queryByRole("button", { name: "I'm Interested" })).toBeNull();
+    await screen.findByText(/that control is unavailable/);
+    // The bookmark does not depend on it and is still offered.
+    await screen.findByRole("button", { name: "Add Trial 1 to favorites" });
+  });
+
+  it("offers no controls at all when the trial itself could not be loaded", async () => {
+    // Reachable, and until the harness could fail a detail request it was
+    // unreachable from this suite: a bookmark or an interest button drawn
+    // beside "Failed to load trial" would be acting on nothing.
+    const api = fakeApi();
+    renderTrialMatches(api, { state: fakeState().adapter });
+    await waitFor(() => expect(listed(api).length).toBe(1));
+
+    api.failNextWith(500);
+    await userEvent.click(await screen.findByRole("button", { name: "View Trial" }));
+    await screen.findByText(/Failed to load trial/);
+    expect(screen.queryByRole("button", { name: /favorites$/ })).toBeNull();
+    expect(screen.queryByRole("button", { name: "I'm Interested" })).toBeNull();
+  });
+
+  it("offers neither control without an adapter", async () => {
+    const api = fakeApi();
+    renderTrialMatches(api);
+    await openDetail(api);
+
+    expect(screen.queryByRole("button", { name: /favorites$/ })).toBeNull();
+    expect(screen.queryByRole("button", { name: "I'm Interested" })).toBeNull();
+  });
+
+  it("un-bookmarks, and not only bookmarks", async () => {
+    // The star sends `!isFavorite`, and nothing in the suite exercised the
+    // false half: a control hard-wired to `true` — on both surfaces, since
+    // they now share one component — passed every other test here.
+    const api = fakeApi();
+    const state = fakeState({ favorites: ["1"] });
+    renderTrialMatches(api, { state: state.adapter });
+    await openDetail(api);
+
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Remove Trial 1 from favorites" }),
+    );
+    await waitFor(() => expect(state.favorites).toEqual([]));
+    expect(state.adapter.setFavorite).toHaveBeenCalledWith("1", false);
+  });
+
+  it("asks for the trial that was clicked", async () => {
+    const api = fakeApi({ results: [trial(1), trial(7)] });
+    renderTrialMatches(api, { state: fakeState().adapter });
+    await waitFor(() => expect(listed(api).length).toBe(1));
+
+    const cards = await screen.findAllByRole("button", { name: "View Trial" });
+    await userEvent.click(cards[1]);
+    await waitFor(() => expect(api.detailRequests().length).toBe(1));
+    expect(api.detailRequests()[0].url).toContain("/trials/7/");
+    await screen.findByText("Trial 7");
+  });
+
+  it("keeps a failed write on the trial it failed for", async () => {
+    // A mutation's error survives until the next `mutate()`, and this
+    // component does not unmount when the reader opens a different trial —
+    // so the failure printed itself inside the next trial's card, which
+    // names a trial and so reads as a statement about that one.
+    const api = fakeApi({ results: [trial(1), trial(7)] });
+    const state = fakeState({
+      overrides: {
+        setRegistered: vi.fn(async () => {
+          throw new Error("nope");
+        }),
+      },
+    });
+    renderTrialMatches(api, { state: state.adapter });
+    await openDetail(api);
+
+    await userEvent.click(await screen.findByRole("button", { name: "I'm Interested" }));
+    await screen.findByRole("alert");
+
+    await userEvent.click(screen.getByText("Back to all trials"));
+    const cards = await screen.findAllByRole("button", { name: "View Trial" });
+    await userEvent.click(cards[1]);
+    await screen.findByText("Trial 7");
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  it("does not read as a failure between the write and the re-read", async () => {
+    // Every control here is painted from the id list, and the write
+    // succeeds before that list has been re-read. Left to the refetch, the
+    // reader saw "Saving…" turn back into "I'm Interested" — which reads as
+    // "it didn't take" and invites the second click the pending guard
+    // exists to stop.
+    const api = fakeApi();
+    let release: (ids: string[]) => void = () => {};
+    let reads = 0;
+    const state = fakeState({
+      overrides: {
+        listRegisteredIds: vi.fn(() => {
+          reads += 1;
+          if (reads === 1) return Promise.resolve([]);
+          // The reconciling read never comes back during this test.
+          return new Promise<string[]>((resolve) => {
+            release = resolve;
+          });
+        }),
+      },
+    });
+    renderTrialMatches(api, { state: state.adapter });
+    await openDetail(api);
+
+    await userEvent.click(await screen.findByRole("button", { name: "I'm Interested" }));
+    await waitFor(() => expect(reads).toBe(2));
+    // Answered from the patched list, without waiting for the server.
+    await screen.findByRole("button", { name: "Withdraw" });
+    expect(screen.queryByRole("button", { name: "I'm Interested" })).toBeNull();
+    expect(screen.queryByRole("alert")).toBeNull();
+
+    release(["1"]);
+    await screen.findByRole("button", { name: "Withdraw" });
+  });
+
+  it("does not hold the button open for the round trip either", async () => {
+    // The other way to close that window is to keep the mutation pending
+    // until the re-read returns. It costs the whole round trip — with the
+    // host's default retries, seconds of a disabled button after the write
+    // has already succeeded.
+    const api = fakeApi();
+    const state = fakeState({
+      overrides: {
+        listRegisteredIds: vi.fn((() => {
+          let n = 0;
+          return () => {
+            n += 1;
+            return n === 1
+              ? Promise.resolve([] as string[])
+              : new Promise<string[]>(() => {});
+          };
+        })()),
+      },
+    });
+    renderTrialMatches(api, { state: state.adapter });
+    await openDetail(api);
+
+    await userEvent.click(await screen.findByRole("button", { name: "I'm Interested" }));
+    const button = await screen.findByRole("button", { name: "Withdraw" });
+    expect(button).not.toHaveAttribute("aria-disabled");
+  });
+
+  it("marks a mismatched value for readers who do not see the red", async () => {
+    // The card below points at the mismatches above, and they were marked
+    // in colour and nowhere else.
+    const api = fakeApi();
+    api.setDetail({
+      matchingType: "not_eligible",
+      details: {
+        trialEligibilityAttributes: [
+          {
+            name: "age",
+            label: "Age",
+            type: "number",
+            value: 18,
+            uvalue: 12,
+            units: "years",
+            matchingType: "not_matched",
+          },
+        ],
+      },
+    });
+    renderTrialMatches(api, { state: fakeState().adapter });
+    await openDetail(api);
+
+    const marker = await screen.findByLabelText("does not match");
+    await screen.findByText(/the ones listed above are marked/);
+    // After the units, where the matched cell puts its tick. Before them it
+    // split the value from its unit: "12 ✕ years", read out as
+    // "12, does not match, years".
+    expect(marker.previousElementSibling).toHaveTextContent("years");
+  });
+
+  it("keeps the control when a REFETCH fails over ids it already has", async () => {
+    // A query that errors keeps the data it had. Read as "unavailable",
+    // that printed "…so that control is unavailable right now" directly
+    // underneath a control that was rendered, populated and working.
+    const api = fakeApi();
+    let reads = 0;
+    const state = fakeState({
+      overrides: {
+        listRegisteredIds: vi.fn(async () => {
+          reads += 1;
+          if (reads === 1) return [];
+          throw new Error("promop unreachable");
+        }),
+      },
+    });
+    renderTrialMatches(api, { state: state.adapter });
+    await openDetail(api);
+
+    // The write patches the cache and invalidates it; the re-read rejects.
+    await userEvent.click(await screen.findByRole("button", { name: "I'm Interested" }));
+    await waitFor(() => expect(reads).toBeGreaterThan(1));
+
+    await screen.findByRole("button", { name: "Withdraw" });
+    expect(screen.queryByText(/that control is unavailable/)).toBeNull();
+  });
+
+  it("paints the ineligibility warning as a warning, not as an invitation", async () => {
+    // It arrived in the same success green as "Interested in this trial?".
+    const api = fakeApi();
+    api.setDetail({ matchingType: "not_eligible" });
+    const { container } = renderTrialMatches(api, { state: fakeState().adapter });
+    await openDetail(api);
+
+    await screen.findByText(/You may not meet this trial's eligibility criteria/);
+    expect(container.querySelector(".exact-register")).toHaveClass("is-warning");
+  });
+
+  it("keeps focus on the button it just disabled", async () => {
+    // The reason it is `aria-disabled` and not `disabled`: browsers blur a
+    // control that becomes disabled, dropping a keyboard user to the
+    // document body in the middle of the action they just took.
+    const api = fakeApi();
+    const state = fakeState({
+      overrides: { setRegistered: vi.fn(() => new Promise<void>(() => {})) },
+    });
+    renderTrialMatches(api, { state: state.adapter });
+    await openDetail(api);
+
+    await userEvent.click(await screen.findByRole("button", { name: "I'm Interested" }));
+    expect(await screen.findByRole("button", { name: "Saving…" })).toHaveFocus();
+  });
+
+  it("does not disable a different trial's button while a write is in flight", async () => {
+    const api = fakeApi({ results: [trial(1), trial(7)] });
+    const state = fakeState({
+      overrides: { setRegistered: vi.fn(() => new Promise<void>(() => {})) },
+    });
+    renderTrialMatches(api, { state: state.adapter });
+    await openDetail(api);
+
+    await userEvent.click(await screen.findByRole("button", { name: "I'm Interested" }));
+    await screen.findByRole("button", { name: "Saving…" });
+
+    await userEvent.click(screen.getByText("Back to all trials"));
+    await openDetail(api, 1);
+    await screen.findByText("Trial 7");
+    await screen.findByRole("button", { name: "I'm Interested" });
+  });
+
+  it("does not carry one patient's failed write into the next patient", async () => {
+    // The same shape as the cache-key bug: a host can swap the patient at
+    // any moment, including while a write is on the wire, and a record that
+    // is not keyed to them becomes the next reader's error message.
+    const api = fakeApi();
+    const state = fakeState({
+      overrides: {
+        setFavorite: vi.fn(async () => {
+          throw new Error("nope");
+        }),
+      },
+    });
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, refetchOnWindowFocus: false } },
+    });
+    const ui = (patient: Record<string, unknown>) => (
+      <QueryClientProvider client={queryClient}>
+        <TrialMatches
+          apiClient={api.client}
+          queryClient={queryClient}
+          patientInfo={patient}
+          state={state.adapter}
+        />
+      </QueryClientProvider>
+    );
+    const view = render(ui({ disease: "mm", id: 1 }));
+    await waitFor(() => expect(listed(api).length).toBe(1));
+
+    await userEvent.click(await screen.findByRole("button", { name: /Add .* to favorites/ }));
+    await screen.findByText(/Couldn't update your favorites/);
+
+    view.rerender(ui({ disease: "mm", id: 2 }));
+    await waitFor(() =>
+      expect(screen.queryByText(/Couldn't update your favorites/)).toBeNull(),
+    );
+  });
+
+  it("does not let a write that lands after the swap reach the new patient", async () => {
+    // The other half of the same rule: the record is dropped when the
+    // patient changes, and a callback arriving afterwards carries the key it
+    // was made under, finds it stale, and writes nothing. Dropping alone
+    // would let this rejection land in the new patient's record.
+    const api = fakeApi();
+    let reject: (e: Error) => void = () => {};
+    const state = fakeState({
+      overrides: {
+        setFavorite: vi.fn(
+          () => new Promise<void>((_resolve, r) => {
+            reject = r;
+          }),
+        ),
+      },
+    });
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false, refetchOnWindowFocus: false },
+        mutations: { retry: false },
+      },
+    });
+    const ui = (patient: Record<string, unknown>) => (
+      <QueryClientProvider client={queryClient}>
+        <TrialMatches
+          apiClient={api.client}
+          queryClient={queryClient}
+          patientInfo={patient}
+          state={state.adapter}
+        />
+      </QueryClientProvider>
+    );
+    const view = render(ui({ disease: "mm", id: 1 }));
+    await waitFor(() => expect(listed(api).length).toBe(1));
+    await userEvent.click(await screen.findByRole("button", { name: /Add .* to favorites/ }));
+
+    view.rerender(ui({ disease: "mm", id: 2 }));
+    await waitFor(() => expect(listed(api).length).toBeGreaterThan(1));
+
+    reject(new Error("nope"));
+    await new Promise((r) => setTimeout(r, 30));
+    expect(screen.queryByText(/Couldn't update your favorites/)).toBeNull();
+  });
+
+  it("keeps trial A's button closed while A's write is still in flight", async () => {
+    // `useMutation` answers only for the LAST write submitted, so starting
+    // one for B made A's look settled. Reopen A and its button was live
+    // again with A's PATCH still on the wire — two writes in flight for one
+    // trial, applied in whatever order they arrive.
+    const api = fakeApi({ results: [trial(1), trial(7)] });
+    const state = fakeState({
+      overrides: { setRegistered: vi.fn(() => new Promise<void>(() => {})) },
+    });
+    renderTrialMatches(api, { state: state.adapter });
+
+    await openDetail(api, 0);
+    await userEvent.click(await screen.findByRole("button", { name: "I'm Interested" }));
+    await screen.findByRole("button", { name: "Saving…" });
+
+    await userEvent.click(screen.getByText("Back to all trials"));
+    await openDetail(api, 1);
+    await userEvent.click(await screen.findByRole("button", { name: "I'm Interested" }));
+    await screen.findByRole("button", { name: "Saving…" });
+
+    await userEvent.click(screen.getByText("Back to all trials"));
+    await openDetail(api, 0);
+    await screen.findByText("Trial 1");
+    // Still A's write, still unfinished.
+    const button = await screen.findByRole("button", { name: "Saving…" });
+    await userEvent.click(button);
+    expect(state.adapter.setRegistered).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not send two bookmark writes for one trial at once", async () => {
+    // The star now sends the opposite of what the patched cache says, so a
+    // second click while the first is on the wire carries the opposite
+    // value — and the server applies whichever arrives last.
+    const api = fakeApi();
+    const state = fakeState({
+      overrides: { setFavorite: vi.fn(() => new Promise<void>(() => {})) },
+    });
+    renderTrialMatches(api, { state: state.adapter });
+    await openDetail(api);
+
+    const star = await screen.findByRole("button", { name: "Add Trial 1 to favorites" });
+    await userEvent.click(star);
+    await waitFor(() => expect(star).toHaveAttribute("aria-busy", "true"));
+    await userEvent.click(star);
+    expect(state.adapter.setFavorite).toHaveBeenCalledTimes(1);
+  });
+
+  it("remembers a failed bookmark for the trial it happened on", async () => {
+    // A rejection that lands after the reader has moved on has no trial on
+    // screen to belong to, and reading the failure off the shared mutation
+    // meant the next click on any trial discarded it. Both end with a
+    // patient who was never told the write did not take.
+    const api = fakeApi({ results: [trial(1), trial(7)] });
+    const state = fakeState({
+      overrides: {
+        setFavorite: vi.fn(async () => {
+          throw new Error("nope");
+        }),
+      },
+    });
+    renderTrialMatches(api, { state: state.adapter });
+    await openDetail(api);
+
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Add Trial 1 to favorites" }),
+    );
+    await screen.findByText(/Couldn't update your favorites/);
+
+    // Not on the next trial…
+    await userEvent.click(screen.getByText("Back to all trials"));
+    await openDetail(api, 1);
+    await screen.findByText("Trial 7");
+    expect(screen.queryByText(/Couldn't update your favorites/)).toBeNull();
+
+    // …and still there on the one it happened on.
+    await userEvent.click(screen.getByText("Back to all trials"));
+    await openDetail(api, 0);
+    await screen.findByText(/Couldn't update your favorites/);
+  });
+
+  it("says on the list that a registration could not be saved", async () => {
+    // The reader may be back on the list by the time the PATCH is refused,
+    // and until now nothing there mentioned registrations at all — so the
+    // last thing they ever saw was "Saving…".
+    const api = fakeApi();
+    const state = fakeState({
+      overrides: {
+        setRegistered: vi.fn(async () => {
+          throw new Error("nope");
+        }),
+      },
+    });
+    renderTrialMatches(api, { state: state.adapter });
+    await openDetail(api);
+
+    await userEvent.click(await screen.findByRole("button", { name: "I'm Interested" }));
+    await screen.findByText(/Couldn't save that/);
+
+    await userEvent.click(screen.getByText("Back to all trials"));
+    await screen.findByText(/Couldn't save your interest in a trial/);
+  });
+
+  it("does not point at mismatches the table is not showing", async () => {
+    // `matchingType` is decided over every mapped attribute; the table is a
+    // filtered view that drops whole groups, blank values and select values
+    // absent from their own options. It can be empty — as it is here, which
+    // is the response the endpoint really returns — while the verdict is
+    // not_eligible. "The mismatches are marked above" then points at
+    // "No eligibility attributes to show for this trial."
+    const api = fakeApi();
+    api.setDetail({ matchingType: "not_eligible" });
+    renderTrialMatches(api, { state: fakeState().adapter });
+    await openDetail(api);
+
+    await screen.findByText(
+      /One or more of this trial's requirements does not match your profile\./,
+    );
+    expect(screen.queryByText(/marked above/)).toBeNull();
+  });
+
+  it("goes on saying the profile does not match after registering", async () => {
+    // CB #4669's point survives the click: the heading becomes a receipt,
+    // and the reason they may not be eligible must not disappear with it.
+    const api = fakeApi();
+    api.setDetail({ matchingType: "not_eligible" });
+    renderTrialMatches(api, { state: fakeState({ registered: ["1"] }).adapter });
+    await openDetail(api);
+
+    await screen.findByText(/You registered interest in this trial/);
+    await screen.findByText(
+      /One or more of this trial's requirements does not match your profile/,
+    );
+  });
+
+  it("does not claim the reader may be eligible when the matcher says otherwise", async () => {
+    // CB #4669, and the same field: unlike the list — where the queryset
+    // drops the not-eligibles before serializing — the detail endpoint
+    // scores the trial by id and really does answer not_eligible.
+    const api = fakeApi();
+    api.setDetail({ matchingType: "not_eligible", matchScore: 0 });
+    renderTrialMatches(api, { state: fakeState().adapter });
+    await openDetail(api);
+
+    await screen.findByText(/You may not meet this trial's eligibility criteria/);
+    // Still offered: CB lets someone register against a mismatch too.
+    await screen.findByRole("button", { name: "I'm Interested" });
+  });
+
+  it("promises nothing it does not do", async () => {
+    // CB's copy says a study coordinator will reach out. Here nothing is
+    // notified — registering writes a status and stops — so the card says
+    // so. This test exists to fail if CB's wording is ever pasted across.
+    const api = fakeApi();
+    renderTrialMatches(api, { state: fakeState().adapter });
+    await openDetail(api);
+
+    await screen.findByText(/Nothing is sent to the trial's coordinators/);
+    expect(screen.queryByText(/coordinator will reach out/i)).toBeNull();
   });
 });

--- a/frontend/src/federation/TrialMatches.tsx
+++ b/frontend/src/federation/TrialMatches.tsx
@@ -33,9 +33,22 @@ import {
   tabsFor,
   type TabValue,
 } from "./listChrome";
-import { useSetTrialState, useStateIds, useTrials } from "./hooks";
+import {
+  canReadAdvanced,
+  useAdvancedEnrollments,
+  useSetTrialState,
+  useStateIds,
+  useTrials,
+} from "./hooks";
 import { injectStyles } from "./injectStyles";
 import type { FilterState, TrialMatch, TrialMatchesProps } from "./types";
+
+type StateKind = "favorites" | "registered";
+/** Which trials have a write in flight, and which have one that failed. */
+interface WriteState {
+  pending: string[];
+  failed: string[];
+}
 
 function TrialMatchesInner({
   apiClient,
@@ -189,7 +202,95 @@ function TrialMatchesInner({
   const stateKey = `${personId ?? ""}|${patientInfoKey ?? ""}`;
   const favorites = useStateIds(state, "favorites", stateKey);
   const registered = useStateIds(state, "registered", stateKey);
+  // Not a display concern: this is what stops the register control being
+  // drawn for a trial whose enrollment a study team has already advanced,
+  // where "I'm Interested" would write `registered` over `entered`.
+  const advanced = useAdvancedEnrollments(state, stateKey);
   const setFavorite = useSetTrialState(state, "favorites", stateKey);
+  const setRegistered = useSetTrialState(state, "registered", stateKey);
+
+  // What each trial's writes are doing, remembered here rather than read
+  // off the mutation.
+  //
+  // One `useMutation` stands in for a per-trial operation, and it answers
+  // only for the LAST one submitted. Both of its flags were wrong for the
+  // same reason:
+  //
+  //   - `isError` answers "did the last write fail", not "did the write for
+  //     THIS trial fail". Filtering by `variables.trialId` addresses the
+  //     message to the right trial but does not make it durable: a rejection
+  //     that lands after the reader has moved on has no trial on screen to
+  //     belong to, and the next click on any trial discards it. Both cases
+  //     end with a patient who was shown "Saving…" and never told otherwise.
+  //
+  //   - `isPending` with the same filter goes FALSE for trial A as soon as a
+  //     write for trial B is submitted, because `variables` is B's. Reopen A
+  //     and its button is live again, with A's PATCH still on the wire —
+  //     the two-writes-in-flight race the guard exists to prevent.
+  //
+  // And it belongs to a PATIENT as much as to a trial. A host can swap
+  // `personId` or the inline payload at any moment, including while a write
+  // is on the wire; unkeyed, the previous patient's failure became this
+  // one's error message, and a trial id both have in common stayed busy.
+  //
+  // Two mechanisms, and they are not the same one twice: the record is
+  // DROPPED when the patient changes, and a callback that arrives after the
+  // change finds a key that no longer matches and writes nothing. Neither
+  // covers the other's case.
+  const [writes, setWrites] = useState<
+    { key: string } & Record<StateKind, WriteState>
+  >(() => ({
+    key: stateKey,
+    favorites: { pending: [], failed: [] },
+    registered: { pending: [], failed: [] },
+  }));
+  // Adjusted during render, like the tab fallback above, so the messages on
+  // screen belong to the patient on screen. An effect would paint one frame
+  // of the previous patient's failures first.
+  if (writes.key !== stateKey) {
+    setWrites({
+      key: stateKey,
+      favorites: { pending: [], failed: [] },
+      registered: { pending: [], failed: [] },
+    });
+  }
+  const mark = (
+    key: string,
+    kind: StateKind,
+    field: keyof WriteState,
+    trialId: string,
+    on: boolean,
+  ) =>
+    setWrites((prev) => {
+      if (prev.key !== key) return prev;
+      const list = prev[kind][field];
+      if (list.includes(trialId) === on) return prev;
+      return {
+        ...prev,
+        [kind]: {
+          ...prev[kind],
+          [field]: on ? [...list, trialId] : list.filter((id) => id !== trialId),
+        },
+      };
+    });
+  const write = (
+    kind: StateKind,
+    mutation: typeof setFavorite,
+    trialId: string,
+    on: boolean,
+  ) => {
+    if (writes[kind].pending.includes(trialId)) return;
+    const key = stateKey;
+    mark(key, kind, "pending", trialId, true);
+    mutation.mutate(
+      { trialId, on },
+      {
+        onError: () => mark(key, kind, "failed", trialId, true),
+        onSuccess: () => mark(key, kind, "failed", trialId, false),
+        onSettled: () => mark(key, kind, "pending", trialId, false),
+      },
+    );
+  };
 
   const stateCounts = {
     favorites: favorites.data?.length,
@@ -215,7 +316,11 @@ function TrialMatchesInner({
   // "Loading trials…" for ever, with the trials query disabled so even its
   // error branch could never speak.
   const waitingForIds = stateTab != null && stateIdsQuery.isPending;
-  const idsFailed = stateTab != null && stateIdsQuery.isError;
+  // `data === undefined` too: a failed REFETCH keeps the ids it had, and
+  // narrowing by slightly stale bookmarks beats blanking the tab and saying
+  // it could not be loaded when it could.
+  const idsFailed =
+    stateTab != null && stateIdsQuery.isError && stateIdsQuery.data === undefined;
   // Mutually exclusive by construction: a query that has rejected is no
   // longer pending. Guarding the loading line with `!idsFailed` as well
   // would be a second mechanism for the same thing, and would make the
@@ -380,12 +485,57 @@ function TrialMatchesInner({
   // `onBack` calls history.back() so the synthetic entry is consumed and
   // the popstate listener above fires setSelectedTrial(null).
   if (selectedTrial) {
+    const selectedId = String(selectedTrial.trialId);
     return (
       <TrialDetailPage
         apiClient={apiClient}
         trialId={selectedTrial.trialId}
         patientInfo={patientInfo}
         personId={personId}
+        // Values and callbacks, not the adapter: this component owns the id
+        // lists and the mutations, so it is the only place that can keep the
+        // star on the card and the star on the detail page saying the same
+        // thing. `undefined` where the answer is not known — the control is
+        // then not drawn at all, rather than drawn wrong for a moment.
+        trialState={
+          state
+            ? {
+                isFavorite: favorites.data
+                  ? favorites.data.includes(selectedId)
+                  : undefined,
+                favoriteBusy: writes.favorites.pending.includes(selectedId),
+                onToggleFavorite: (on) =>
+                  write("favorites", setFavorite, selectedId, on),
+                favoriteFailed: writes.favorites.failed.includes(selectedId),
+                // `data === undefined` too: a query that has errored KEEPS
+                // the data it had, so after a failed background refetch this
+                // was true while the star was still being drawn from the
+                // retained ids — an "unavailable" notice printed underneath
+                // a control that is present and works.
+                favoritesUnavailable: favorites.isError && favorites.data === undefined,
+                isRegistered:
+                  registered.data && advanced.data
+                    ? registered.data.includes(selectedId)
+                    : undefined,
+                onToggleRegistered: (on) =>
+                  write("registered", setRegistered, selectedId, on),
+                // Pending IS read off the mutation, and is scoped the same
+                // way: it describes a write in flight, which there can only
+                // be one of, and it must not disable a different trial's
+                // button.
+                registerPending: writes.registered.pending.includes(selectedId),
+                registerFailed: writes.registered.failed.includes(selectedId),
+                registeredUnavailable:
+                  (registered.isError && registered.data === undefined) ||
+                  (advanced.isError && advanced.data === undefined) ||
+                  !canReadAdvanced(state),
+                // Absent until the read answers: drawn against an unknown
+                // answer, the control is exactly the one that overwrites an
+                // advanced status.
+                advancedStatus: advanced.data?.[selectedId],
+              }
+            : undefined
+        }
         // The derived set, not raw state: the detail is scored under the
         // preferences the list used, and `country` no longer lives in
         // `filters`. Passing raw state sent the detail request without the
@@ -467,19 +617,33 @@ function TrialMatchesInner({
           that read fails every star vanishes — on EVERY tab, not just the
           Favorites one, and with nothing on screen to say why. The reader
           would conclude the feature had been removed. */}
-      {favorites.isError && !idsFailed ? (
+      {favorites.isError && favorites.data === undefined && !idsFailed ? (
         <p style={{ color: "var(--exact-color-not-eligible)" }}>
           Couldn't load your favorites, so bookmarking is unavailable right
           now.
         </p>
       ) : null}
 
-      {/* (4) A write that failed has to say so. The star is painted from
-          the server's list, so a rejected PATCH leaves it exactly where it
-          was — indistinguishable from a click that never registered. */}
-      {setFavorite.isError ? (
+      {/* A write that failed has to say so. The star is painted from the
+          server's list, so a rejected PATCH leaves it exactly where it was —
+          indistinguishable from a click that never registered.
+
+          From the recorded failures, not from the mutation: a registration
+          that rejects after the reader has gone back to the list had no
+          surface here at all, so the only thing they ever saw was
+          "Saving…". */}
+      {writes.favorites.failed.length ? (
         <p style={{ color: "var(--exact-color-not-eligible)" }} role="alert">
           Couldn't update your favorites. Please try again.
+        </p>
+      ) : null}
+
+      {writes.registered.failed.length ? (
+        <p style={{ color: "var(--exact-color-not-eligible)" }} role="alert">
+          Couldn't save your interest in {writes.registered.failed.length === 1
+            ? "a trial"
+            : `${writes.registered.failed.length} trials`}
+          . Open the trial to try again.
         </p>
       ) : null}
 
@@ -516,9 +680,10 @@ function TrialMatchesInner({
             isFavorite={
               favorites.data ? favorites.data.includes(String(t.trialId)) : undefined
             }
+            busy={writes.favorites.pending.includes(String(t.trialId))}
             onToggleFavorite={
               state
-                ? (on) => setFavorite.mutate({ trialId: String(t.trialId), on })
+                ? (on) => write("favorites", setFavorite, String(t.trialId), on)
                 : undefined
             }
           />

--- a/frontend/src/federation/bits.tsx
+++ b/frontend/src/federation/bits.tsx
@@ -182,3 +182,61 @@ export const EyeIcon = () => (
     <circle cx="12" cy="12" r="3" />
   </svg>
 );
+
+/** The bookmark toggle, drawn identically on a card and on the detail page.
+ *
+ *  One component rather than the same JSX twice, because the interesting
+ *  part is not the star but the rule about when it may be drawn at all:
+ *  only with somewhere to write (`onToggle`) AND a known answer
+ *  (`isFavorite !== undefined`). An unknown answer renders nothing rather
+ *  than an empty star that would fill in under the reader's eye a moment
+ *  later — and "unknown" covers the read having failed, not just being slow.
+ *
+ *  Written twice, the two copies drift: the card had the rule and the detail
+ *  page, added later, would have had a star that flickered.
+ */
+export function FavoriteToggle({
+  title,
+  isFavorite,
+  onToggle,
+  busy,
+}: {
+  /** The trial's title, for the accessible name — "Add <title> to
+   *  favorites" reads usefully in a list of several. */
+  title: string;
+  isFavorite?: boolean;
+  onToggle?: (next: boolean) => void;
+  /** A write for this trial is on the wire — announced, not enforced.
+   *
+   *  Dropping the second click is the caller's job and happens in exactly
+   *  one place (`TrialMatches`'s `write`), because every path to a write
+   *  goes through it and a control that enforced it too would be the same
+   *  rule written twice: a mutation test showed each copy keeping the other
+   *  one's test green.
+   *
+   *  `aria-disabled` rather than `disabled` so the control is not blurred
+   *  out from under a keyboard user mid-action. */
+  busy?: boolean;
+}) {
+  if (!onToggle || isFavorite === undefined) return null;
+  return (
+    <button
+      type="button"
+      className={`exact-fav${isFavorite ? " is-on" : ""}`}
+      aria-pressed={isFavorite}
+      aria-disabled={busy || undefined}
+      aria-busy={busy || undefined}
+      aria-label={
+        isFavorite ? `Remove ${title} from favorites` : `Add ${title} to favorites`
+      }
+      onClick={(e) => {
+        // The card is itself a click target; without this, bookmarking would
+        // also open the trial. Harmless where nothing is listening.
+        e.stopPropagation();
+        onToggle(!isFavorite);
+      }}
+    >
+      {isFavorite ? "★" : "☆"}
+    </button>
+  );
+}

--- a/frontend/src/federation/exact.css
+++ b/frontend/src/federation/exact.css
@@ -263,6 +263,15 @@
 .exact-root .exact-detail__back:hover {
   text-decoration: underline;
 }
+/* Title and bookmark on one line, as CB puts its title and actions. The
+   star keeps its own baseline — `align-items: start` rather than center, so
+   a title that wraps to three lines does not drag the star to the middle. */
+.exact-root .exact-detail__head {
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
 .exact-root .exact-detail__title {
   margin: 0 0 0.75rem;
   font-size: 1.25rem;
@@ -385,6 +394,11 @@
 .exact-root .exact-elig__check {
   display: inline-flex;
   color: var(--exact-color-success-700);
+}
+
+.exact-root .exact-elig__mismatch {
+  display: inline-flex;
+  color: var(--exact-color-not-eligible);
 }
 .exact-root .exact-elig__units {
   font-size: 0.75rem;
@@ -908,4 +922,88 @@
   outline: 2px solid var(--exact-color-primary);
   outline-offset: 1px;
   border-radius: 0.25rem;
+}
+
+/* ---------------------------------------------------------------------------
+ * Register interest — CB's `RegisterInterestCard`, minus the promise that a
+ * coordinator will be in touch (nothing here notifies anyone).
+ * ------------------------------------------------------------------------- */
+.exact-root .exact-register {
+  margin-top: 1rem;
+  border-color: var(--exact-color-success-200);
+  background: var(--exact-color-success-50);
+}
+
+.exact-root .exact-register__text {
+  margin: 0.5rem 0 0.75rem;
+  color: var(--exact-color-text-muted);
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+}
+
+.exact-root .exact-register__btn {
+  padding: 0.625rem 0.875rem;
+  border: 2px solid rgba(255, 255, 255, 0.12);
+  border-radius: 0.5rem;
+  background: var(--exact-color-brand-green);
+  box-shadow: var(--exact-shadow-card);
+  color: var(--exact-color-on-brand);
+  font: inherit;
+  font-weight: 600;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  cursor: pointer;
+  transition: background-color 0.15s ease;
+}
+
+.exact-root .exact-register__btn:hover:not([aria-disabled="true"]) {
+  background: var(--exact-color-brand-green-hover);
+}
+
+/* Withdraw is not the same act as registering and must not wear the same
+   green CTA: the reader is looking for the way out of something, not for
+   the way into it. */
+.exact-root .exact-register__btn.is-on {
+  border-color: var(--exact-color-border);
+  background: var(--exact-color-surface);
+  box-shadow: var(--exact-shadow-sm);
+  color: var(--exact-color-text-muted);
+}
+
+.exact-root .exact-register__btn.is-on:hover:not([aria-disabled="true"]) {
+  background: var(--exact-color-surface);
+  color: var(--exact-color-text);
+}
+
+/* `aria-disabled`, not `:disabled` — the button keeps focus while the write
+   is on the wire (see TrialDetailPage), so the styling has to follow the
+   attribute that is actually set. */
+.exact-root .exact-register__btn[aria-disabled="true"] {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.exact-root .exact-register__btn:focus-visible {
+  outline: 2px solid var(--exact-color-primary);
+  outline-offset: 2px;
+}
+
+/* A warning must not arrive in the same success green as an invitation:
+   "You may not meet this trial's eligibility criteria" was painted exactly
+   like "Interested in this trial?". And once the answer is recorded the
+   panel is neither — it is a receipt. */
+.exact-root .exact-register.is-warning {
+  border-color: var(--exact-color-warning-200);
+  background: var(--exact-color-warning-50);
+}
+
+.exact-root .exact-register.is-registered {
+  border-color: var(--exact-color-border);
+  background: var(--exact-color-surface);
+}
+
+.exact-root .exact-register__error {
+  margin: 0.5rem 0 0;
+  color: var(--exact-color-not-eligible);
+  font-size: 0.875rem;
 }

--- a/frontend/src/federation/hooks.ts
+++ b/frontend/src/federation/hooks.ts
@@ -12,7 +12,7 @@ import type { AxiosInstance } from "axios";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 
 import { fetchFormSettings, fetchTrialDetail, fetchTrials } from "./api";
-import type { TrialId, TrialStateAdapter } from "./state";
+import type { AdvancedStatus, TrialId, TrialStateAdapter } from "./state";
 import type {
   FilterState,
   PatientInfo,
@@ -48,11 +48,27 @@ export function useStateIds(
 
 /** Toggle one trial's bookmark or registration.
  *
- *  Invalidates the id lists rather than patching them by hand: the lists
- *  drive a tab count and a tab's contents, and a hand-patched cache that
- *  drifts from the server shows a Favorites tab that disagrees with the
- *  bookmark on the card. The trial list itself is invalidated too, because
- *  on the Favorites tab the row set IS the id list.
+ *  Applies the change to the cached id list AND invalidates it. Both,
+ *  because each alone is wrong in its own way.
+ *
+ *  Invalidating alone leaves a window where the write has succeeded and the
+ *  list has not been re-read yet, and every control is painted from that
+ *  list: the reader saw "Saving…" turn back into "I'm Interested", which
+ *  reads as "it didn't take" and invites the second click the pending guard
+ *  exists to prevent. Holding the mutation open until the re-read returns
+ *  closes the window but pays for it with the whole round trip — with the
+ *  host's default retries, up to some seven seconds of a disabled button
+ *  after the write already succeeded, and a failed re-read then leaves the
+ *  control contradicting the record anyway.
+ *
+ *  Patching alone is the bug the first version of this comment warned
+ *  about: a cache that drifts from the server shows a Favorites tab that
+ *  disagrees with the star on the card. So the patch answers immediately
+ *  and the invalidation reconciles a round trip later; drift is bounded to
+ *  that round trip rather than lasting until something else refetches.
+ *
+ *  The trial list is invalidated too: on the Favorites tab the row set IS
+ *  the id list.
  */
 export function useSetTrialState(
   state: TrialStateAdapter | undefined,
@@ -65,10 +81,48 @@ export function useSetTrialState(
       kind === "favorites"
         ? state!.setFavorite(trialId, on)
         : state!.setRegistered(trialId, on),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["exact-state-ids", kind, key] });
+    onSuccess: (_result, { trialId, on }) => {
+      const idsKey = ["exact-state-ids", kind, key];
+      // Only an existing list is patched. With nothing cached there is
+      // nothing to be consistent with, and the invalidation below will
+      // fetch the truth.
+      queryClient.setQueryData<TrialId[]>(idsKey, (previous) => {
+        if (previous == null) return previous;
+        if (!on) return previous.filter((id) => id !== trialId);
+        return previous.includes(trialId) ? previous : [...previous, trialId];
+      });
+      queryClient.invalidateQueries({ queryKey: idsKey });
       queryClient.invalidateQueries({ queryKey: ["exact-trials"] });
     },
+  });
+}
+
+/** Whether an adapter can answer the advanced-status question at all.
+ *
+ *  The method is required by the interface, but the interface is a
+ *  compile-time contract and a host may be plain JavaScript — or an older
+ *  build of one. Missing, calling it throws a TypeError inside the query,
+ *  which is a confusing route to the right outcome; checked, the outcome is
+ *  the same and it is deliberate. Either way the register control is
+ *  withheld, because it is the control that would overwrite the status this
+ *  answers about. */
+export function canReadAdvanced(state?: TrialStateAdapter): boolean {
+  return typeof state?.listAdvancedEnrollments === "function";
+}
+
+/** The trials a study team has already moved past "registered".
+ *
+ *  Read on the same key as the id lists, and for the same reason: it
+ *  decides whether a control that WRITES is drawn at all. */
+export function useAdvancedEnrollments(
+  state: TrialStateAdapter | undefined,
+  key: string,
+): UseQueryResult<Record<TrialId, AdvancedStatus>> {
+  return useQuery({
+    queryKey: ["exact-state-advanced", key],
+    queryFn: () => state!.listAdvancedEnrollments(),
+    enabled: state != null && canReadAdvanced(state),
+    staleTime: 30_000,
   });
 }
 

--- a/frontend/src/federation/state.test.ts
+++ b/frontend/src/federation/state.test.ts
@@ -40,6 +40,43 @@ describe("reading the ids", () => {
   });
 });
 
+describe("the statuses a patient must not overwrite", () => {
+  const clientFor = (byStatus: Record<string, string[]>) => {
+    const get = vi.fn((_url: string, config?: { params?: Record<string, string> }) =>
+      Promise.resolve({
+        data: { trial_ids: byStatus[config?.params?.status ?? ""] ?? [], count: 0 },
+      }),
+    );
+    return { get } as unknown as AxiosInstance & { get: ReturnType<typeof vi.fn> };
+  };
+
+  it("asks for entered and completed separately, because ?status= takes one", async () => {
+    const client = clientFor({ entered: ["1"], completed: ["2"] });
+    const map = await adapter(client).listAdvancedEnrollments();
+    expect(map).toEqual({ "1": "entered", "2": "completed" });
+    expect(client.get.mock.calls.map((c) => c[1].params.status).sort()).toEqual([
+      "completed",
+      "entered",
+    ]);
+  });
+
+  it("keeps the two apart", async () => {
+    // They are not interchangeable on screen: one says the patient is
+    // taking part, the other that they took part.
+    const client = clientFor({ entered: [], completed: ["7"] });
+    expect(await adapter(client).listAdvancedEnrollments()).toEqual({
+      "7": "completed",
+    });
+  });
+
+  it("is empty when the patient has no advanced enrollment", async () => {
+    // `{}` and not a rejection: this decides whether a WRITING control is
+    // drawn, and "no advanced rows" is a real answer, not a failure.
+    const client = clientFor({});
+    expect(await adapter(client).listAdvancedEnrollments()).toEqual({});
+  });
+});
+
 describe("writing", () => {
   it("bookmarks through the upsert, which creates the row if needed", async () => {
     // A patient may bookmark a trial they were never enrolled in, and the

--- a/frontend/src/federation/state.ts
+++ b/frontend/src/federation/state.ts
@@ -29,6 +29,10 @@ export type TrialId = string;
  */
 export const MAX_TRIAL_IDS = 500;
 
+/** The enrollment statuses a patient must not be able to overwrite from
+ *  here. Set by a study team, not by the patient. */
+export type AdvancedStatus = "entered" | "completed";
+
 export interface TrialStateAdapter {
   /** The patient's bookmarked trial ids. */
   listFavoriteIds(): Promise<TrialId[]>;
@@ -38,6 +42,16 @@ export interface TrialStateAdapter {
   listRegisteredIds(): Promise<TrialId[]>;
   /** Register (or withdraw) interest in one trial. */
   setRegistered(trialId: TrialId, registered: boolean): Promise<void>;
+  /** The trials whose enrollment a study team has already moved past
+   *  "registered", by status.
+   *
+   *  Required, not optional, because what depends on it is not a nicety:
+   *  `listRegisteredIds` asks for `status=registered` exactly, so a patient
+   *  a coordinator has advanced to `entered` reads back as NOT registered —
+   *  and a control that then offers "I'm Interested" writes `registered`
+   *  over the advanced status when clicked. An adapter that cannot answer
+   *  this cannot safely be given the register control. */
+  listAdvancedEnrollments(): Promise<Record<TrialId, AdvancedStatus>>;
   /** The patient's saved search filters, or `{}` when they have none. */
   getPreferences(): Promise<FilterState>;
   /** Store the filters. */
@@ -98,6 +112,21 @@ export function createPromopState({
     // states is a product question, filed as EXACT #434; answering it also
     // needs PROMOP's `?status=` to accept more than one value.
     listRegisteredIds: () => ids({ status: "registered" }),
+    // Two requests because `?status=` takes one value. Ids only, like the
+    // others — the status is the map's value, so the UI can say which of
+    // the two it is rather than guessing.
+    listAdvancedEnrollments: async () => {
+      const [entered, completed] = await Promise.all([
+        ids({ status: "entered" }),
+        ids({ status: "completed" }),
+      ]);
+      const out: Record<TrialId, AdvancedStatus> = {};
+      for (const id of entered) out[id] = "entered";
+      // Completed last: a row can only be one status, but if the two reads
+      // straddle a change, the later state is the better answer.
+      for (const id of completed) out[id] = "completed";
+      return out;
+    },
     // Withdrawing is a status of its own rather than a deletion: the row is
     // the record that the patient was once interested, and PROMOP's enum
     // has `withdrawn` precisely so that fact survives.

--- a/frontend/src/federation/types.ts
+++ b/frontend/src/federation/types.ts
@@ -144,6 +144,12 @@ export interface TrialDetailResponse {
   participationCriteria?: string | null;
   matchScore: number | null;
   goodnessScore: number | null;
+  /** The verdict for THIS patient. Unlike the list — where the queryset drops
+   *  the not-eligibles before serializing — the detail endpoint returns the
+   *  trial by id without that filter and scores it with the conflict-aware
+   *  Python matcher, so `not_eligible` really does arrive here
+   *  (`TrialDetailSerializer.to_representation`). `null` without a patient. */
+  matchingType?: MatchingType | null;
   details: Record<string, TrialDetailField[]>;
   groupNames: GroupName[];
   [key: string]: unknown;

--- a/frontend/src/test/renderTrialMatches.tsx
+++ b/frontend/src/test/renderTrialMatches.tsx
@@ -12,9 +12,11 @@ import type { AxiosInstance } from "axios";
 import { vi } from "vitest";
 
 import { TrialMatches } from "../federation/TrialMatches";
+import type { AdvancedStatus, TrialStateAdapter } from "../federation/state";
 import type {
   FilterState,
   PatientInfo,
+  TrialDetailResponse,
   TrialMatch,
   TrialsResponse,
 } from "../federation/types";
@@ -35,11 +37,17 @@ export interface FakeApi {
   listRequests: () => RecordedRequest[];
   /** Requests for one trial's detail. */
   detailRequests: () => RecordedRequest[];
-  /** Make the next list response a 404, as DRF's paginator does for a page
-   *  past the end. */
+  /** Make the next response — whichever request arrives first, list or
+   *  detail — fail with this status. DRF's paginator answers a page past
+   *  the end with a 404, which is the case most tests here arm it for. */
   failNextWith: (status: number) => void;
   /** Replace what the list returns from now on. */
   setResponse: (response: Partial<TrialsResponse>) => void;
+  /** Override fields on every trial's detail response from now on.
+   *  Whatever is NOT overridden follows the trial actually asked for — so
+   *  the id and title track the row that was clicked unless a test pins
+   *  them deliberately. */
+  setDetail: (detail: Partial<TrialDetailResponse>) => void;
 }
 
 export function trial(id: number, overrides: Partial<TrialMatch> = {}): TrialMatch {
@@ -73,6 +81,31 @@ export function trial(id: number, overrides: Partial<TrialMatch> = {}): TrialMat
   };
 }
 
+/** A detail response, as `GET /trials/{id}/` returns it.
+ *
+ *  The fake used to answer a detail request with the LIST payload, which has
+ *  no `briefTitle` and no `details` — so the detail page rendered blank and
+ *  any test about what it shows would have been asserting against an empty
+ *  document. */
+export function trialDetail(
+  id: number,
+  overrides: Partial<TrialDetailResponse> = {},
+): TrialDetailResponse {
+  return {
+    trialId: id,
+    studyId: `NCT${id}`,
+    briefTitle: `Trial ${id}`,
+    officialTitle: `Trial ${id}`,
+    laySummary: "A summary.",
+    matchScore: 90,
+    goodnessScore: 80,
+    matchingType: "eligible",
+    details: { trialEligibilityAttributes: [] },
+    groupNames: [],
+    ...overrides,
+  };
+}
+
 const FORM_SETTINGS = {
   trialPurpose: { options: [{ value: "", label: "ALL" }, { value: "treatment", label: "Treatment" }] },
   trialType: {
@@ -100,6 +133,7 @@ export function fakeApi(initial: Partial<TrialsResponse> = {}): FakeApi {
     ...initial,
   };
   let failWith: number | null = null;
+  let detailOverrides: Partial<TrialDetailResponse> = {};
 
   const respond = (url: string, body?: unknown) => {
     if (url.includes("form-settings")) return Promise.resolve({ data: FORM_SETTINGS });
@@ -111,6 +145,15 @@ export function fakeApi(initial: Partial<TrialsResponse> = {}): FakeApi {
           response: { status },
         }),
       );
+    }
+    // A single trial, not the list: `/trials/7/` and `/trials/7/match/`.
+    // Answered FOR THE ID ASKED FOR — one id-blind object would render
+    // "Trial 1" whichever row was clicked, so a page that fetched or showed
+    // the wrong trial would look right.
+    const detailMatch = /^\/trials\/(\d+)\//.exec(url);
+    if (detailMatch) {
+      const id = Number(detailMatch[1]);
+      return Promise.resolve({ data: { ...trialDetail(id), ...detailOverrides } });
     }
     // Honour `trial_ids` the way the server does. Returning the same rows
     // for a narrowed request makes the fake agree with any implementation,
@@ -159,7 +202,68 @@ export function fakeApi(initial: Partial<TrialsResponse> = {}): FakeApi {
     setResponse: (next: Partial<TrialsResponse>) => {
       response = { ...response, ...next };
     },
+    setDetail: (next: Partial<TrialDetailResponse>) => {
+      detailOverrides = { ...detailOverrides, ...next };
+    },
   };
+}
+
+export interface FakeState {
+  adapter: TrialStateAdapter;
+  /** The stored ids, readable after a write. They are the SAME arrays the
+   *  reads return, so a test can assert that a write actually landed rather
+   *  than only that a spy was called. */
+  favorites: string[];
+  registered: string[];
+  /** Reads, counted. A write is supposed to invalidate the list it changed,
+   *  and the only externally visible sign of that is a re-read. */
+  reads: { favorites: number; registered: number };
+}
+
+/** A working adapter, backed by two arrays.
+ *
+ *  Typed as `TrialStateAdapter` rather than cast to `never` at the call
+ *  site: the tests that went through `as never` would have kept compiling
+ *  if a method were renamed, which is exactly the change that should break
+ *  them. */
+export function fakeState(
+  initial: {
+    favorites?: string[];
+    registered?: string[];
+    /** Trials a study team has moved past "registered". */
+    advanced?: Record<string, AdvancedStatus>;
+    overrides?: Partial<TrialStateAdapter>;
+  } = {},
+): FakeState {
+  const favorites = [...(initial.favorites ?? [])];
+  const registered = [...(initial.registered ?? [])];
+  const reads = { favorites: 0, registered: 0 };
+
+  const set = (list: string[], id: string, on: boolean) => {
+    const at = list.indexOf(id);
+    if (on && at === -1) list.push(id);
+    if (!on && at !== -1) list.splice(at, 1);
+  };
+
+  const adapter: TrialStateAdapter = {
+    listFavoriteIds: vi.fn(async () => {
+      reads.favorites += 1;
+      return [...favorites];
+    }),
+    listRegisteredIds: vi.fn(async () => {
+      reads.registered += 1;
+      return [...registered];
+    }),
+    setFavorite: vi.fn(async (id: string, on: boolean) => set(favorites, id, on)),
+    setRegistered: vi.fn(async (id: string, on: boolean) => set(registered, id, on)),
+    listAdvancedEnrollments: vi.fn(async () => ({ ...(initial.advanced ?? {}) })),
+    getPreferences: vi.fn(async () => ({})),
+    savePreferences: vi.fn(async () => undefined),
+    resetPreferences: vi.fn(async () => undefined),
+    ...initial.overrides,
+  };
+
+  return { adapter, favorites, registered, reads };
 }
 
 export function renderTrialMatches(
@@ -171,6 +275,7 @@ export function renderTrialMatches(
     // checking for every test, so a typo'd filter name compiled and the
     // test asserted nothing.
     initialFilters?: FilterState;
+    state?: TrialStateAdapter;
   } = {},
 ): RenderResult {
   const queryClient = new QueryClient({
@@ -195,6 +300,7 @@ export function renderTrialMatches(
         }
         personId={props.personId}
         initialFilters={props.initialFilters}
+        state={props.state}
       />
     </QueryClientProvider>,
   );


### PR DESCRIPTION
Stacked on #435 (base is `feat/phase2-state-adapter`, so review that one first; this diff is only the detail-page delta). Closes out the phase-2 UI in `docs/federated-ui-parity-plan.md` apart from persisting the filter panel.

The bookmark and CB's "I'm Interested", on the in-remote detail page. Both write through the `state` adapter; the page never sees the adapter itself — `TrialMatches` owns the id lists and the mutations, so it is the only place that can keep the star on the card and the star on the detail page saying the same thing.

**Registering writes a status and nothing else** — no mail, no queue, nobody notified, as decided. So CB's copy ("a study coordinator will reach out to discuss next steps") could not come across; the card says what the click does and what it does not: *Nothing is sent to the trial's coordinators from here.* A test asserts that sentence is present and CB's is absent, because wording like that gets pasted back in.

## The findings, and what each one was

Two fresh-context reviews and five `codex review` passes. Every round found something the code looked finished without.

**One `useMutation` is not a per-trial operation.** It answers only for the last write submitted, which was wrong three different ways: `isError` printed trial 1's failure inside trial 2's card (which names a trial, so it reads as a statement about that one); `isPending` went false for trial A the moment a write for B was submitted, so reopening A offered a live button with A's PATCH still on the wire; and the star had no pending state at all. The component now keeps `{pending, failed}` trial ids per kind, and `write()` is the single place a click becomes a PATCH. The controls *announce* that with `aria-disabled`/`aria-busy` and do not also enforce it — written twice, each copy kept the other's test passing under mutation.

**And that record belongs to a patient too.** Same shape as the cache-key bug in #435: a host can swap `personId` mid-write, and unkeyed, the previous patient's failure became this one's message. Dropped when the patient changes *and* keyed so a late callback writes nothing — two mechanisms because neither covers the other's case, each pinned by its own test.

**A control that writes cannot use a read that narrows.** `listRegisteredIds` asks for `status=registered` exactly. As a display question that was #434 — a trial dropping off the Registered tab once a coordinator advanced it to `entered`. A *button* makes it a data-integrity one: such a patient reads back as not registered, the card offers "I'm Interested", and the click writes `registered` over the study team's status. The adapter gained `listAdvancedEnrollments()`, and for an `entered`/`completed` trial the card is a statement rather than a control. PROMOP should refuse the regressing write server-side as well — commented on #434.

**A write answers immediately, and reconciles.** Invalidating alone left a window where the write had succeeded and the list had not been re-read, and every control is painted from that list: "Saving…" turned back into "I'm Interested", which reads as "it didn't take". Holding the mutation open until the re-read returns closes it but pays the whole round trip — with the host's default retries, seconds of a disabled button after the write already succeeded. So: patch the cache, then invalidate. Related, a query that errors *keeps its data*, so `isError` alone printed "unavailable" underneath controls that were rendered and working; all three read-failure surfaces now also require `data === undefined`.

**Copy that was not true.** "The mismatches are marked above" pointed, reachably, at "No eligibility attributes to show for this trial" — `matchingType` is decided over every mapped attribute while the table is a filtered view that can be empty. And the mismatches were marked in red and nowhere else, so for a reader not seeing colour the sentence promised something the page did not provide. Both fixed; the marker sits after the units, where the tick does — before them it split the value from its unit, read out as "12, does not match, years".

Also: the ineligibility warning used to disappear once registered (CB #4669's point holds at the moment it matters most) and arrived in the same success green as the invitation.

## Two review findings not adopted, with reasons

- **`role="alert"` is conditionally mounted**, unlike the always-mounted `role="status"` region on the list. Alerts are announced on insertion; the rule that region documents is about `status`, which is not.
- **`listAdvancedEnrollments` stays required on the interface.** Codex asked for it optional so hosts can upgrade independently — its premise is that TypeScript hosts already implement `TrialStateAdapter`, and none do: the interface ships in #435, which is not merged. A host that has not implemented the method cannot safely be given a control that overwrites the status it answers about, and compile time is the right moment to learn that. The runtime guard (`canReadAdvanced`) exists for plain-JavaScript hosts, not as an endorsement of omitting it: the control is withheld and the page says so.

## Tests

174, `tsc -b --force` clean, app and remote builds green. **41 mutations, all caught** — including "invalidate favorites regardless of kind", "withdraw sends registered", "the star can only add", "ignore the advanced status", "the record is not dropped on patient change", and "a late callback is not rejected".

The harness gained a detail response that answers *for the id asked for* (an id-blind object renders "Trial 1" whichever row is clicked, so a page fetching or showing the wrong trial would look right) and a fake adapter backed by real arrays, replacing three near-identical copies in the test file. Two existing assertions were tightened on the way: the card's bookmark test had lost its call count, and nothing in the suite ever un-bookmarked — a star hard-wired to `true`, on both surfaces, passed everything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015G5YkuAcDZQUTutNEBGwyX