### PR TITLE
feat(federation): saved search filters, and the queue that keeps them in order

### DIFF
--- a/frontend/src/federation/TrialMatches.test.tsx
+++ b/frontend/src/federation/TrialMatches.test.tsx
@@ -1684,3 +1684,398 @@ describe("the controls on the detail page", () => {
     expect(screen.queryByText(/coordinator will reach out/i)).toBeNull();
   });
 });
+
+describe("saved filters", () => {
+  const adapter = (saved: Record<string, unknown> = {}) => ({
+    listFavoriteIds: vi.fn(async () => []),
+    listRegisteredIds: vi.fn(async () => []),
+    listAdvancedEnrollments: vi.fn(async () => ({})),
+    setFavorite: vi.fn(async () => undefined),
+    setRegistered: vi.fn(async () => undefined),
+    getPreferences: vi.fn(async () => saved),
+    // Typed argument so the assertion below can read what was saved.
+    savePreferences: vi.fn(async (_filters: Record<string, unknown>) => undefined),
+    resetPreferences: vi.fn(async () => undefined),
+  });
+
+  const renderIt = (api: ReturnType<typeof fakeApi>, state?: unknown) => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, refetchOnWindowFocus: false } },
+    });
+    return render(
+      <QueryClientProvider client={queryClient}>
+        <TrialMatches
+          apiClient={api.client}
+          queryClient={queryClient}
+          patientInfo={{ disease: "multiple myeloma" }}
+          state={state as never}
+        />
+      </QueryClientProvider>,
+    );
+  };
+
+  it("applies what the reader saved last time", async () => {
+    const api = fakeApi();
+    renderIt(api, adapter({ searchTitle: "daratumumab" }));
+
+    // The badge counts filters that differ from the baseline, so it is the
+    // visible proof the saved set was applied rather than ignored.
+    await screen.findByRole("button", { name: /Filters \(1\)/ });
+  });
+
+  it("does not let an empty saved set clobber the seeded baseline", async () => {
+    const api = fakeApi();
+    renderIt(api, adapter({}));
+    await waitFor(() => expect(listed(api).length).toBeGreaterThan(0));
+    // No saved opinion means the baseline stands, so nothing counts as active.
+    expect(
+      screen.queryByRole("button", { name: /Filters \(\d+\)/ }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("persists an edit through the adapter", async () => {
+    const api = fakeApi();
+    const state = adapter();
+    renderIt(api, state);
+    await waitFor(() => expect(listed(api).length).toBeGreaterThan(0));
+
+    await userEvent.click(screen.getByRole("button", { name: /Filter Results|Filters \(/ }));
+    await userEvent.type(
+      await screen.findByLabelText("Title"),
+      "myeloma",
+    );
+
+    await waitFor(() => expect(state.savePreferences).toHaveBeenCalled());
+    const last = state.savePreferences.mock.calls.at(-1)?.[0];
+    expect(last?.searchTitle).toBe("myeloma");
+  });
+
+  it("resets through resetPreferences, not by saving the baseline", async () => {
+    // The server merges a partial update, so writing the baseline would leave
+    // whatever was saved for keys the baseline does not mention.
+    const api = fakeApi();
+    const state = adapter({ searchTitle: "daratumumab" });
+    renderIt(api, state);
+    await screen.findByRole("button", { name: /Filters \(1\)/ });
+
+    await userEvent.click(screen.getByRole("button", { name: /Filter Results|Filters \(/ }));
+    await userEvent.click(await screen.findByRole("button", { name: /Reset/ }));
+
+    await waitFor(() => expect(state.resetPreferences).toHaveBeenCalled());
+  });
+
+  it("does not send one patient's edit to the next patient's adapter", async () => {
+    // The writer debounces, so a host switching patients inside that window
+    // runs the old writer's flush during cleanup — after the prop has already
+    // changed. Reading the adapter at flush time would write filters edited
+    // for patient A into patient B's saved preferences.
+    const api = fakeApi();
+    const first = adapter();
+    const second = adapter();
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, refetchOnWindowFocus: false } },
+    });
+    const ui = (personId: string, state: unknown) => (
+      <QueryClientProvider client={queryClient}>
+        <TrialMatches
+          apiClient={api.client}
+          queryClient={queryClient}
+          personId={personId}
+          state={state as never}
+        />
+      </QueryClientProvider>
+    );
+
+    const view = render(ui("p1", first));
+    await waitFor(() => expect(listed(api).length).toBeGreaterThan(0));
+    await userEvent.click(
+      screen.getByRole("button", { name: /Filter Results|Filters \(/ }),
+    );
+    await userEvent.type(await screen.findByLabelText("Title"), "vrd");
+
+    // Switch patients immediately, inside the debounce window.
+    view.rerender(ui("p2", second));
+
+    await waitFor(() => expect(first.savePreferences).toHaveBeenCalled());
+    expect(second.savePreferences).not.toHaveBeenCalled();
+  });
+
+  it("does not let a slow load revert an edit made while it was in flight", async () => {
+    const api = fakeApi();
+    let release: (v: Record<string, unknown>) => void = () => {};
+    const state = {
+      ...adapter(),
+      getPreferences: vi.fn(
+        () =>
+          new Promise<Record<string, unknown>>((resolve) => {
+            release = resolve;
+          }),
+      ),
+    };
+    renderIt(api, state);
+    await waitFor(() => expect(listed(api).length).toBeGreaterThan(0));
+
+    await userEvent.click(
+      screen.getByRole("button", { name: /Filter Results|Filters \(/ }),
+    );
+    await userEvent.type(await screen.findByLabelText("Title"), "vrd");
+    const afterEdit = await screen.findByRole("button", { name: /Filters \(1\)/ });
+    expect(afterEdit).toBeInTheDocument();
+
+    // The stored set finally arrives, carrying something else entirely.
+    release({ sponsor: "someone else" });
+
+    // The reader's edit stands; the late answer is dropped.
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /Filters \(1\)/ })).toBeInTheDocument(),
+    );
+  });
+
+  it("keeps filters across a remount with no adapter at all", async () => {
+    // The fallback exists so the panel does not silently forget on reload for
+    // a host that supplies no state.
+    const first = fakeApi();
+    const view = renderIt(first);
+    await waitFor(() => expect(listed(first).length).toBeGreaterThan(0));
+
+    await userEvent.click(screen.getByRole("button", { name: /Filter Results|Filters \(/ }));
+    await userEvent.type(await screen.findByLabelText("Title"), "vrd");
+    await screen.findByRole("button", { name: /Filters \(1\)/ });
+
+    view.unmount();
+    const second = fakeApi();
+    renderIt(second);
+    await screen.findByRole("button", { name: /Filters \(1\)/ });
+  });
+});
+
+describe("a host that replaces the adapter without changing patient", () => {
+  it("writes through the new one, not the one captured at mount", async () => {
+    // A refreshed auth client is a new object for the same patient. The writer
+    // is deliberately not rebuilt — that would drop anything queued — so the
+    // calls have to route to whatever adapter is current for this key.
+    const mk = () => ({
+      listFavoriteIds: vi.fn(async () => []),
+      listRegisteredIds: vi.fn(async () => []),
+      listAdvancedEnrollments: vi.fn(async () => ({})),
+      setFavorite: vi.fn(async () => undefined),
+      setRegistered: vi.fn(async () => undefined),
+      getPreferences: vi.fn(async () => ({}) as Record<string, unknown>),
+      savePreferences: vi.fn(async (_f: Record<string, unknown>) => undefined),
+      resetPreferences: vi.fn(async () => undefined),
+    });
+    const api = fakeApi();
+    const stale = mk();
+    const fresh = mk();
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, refetchOnWindowFocus: false } },
+    });
+    const ui = (state: unknown) => (
+      <QueryClientProvider client={queryClient}>
+        <TrialMatches
+          apiClient={api.client}
+          queryClient={queryClient}
+          personId="p1"
+          state={state as never}
+        />
+      </QueryClientProvider>
+    );
+
+    const view = render(ui(stale));
+    await waitFor(() => expect(listed(api).length).toBeGreaterThan(0));
+    view.rerender(ui(fresh));
+
+    await userEvent.click(
+      screen.getByRole("button", { name: /Filter Results|Filters \(/ }),
+    );
+    await userEvent.type(await screen.findByLabelText("Title"), "vrd");
+
+    await waitFor(() => expect(fresh.savePreferences).toHaveBeenCalled());
+    expect(stale.savePreferences).not.toHaveBeenCalled();
+  });
+});
+
+describe("saved filters belong to the patient they were saved for", () => {
+  const mk = (saved: Record<string, unknown> = {}) => ({
+    listFavoriteIds: vi.fn(async () => []),
+    listRegisteredIds: vi.fn(async () => []),
+    listAdvancedEnrollments: vi.fn(async () => ({})),
+    setFavorite: vi.fn(async () => undefined),
+    setRegistered: vi.fn(async () => undefined),
+    getPreferences: vi.fn(async () => saved),
+    savePreferences: vi.fn(async (_f: Record<string, unknown>) => undefined),
+    resetPreferences: vi.fn(async () => undefined),
+  });
+  const client = () =>
+    new QueryClient({
+      defaultOptions: { queries: { retry: false, refetchOnWindowFocus: false } },
+    });
+
+  it("applies a loaded trial type instead of expiring it as someone else's", async () => {
+    // The staleness rule exists to expire a type PICKED for another patient.
+    // A type read out of this patient's own storage is not that, but it
+    // arrives without an owner — so unless loading claims it, the mask set by
+    // the previous patient's pick hides the value that was just loaded.
+    const api = fakeApi();
+    const queryClient = client();
+    const ui = (personId: string, state: unknown) => (
+      <QueryClientProvider client={queryClient}>
+        <TrialMatches
+          apiClient={api.client}
+          queryClient={queryClient}
+          personId={personId}
+          state={state as never}
+        />
+      </QueryClientProvider>
+    );
+
+    const view = render(ui("p1", mk()));
+    await waitFor(() => expect(listed(api).length).toBe(1));
+    await userEvent.click(screen.getByRole("button", { name: /Filter/ }));
+    await userEvent.selectOptions(await screen.findByLabelText("Trial type"), "device");
+    await waitFor(() => expect(listed(api).length).toBe(2));
+
+    view.rerender(ui("p2", mk({ trialType: "drug" })));
+
+    await waitFor(() =>
+      expect(listed(api).at(-1)?.params.trialType).toBe("drug"),
+    );
+  });
+
+  // NOT tested here, because it is not a defect: patient A's VISIBLE filters
+  // are saved for B after a switch. The panel deliberately keeps the reader's
+  // filters across a patient switch (see the NOTE in `TrialMatches`), so what
+  // is written for B is what B's reader is looking at. Ownership is reset per
+  // patient all the same — it is a claim about who chose a value, and that
+  // claim does not survive the switch.
+});
+
+describe("a slow load that is discarded", () => {
+  const mk = (getPreferences: () => Promise<Record<string, unknown>>) => ({
+    listFavoriteIds: vi.fn(async () => []),
+    listRegisteredIds: vi.fn(async () => []),
+    listAdvancedEnrollments: vi.fn(async () => ({})),
+    setFavorite: vi.fn(async () => undefined),
+    setRegistered: vi.fn(async () => undefined),
+    getPreferences: vi.fn(getPreferences),
+    savePreferences: vi.fn(async (_f: Record<string, unknown>) => undefined),
+    resetPreferences: vi.fn(async () => undefined),
+  });
+
+  it("does not delete the saved filters it decided not to apply", async () => {
+    // The reader has sponsor and phase saved. On a slow connection the load
+    // arrives after they have already typed a title, so it is dropped — which
+    // is right, reverting a visible edit is worse. But the save that follows
+    // carries only the title, and a transport that saw the load will null
+    // every other key it knows about: two filters destroyed, never shown, on
+    // a slow connection only.
+    const api = fakeApi();
+    let release: (v: Record<string, unknown>) => void = () => {};
+    const state = mk(
+      () =>
+        new Promise<Record<string, unknown>>((resolve) => {
+          release = resolve;
+        }),
+    );
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, refetchOnWindowFocus: false } },
+    });
+    render(
+      <QueryClientProvider client={queryClient}>
+        <TrialMatches
+          apiClient={api.client}
+          queryClient={queryClient}
+          personId="p1"
+          state={state as never}
+        />
+      </QueryClientProvider>,
+    );
+    await waitFor(() => expect(listed(api).length).toBeGreaterThan(0));
+
+    await userEvent.click(
+      screen.getByRole("button", { name: /Filter Results|Filters \(/ }),
+    );
+    await userEvent.type(await screen.findByLabelText("Title"), "dara");
+
+    release({ sponsor: "Janssen", phase: "2" });
+
+    await waitFor(() => expect(state.savePreferences).toHaveBeenCalled());
+    for (const call of state.savePreferences.mock.calls) {
+      expect(call[0]).not.toHaveProperty("sponsor");
+      expect(call[0]).not.toHaveProperty("phase");
+    }
+  });
+
+  it("does not delete them when the reader leaves before the load lands", async () => {
+    // Same wipe, reached the other way. The unmount cancels the load AND runs
+    // the flush against this same transport, so the save is queued behind a
+    // read that seeds the transport on its way through — while the set being
+    // saved is only what the reader typed.
+    const api = fakeApi();
+    let release: (v: Record<string, unknown>) => void = () => {};
+    const state = mk(
+      () =>
+        new Promise<Record<string, unknown>>((resolve) => {
+          release = resolve;
+        }),
+    );
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, refetchOnWindowFocus: false } },
+    });
+    const view = render(
+      <QueryClientProvider client={queryClient}>
+        <TrialMatches
+          apiClient={api.client}
+          queryClient={queryClient}
+          personId="p1"
+          state={state as never}
+        />
+      </QueryClientProvider>,
+    );
+    await waitFor(() => expect(listed(api).length).toBeGreaterThan(0));
+
+    await userEvent.click(
+      screen.getByRole("button", { name: /Filter Results|Filters \(/ }),
+    );
+    await userEvent.type(await screen.findByLabelText("Title"), "dara");
+
+    view.unmount();
+    release({ sponsor: "Janssen", phase: "2" });
+
+    await waitFor(() => expect(state.savePreferences).toHaveBeenCalled());
+    for (const call of state.savePreferences.mock.calls) {
+      expect(call[0]).not.toHaveProperty("sponsor");
+      expect(call[0]).not.toHaveProperty("phase");
+    }
+  });
+});
+
+describe("leaving the page without unmounting", () => {
+  it("flushes the queue on pagehide, and unsubscribes on unmount", async () => {
+    // A reload or tab close never unmounts, so the unmount flush does not
+    // cover the case the feature most obviously needs: set a filter, hit
+    // reload, find it gone. Asserted as wiring rather than behaviour — a
+    // debounce that fires on its own would make a behavioural assertion pass
+    // whether the listener existed or not.
+    const api = fakeApi();
+    const add = vi.spyOn(window, "addEventListener");
+    const remove = vi.spyOn(window, "removeEventListener");
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, refetchOnWindowFocus: false } },
+    });
+    const view = render(
+      <QueryClientProvider client={queryClient}>
+        <TrialMatches apiClient={api.client} queryClient={queryClient} personId="p1" />
+      </QueryClientProvider>,
+    );
+    await waitFor(() => expect(listed(api).length).toBeGreaterThan(0));
+
+    const registered = add.mock.calls.filter(([type]) => type === "pagehide");
+    expect(registered).toHaveLength(1);
+
+    view.unmount();
+    expect(remove.mock.calls.filter(([type]) => type === "pagehide")).toHaveLength(1);
+    add.mockRestore();
+    remove.mockRestore();
+  });
+});

--- a/frontend/src/federation/TrialMatches.tsx
+++ b/frontend/src/federation/TrialMatches.tsx
@@ -24,7 +24,12 @@ import { Pagination } from "./Pagination";
 import { SortControl } from "./SortControl";
 import { Tabs } from "./Tabs";
 import { hasInlinePatient } from "./api";
-import { baselineFilters, countActiveFilters, countryFor } from "./filters";
+import {
+  baselineFilters,
+  countActiveFilters,
+  countryFor,
+  userOwnedFilters,
+} from "./filters";
 import { MAX_TRIAL_IDS } from "./state";
 import {
   DEFAULT_SORT,
@@ -36,6 +41,7 @@ import {
 import {
   canReadAdvanced,
   useAdvancedEnrollments,
+  useSavedFilters,
   useSetTrialState,
   useStateIds,
   useTrials,
@@ -206,6 +212,42 @@ function TrialMatchesInner({
   // drawn for a trial whose enrollment a study team has already advanced,
   // where "I'm Interested" would write `registered` over `entered`.
   const advanced = useAdvancedEnrollments(state, stateKey);
+  // Saved filters. Applied over the host's `initialFilters` rather than in
+  // place of them: the seeded country is the baseline the reader never chose,
+  // and a saved set that omits it must not silently widen the search to every
+  // country. Keys the reader did save win.
+  // Which fields are the reader's rather than the host's. Sticky: seeded from
+  // whatever was loaded, added to on every save, and emptied by Reset. Without
+  // it a saved field that happens to equal the current baseline would look
+  // like host scope on the next edit and be dropped. See `userOwnedFilters`.
+  const ownedFields = useRef<Set<string>>(new Set());
+  const savedFilters = useSavedFilters(state, stateKey, (saved) => {
+    for (const field of Object.keys(saved)) ownedFields.current.add(field);
+    // A saved trial type came from THIS patient's storage, so it is this
+    // patient's choice. Without claiming it the staleness rule — which exists
+    // to expire a type picked for someone else — would mask the very type
+    // just loaded, and a later edit would overwrite it.
+    if (saved.trialType !== undefined) setTrialTypeOwner(patientIdentity);
+    setFilters((current) => ({ ...current, ...saved }));
+  });
+  // Ownership is per patient: what the previous one had saved is not evidence
+  // about this one. Kept in step with `stateKey` — the same key the saved-set
+  // load is keyed on, so the clear lands before that patient's answer does.
+  // (The reader's session FILTERS are deliberately kept across the switch; it
+  // is the claim about who owns them that does not carry over.)
+  useEffect(() => {
+    ownedFields.current = new Set();
+  }, [stateKey]);
+
+  // NOTE on switching patients in place: the reader's session filters are
+  // deliberately KEPT, and only the trial-type ownership is re-decided (see
+  // `setTrialTypeOwner` below and "a trial type belongs to the patient it was
+  // chosen for"). Review flagged the saved-set overlay as leaking filters from
+  // one patient to the next; resetting to the seed instead breaks that tested
+  // decision. The filters belong to the reader's search, not to the patient —
+  // what belongs to the patient is the SAVED set, and the overlay applies the
+  // new patient's own saved keys over the top.
+
   const setFavorite = useSetTrialState(state, "favorites", stateKey);
   const setRegistered = useSetTrialState(state, "registered", stateKey);
 
@@ -451,6 +493,12 @@ function TrialMatchesInner({
       setTrialTypeOwner(patientIdentity);
     }
     setFilters(next);
+    // Only what the reader changed. `next` carries the host's mount-time
+    // scope too, and saving that would make one mount's scope their standing
+    // preference — a later mount with a different scope would lose to it.
+    const owned = userOwnedFilters(next, baseline, ownedFields.current);
+    for (const field of Object.keys(owned)) ownedFields.current.add(field);
+    savedFilters.persist(owned);
   };
   // Reset goes back to the baseline, not to `{}`: clearing the seeded
   // country would silently widen the search to every country in the
@@ -460,7 +508,17 @@ function TrialMatchesInner({
   // produce the same value — and a mutation test confirmed the line was
   // dead. It was load-bearing only under the earlier "mask to undefined"
   // rule, which is gone.
-  const handleFiltersReset = () => setFilters(baseline);
+  const handleFiltersReset = () => {
+    setFilters(baseline);
+    // Reset gives the fields back to the host, so nothing is owned any more.
+    ownedFields.current = new Set();
+    // `reset`, not `persist(baseline)`: the server merges a partial update, so
+    // writing the baseline would leave whatever the reader had saved for keys
+    // the baseline does not mention. It also retires a save already on the
+    // wire, which would otherwise land afterwards and restore what was
+    // just cleared.
+    savedFilters.reset();
+  };
 
   const handleSelect = (trial: TrialMatch) => {
     setSelectedTrial(trial);

--- a/frontend/src/federation/filters.test.ts
+++ b/frontend/src/federation/filters.test.ts
@@ -7,6 +7,7 @@ import {
   countryFor,
   hasActiveFilters,
   isActiveDistance,
+  userOwnedFilters,
 } from "./filters";
 
 describe("baselineFilters", () => {
@@ -197,5 +198,113 @@ describe("isActiveDistance", () => {
     expect(isActiveDistance("25")).toBe(false);
     expect(isActiveDistance(Number.NaN)).toBe(false);
     expect(isActiveDistance(Number.POSITIVE_INFINITY)).toBe(false);
+  });
+});
+
+describe("userOwnedFilters", () => {
+  it("keeps only what the reader changed", () => {
+    const baseline = { country: "US", recruitmentStatus: "RECRUITING" };
+    const filters = { country: "US", recruitmentStatus: "RECRUITING", searchTitle: "vrd" };
+    expect(userOwnedFilters(filters, baseline)).toEqual({ searchTitle: "vrd" });
+  });
+
+  it("does not save the host's mount-time scope", () => {
+    // Persisting it would turn one mount's scope into a standing preference,
+    // and a later mount with a different scope would lose to the saved one.
+    const baseline = { country: "DE", recruitmentStatus: "NOT_YET_RECRUITING" };
+    expect(userOwnedFilters({ ...baseline }, baseline)).toEqual({});
+  });
+
+  it("keeps a field the reader overrode, even back to a common value", () => {
+    const baseline = { recruitmentStatus: "RECRUITING" };
+    expect(userOwnedFilters({ recruitmentStatus: "COMPLETED" }, baseline)).toEqual({
+      recruitmentStatus: "COMPLETED",
+    });
+  });
+
+  it("marks a cleared field present-but-undefined so it can be cleared server-side", () => {
+    const baseline = { searchTitle: "vrd" };
+    const out = userOwnedFilters({ searchTitle: undefined }, baseline);
+    expect("searchTitle" in out).toBe(true);
+    expect(out.searchTitle).toBeUndefined();
+  });
+});
+
+describe("userOwnedFilters — distance carries its unit", () => {
+  it("saves the unit alongside a distance", () => {
+    // Without it a radius chosen in miles comes back as the same number of km.
+    const out = userOwnedFilters({ distance: 50, distanceUnits: "miles" }, {});
+    expect(out).toEqual({ distance: 50, distanceUnits: "miles" });
+  });
+
+  it("does not save a unit with no distance behind it", () => {
+    expect(userOwnedFilters({ distanceUnits: "miles" }, {})).toEqual({});
+  });
+});
+
+describe("userOwnedFilters — ownership is sticky", () => {
+  it("keeps a saved field whose value happens to equal the baseline", () => {
+    // 50 miles against a 50-km baseline: the numbers match, the meanings do
+    // not. Dropping it here would make the next unrelated edit clear the
+    // reader's radius — units and all — on the server.
+    const baseline = { distance: 50, distanceUnits: "km" as const };
+    const next = { distance: 50, distanceUnits: "miles" as const, searchTitle: "vrd" };
+
+    // The units go either way — the control is enabled for a host-seeded
+    // distance, so switching 50 km to 50 miles has to be saved even though the
+    // number never changed and `distance` itself is the host's.
+    expect(userOwnedFilters(next, baseline)).toEqual({
+      searchTitle: "vrd",
+      distanceUnits: "miles",
+    });
+    // But units the reader never touched stay the host's.
+    expect(userOwnedFilters({ ...next, distanceUnits: "km" }, baseline)).toEqual({
+      searchTitle: "vrd",
+    });
+    expect(userOwnedFilters(next, baseline, new Set(["distance"]))).toEqual({
+      searchTitle: "vrd",
+      distance: 50,
+      distanceUnits: "miles",
+    });
+  });
+});
+
+describe("userOwnedFilters — a units-only change", () => {
+  it("is saved even though nothing else about the distance moved", () => {
+    // Otherwise the reader sets a 50-mile radius against the host's 50 km,
+    // nothing is persisted, and the next mount silently searches 50 km — a
+    // materially different search, with no sign anything was discarded.
+    const baseline = { distance: 50, distanceUnits: "km" as const };
+    const next = { distance: 50, distanceUnits: "miles" as const };
+    expect(userOwnedFilters(next, baseline)).toEqual({ distanceUnits: "miles" });
+    // And with no distance in play there is no unit to qualify.
+    expect(userOwnedFilters({ distanceUnits: "miles" as const }, {})).toEqual({});
+  });
+});
+
+describe("userOwnedFilters — clearing an owned field", () => {
+  it("emits a tombstone rather than omitting the key", () => {
+    // Both transports merge, so an absent key means "no opinion, keep what you
+    // have". A cleared filter that is merely omitted survives storage and is
+    // applied again on the next mount.
+    const out = userOwnedFilters({ searchTitle: undefined }, {}, new Set(["searchTitle"]));
+    expect("searchTitle" in out).toBe(true);
+    expect(out.searchTitle).toBeUndefined();
+    // Unowned and empty is genuinely nothing to say.
+    expect(userOwnedFilters({ searchTitle: undefined }, {})).toEqual({});
+  });
+});
+
+describe("userOwnedFilters — a cleared distance", () => {
+  it("takes its unit with it", () => {
+    // Otherwise the old unit survives on disk under a merge transport and
+    // becomes the unit for the next radius the reader enters.
+    const out = userOwnedFilters(
+      { distance: undefined, distanceUnits: "miles" as const },
+      {},
+      new Set(["distance"]),
+    );
+    expect("distanceUnits" in out).toBe(true);
+    expect(out.distanceUnits).toBeUndefined();
   });
 });

--- a/frontend/src/federation/filters.ts
+++ b/frontend/src/federation/filters.ts
@@ -127,6 +127,75 @@ export function countActiveFilters(
   }, 0);
 }
 
+/** The panel fields the reader has actually changed, as a partial filter set.
+ *
+ *  What gets SAVED, as opposed to what gets sent to the search. The baseline
+ *  carries the host's mount-time scope — the seeded country, an
+ *  `initialFilters.register` or `recruitmentStatus` the host chose for this
+ *  mount — and persisting those would turn one mount's scope into the reader's
+ *  standing preference: a later mount with a different scope would find the
+ *  stale one saved and the overlay would win.
+ *
+ *  A field the reader cleared back to nothing is present with `undefined`, not
+ *  absent, so the transport can clear it on the server rather than leaving the
+ *  old value behind a merge.
+ *
+ *  `owned` names fields already known to be the reader's — what a previous
+ *  mount loaded from storage, plus everything persisted since. Ownership is
+ *  sticky because equality to the current baseline is not evidence of its
+ *  absence: a reader who saved a 50-mile radius against a 50-KM baseline owns
+ *  a field whose value matches, and deriving ownership from the diff alone
+ *  would drop it on the next unrelated edit and take the units with it.
+ */
+export function userOwnedFilters(
+  filters: FilterState,
+  baseline: FilterState,
+  owned: ReadonlySet<string> = new Set(),
+): FilterState {
+  const out: FilterState = {};
+  for (const field of PANEL_FIELDS) {
+    const value = filters[field];
+    const base = baseline[field];
+    if (isInactive(field, value) && isInactive(field, base)) {
+      // An OWNED field that is now empty is emitted as `undefined` — a
+      // tombstone, not an omission. The merge transports both treat a key
+      // that is simply absent as "no opinion, keep what you have", so a
+      // cleared filter would survive on disk and be applied again on the
+      // next mount.
+      if (!owned.has(field)) continue;
+      (out as Record<string, unknown>)[field] = undefined;
+      continue;
+    }
+    if (value === base && !owned.has(field)) continue;
+    (out as Record<string, unknown>)[field] = value;
+  }
+  // `distanceUnits` is not a PANEL_FIELD — it qualifies `distance` rather than
+  // standing on its own, which is why it does not count toward the badge. It
+  // still has to be SAVED whenever a distance is active, or a radius chosen in
+  // miles comes back as the same number of kilometres.
+  //
+  // Not keyed on `distance` reaching `out`: the units control is enabled for a
+  // host-seeded distance too, so a reader can switch 50 km to 50 miles without
+  // changing the number, which leaves `distance` equal to the baseline and
+  // absent from `out`. Keyed on the units having actually been chosen, though
+  // — saving a unit the HOST seeded would make one mount's scope the reader's
+  // standing preference, and a later mount's 50-mile host radius would come
+  // back as 50 km.
+  if ("distance" in out && out.distance === undefined) {
+    // The units leave with the distance they qualified — the panel treats them
+    // that way, and a merge transport would otherwise keep the old unit on
+    // disk, to be applied to whatever radius comes next.
+    out.distanceUnits = undefined;
+  } else if (
+    isActiveDistance(filters.distance) &&
+    filters.distanceUnits !== undefined &&
+    ("distance" in out || filters.distanceUnits !== baseline.distanceUnits)
+  ) {
+    out.distanceUnits = filters.distanceUnits;
+  }
+  return out;
+}
+
 /** Whether the panel is showing anything other than the baseline — drives
  *  whether Reset is worth offering. */
 export function hasActiveFilters(

--- a/frontend/src/federation/hooks.ts
+++ b/frontend/src/federation/hooks.ts
@@ -10,6 +10,13 @@ import {
 import type { AxiosInstance } from "axios";
 
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useEffect, useMemo, useRef } from "react";
+
+import {
+  PreferenceWriter,
+  adapterPreferences,
+  localStoragePreferences,
+} from "./preferences";
 
 import { fetchFormSettings, fetchTrialDetail, fetchTrials } from "./api";
 import type { AdvancedStatus, TrialId, TrialStateAdapter } from "./state";
@@ -224,4 +231,151 @@ export function useFormSettings(
     queryFn: () => fetchFormSettings(apiClient, diseaseCode),
     staleTime: 5 * 60_000,
   });
+}
+
+/** Saved search filters: load them once, and route every write through the
+ *  queue in `preferences.ts`.
+ *
+ *  Keyed on the PATIENT, not on the adapter object — same reasoning as
+ *  `useStateIds`: a host that builds `state={createPromopState(...)}` inline
+ *  hands over a new object every render, and rebuilding the writer on each one
+ *  would lose whatever it had queued. A host that genuinely replaces the
+ *  adapter for the same patient — a refreshed auth client, say — is still
+ *  honoured, because calls route through whatever adapter is current for
+ *  THIS key rather than through the one captured when the writer was built.
+ *
+ *  With no adapter this falls back to `localStorage` rather than doing
+ *  nothing. The filter panel is the same panel either way, and a panel that
+ *  forgets on reload is a worse answer than a per-browser one.
+ */
+export function useSavedFilters(
+  state: TrialStateAdapter | undefined,
+  key: string,
+  onLoad: (saved: FilterState) => void,
+): { persist: (filters: FilterState) => void; reset: () => void } {
+  const hasAdapter = state != null;
+  // Read through a ref so the memo below does not rebuild on every render —
+  // a host writing `state={createPromopState(...)}` inline hands over a new
+  // object each time, and rebuilding would drop whatever the writer had queued.
+  const stateRef = useRef(state);
+  stateRef.current = state;
+  // Which patient the ref above currently belongs to. Both refs are written
+  // during render, so by the time an unmount cleanup runs after a patient
+  // switch they already describe the NEW patient.
+  const keyRef = useRef(key);
+  keyRef.current = key;
+
+  const transport = useMemo(() => {
+    // Each call picks its adapter rather than closing over one, because the
+    // two ways `state` can change need opposite answers:
+    //
+    //  - same patient, new adapter object (an inline `createPromopState(...)`,
+    //    or a genuinely refreshed client): use the current one. Rebuilding the
+    //    memo instead would drop whatever the writer had queued, and closing
+    //    over the old one would write through an expired client.
+    //  - different patient: use the captured one. This transport belongs to
+    //    the previous patient, and its writer's unmount flush carries filters
+    //    edited FOR that patient — sending them through the ref would file
+    //    them under the next patient's preferences.
+    const captured = stateRef.current;
+    const live = () =>
+      (keyRef.current === key ? (stateRef.current ?? captured) : captured)!;
+    return captured
+      ? adapterPreferences({
+          getPreferences: () => live().getPreferences(),
+          savePreferences: (f) => live().savePreferences(f),
+          resetPreferences: () => live().resetPreferences(),
+        })
+      : localStoragePreferences(key);
+    // `hasAdapter` rather than `state`: see above.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [hasAdapter, key]);
+
+  const writer = useMemo(() => new PreferenceWriter(transport), [transport]);
+
+  const onLoadRef = useRef(onLoad);
+  onLoadRef.current = onLoad;
+
+  // Whether the reader has touched the filters since this writer was built.
+  // A slow `getPreferences()` that resolves afterwards must not merge the
+  // stored set over an edit made while it was in flight — that visibly
+  // reverts what they just did, and only on a slow connection, which is the
+  // hardest kind of bug to be told about.
+  const editedRef = useRef(false);
+  useEffect(() => {
+    editedRef.current = false;
+  }, [writer]);
+
+  useEffect(() => {
+    let cancelled = false;
+    void transport
+      .get()
+      .then((saved) => {
+        // Either way the load is NOT applied, which leaves the writer holding
+        // a set that is a strict SUBSET of what is stored — the reader's one
+        // edit. Telling the transport to forget what it read keeps the next
+        // save additive; without it that save reads as "these are all the
+        // filters there are" and deletes saved filters the reader never even
+        // saw. `cancelled` needs it just as much as an edit does: an unmount
+        // runs the flush against this same transport, and the read it is
+        // queued behind seeds the transport on its way through.
+        if (cancelled || editedRef.current) {
+          transport.forget();
+          return;
+        }
+        // Nothing saved is the common case and must not clobber the filters
+        // the host seeded, so an empty object is treated as "no opinion".
+        if (!saved || Object.keys(saved).length === 0) return;
+        onLoadRef.current(saved);
+      })
+      .catch(() => {
+        // Unreachable saved filters are not a reason to fail the search.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [transport]);
+
+  // An edit made in the last few hundred milliseconds should survive the
+  // reader navigating away — or the host switching patients, which rebuilds
+  // the writer and runs this cleanup against the OLD transport.
+  useEffect(() => () => writer.flush(), [writer]);
+
+  // An unmount is not the only way to leave. A reload, a tab close or a host
+  // full-page navigation never unmounts anything, so the debounced write of
+  // the filter just set — the one the reader is most likely to expect back —
+  // is exactly the one that would be lost. `pagehide` covers the bfcache case
+  // that `beforeunload` does not; `visibilitychange` covers mobile, where a
+  // backgrounded tab may never fire either.
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const leave = () => {
+      // `visibilitychange` fires on the way BACK too. Flushing then would
+      // cancel the debounce for an edit still in progress — a half-typed
+      // title persisted, and a second request when the reader finishes.
+      if (document.visibilityState !== "hidden") return;
+      writer.flush();
+    };
+    const hide = () => writer.flush();
+    window.addEventListener("pagehide", hide);
+    document.addEventListener("visibilitychange", leave);
+    return () => {
+      window.removeEventListener("pagehide", hide);
+      document.removeEventListener("visibilitychange", leave);
+    };
+  }, [writer]);
+
+  return useMemo(
+    () => ({
+      persist: (filters: FilterState) => {
+        editedRef.current = true;
+        writer.save(filters);
+      },
+      reset: () => {
+        editedRef.current = true;
+        writer.reset();
+      },
+    }),
+    [writer],
+  );
 }

--- a/frontend/src/federation/preferences.test.ts
+++ b/frontend/src/federation/preferences.test.ts
@@ -1,0 +1,572 @@
+// The write queue is the point of this module, so it is what these test.
+//
+// Each case is a race that actually happens in the panel: two checkboxes in
+// one frame, a Reset pressed while a save is on the wire, a navigation away
+// mid-debounce. The look of the filter panel is covered elsewhere; this is
+// the behaviour CB earned the hard way.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  FILTER_DEBOUNCE_MS,
+  PreferenceWriter,
+  adapterPreferences,
+  localStoragePreferences,
+  type PreferenceTransport,
+} from "./preferences";
+import type { FilterState } from "./types";
+
+/** A transport that lets the test decide when each request completes. */
+function controllable() {
+  const calls: Array<{ kind: "save" | "reset"; value?: FilterState }> = [];
+  const resolvers: Array<() => void> = [];
+  const hold = () =>
+    new Promise<void>((resolve) => {
+      resolvers.push(resolve);
+    });
+  const transport: PreferenceTransport = {
+    get: async () => ({}),
+    save: (value) => {
+      calls.push({ kind: "save", value });
+      return hold();
+    },
+    reset: () => {
+      calls.push({ kind: "reset" });
+      return hold();
+    },
+    forget: () => {},
+  };
+  return {
+    transport,
+    calls,
+    /** Complete the oldest outstanding request. */
+    settle: async () => {
+      resolvers.shift()?.();
+      await Promise.resolve();
+      await Promise.resolve();
+    },
+    outstanding: () => resolvers.length,
+  };
+}
+
+describe("PreferenceWriter", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it("collapses rapid edits into one request", async () => {
+    const t = controllable();
+    const w = new PreferenceWriter(t.transport);
+
+    w.save({ country: "US" });
+    w.save({ country: "US", distance: 50 });
+    w.save({ country: "US", distance: 100 });
+    expect(t.calls).toHaveLength(0);
+
+    vi.advanceTimersByTime(FILTER_DEBOUNCE_MS);
+    expect(t.calls).toEqual([
+      { kind: "save", value: { country: "US", distance: 100 } },
+    ]);
+  });
+
+  it("keeps one request in flight and runs the next after it", async () => {
+    const t = controllable();
+    const w = new PreferenceWriter(t.transport);
+
+    w.save({ distance: 1 });
+    vi.advanceTimersByTime(FILTER_DEBOUNCE_MS);
+    expect(t.outstanding()).toBe(1);
+
+    w.save({ distance: 2 });
+    vi.advanceTimersByTime(FILTER_DEBOUNCE_MS);
+    expect(t.calls).toHaveLength(1); // still only the first — the second waits
+
+    await t.settle();
+    expect(t.calls.map((c) => c.value)).toEqual([{ distance: 1 }, { distance: 2 }]);
+  });
+
+  it("keeps only the newest write waiting", async () => {
+    const t = controllable();
+    const w = new PreferenceWriter(t.transport);
+
+    w.save({ distance: 1 });
+    vi.advanceTimersByTime(FILTER_DEBOUNCE_MS);
+
+    for (const distance of [2, 3, 4]) {
+      w.save({ distance });
+      vi.advanceTimersByTime(FILTER_DEBOUNCE_MS);
+    }
+
+    await t.settle();
+    expect(t.calls.map((c) => c.value)).toEqual([{ distance: 1 }, { distance: 4 }]);
+  });
+
+  it("sends a reset without waiting for the debounce", () => {
+    const t = controllable();
+    const w = new PreferenceWriter(t.transport);
+
+    w.save({ distance: 1 });
+    w.reset();
+    expect(t.calls).toEqual([{ kind: "reset" }]);
+  });
+
+  it("drops a save that was waiting behind a reset", async () => {
+    const t = controllable();
+    const w = new PreferenceWriter(t.transport);
+
+    // A save goes on the wire...
+    w.save({ distance: 1 });
+    vi.advanceTimersByTime(FILTER_DEBOUNCE_MS);
+    // ...a second is queued behind it...
+    w.save({ distance: 2 });
+    vi.advanceTimersByTime(FILTER_DEBOUNCE_MS);
+    // ...and Reset arrives before either finishes.
+    w.reset();
+
+    await t.settle(); // the first save completes
+    await t.settle(); // then whatever the queue chose to run
+
+    expect(t.calls).toEqual([
+      { kind: "save", value: { distance: 1 } },
+      { kind: "reset" },
+    ]);
+  });
+
+  it("does not let a pre-reset save restore what the reset cleared", async () => {
+    const t = controllable();
+    const w = new PreferenceWriter(t.transport);
+
+    w.save({ distance: 1 });
+    vi.advanceTimersByTime(FILTER_DEBOUNCE_MS); // in flight
+    w.save({ distance: 2 });
+    vi.advanceTimersByTime(FILTER_DEBOUNCE_MS); // queued
+    w.reset();
+
+    await t.settle();
+    await t.settle();
+    await t.settle();
+
+    const kinds = t.calls.map((c) => c.kind);
+    expect(kinds[kinds.length - 1]).toBe("reset");
+    expect(t.calls.filter((c) => c.value?.distance === 2)).toHaveLength(0);
+  });
+
+  it("flush sends a pending edit immediately", () => {
+    const t = controllable();
+    const w = new PreferenceWriter(t.transport);
+
+    w.save({ distance: 7 });
+    w.flush();
+    expect(t.calls).toEqual([{ kind: "save", value: { distance: 7 } }]);
+  });
+
+  it("flush is a no-op with nothing pending", () => {
+    const t = controllable();
+    const w = new PreferenceWriter(t.transport);
+    w.flush();
+    expect(t.calls).toHaveLength(0);
+  });
+
+  it("reports a failed write instead of throwing", async () => {
+    const onError = vi.fn();
+    const transport: PreferenceTransport = {
+      get: async () => ({}),
+      save: async () => {
+        throw new Error("503");
+      },
+      reset: async () => {},
+      forget: () => {},
+    };
+    const w = new PreferenceWriter(transport, { onError });
+
+    w.save({ distance: 1 });
+    vi.advanceTimersByTime(FILTER_DEBOUNCE_MS);
+    await w.settled();
+
+    expect(onError).toHaveBeenCalledOnce();
+  });
+
+  it("keeps draining the queue after a failure", async () => {
+    const seen: FilterState[] = [];
+    let fail = true;
+    const transport: PreferenceTransport = {
+      get: async () => ({}),
+      save: async (filters) => {
+        seen.push(filters);
+        if (fail) {
+          fail = false;
+          throw new Error("503");
+        }
+      },
+      reset: async () => {},
+      forget: () => {},
+    };
+    const w = new PreferenceWriter(transport, { onError: () => {} });
+
+    w.save({ distance: 1 });
+    vi.advanceTimersByTime(FILTER_DEBOUNCE_MS);
+    w.save({ distance: 2 });
+    vi.advanceTimersByTime(FILTER_DEBOUNCE_MS);
+    await w.settled();
+
+    expect(seen).toEqual([{ distance: 1 }, { distance: 2 }]);
+  });
+});
+
+describe("localStoragePreferences", () => {
+  const key = "patient-1";
+
+  // A minimal in-memory Storage rather than jsdom: the transport only needs
+  // getItem/setItem/removeItem, and this suite runs in the `node` project,
+  // which the config keeps deliberately cheap.
+  class MemoryStorage {
+    private data = new Map<string, string>();
+    failOnWrite = false;
+    getItem(k: string) {
+      return this.data.has(k) ? this.data.get(k)! : null;
+    }
+    setItem(k: string, v: string) {
+      if (this.failOnWrite) throw new Error("QuotaExceededError");
+      this.data.set(k, v);
+    }
+    removeItem(k: string) {
+      this.data.delete(k);
+    }
+  }
+
+  let store: MemoryStorage;
+
+  beforeEach(() => {
+    store = new MemoryStorage();
+    (globalThis as { localStorage?: unknown }).localStorage = store;
+  });
+
+  afterEach(() => {
+    delete (globalThis as { localStorage?: unknown }).localStorage;
+  });
+
+  it("round-trips filters", async () => {
+    const prefs = localStoragePreferences(key);
+    await prefs.save({ country: "US", distance: 25 });
+    expect(await prefs.get()).toEqual({ country: "US", distance: 25 });
+  });
+
+  it("scopes by patient, so two patients do not share filters", async () => {
+    await localStoragePreferences("patient-1").save({ distance: 1 });
+    expect(await localStoragePreferences("patient-2").get()).toEqual({});
+  });
+
+  it("reads nothing as no filters", async () => {
+    expect(await localStoragePreferences(key).get()).toEqual({});
+  });
+
+  it("treats a corrupt entry as no filters rather than throwing", async () => {
+    store.setItem(`exact.filters.${key}`, "{not json");
+    expect(await localStoragePreferences(key).get()).toEqual({});
+  });
+
+  it("treats a non-object entry as no filters", async () => {
+    store.setItem(`exact.filters.${key}`, '"a string"');
+    expect(await localStoragePreferences(key).get()).toEqual({});
+  });
+
+  it("reset clears them", async () => {
+    const prefs = localStoragePreferences(key);
+    await prefs.save({ distance: 5 });
+    await prefs.reset();
+    expect(await prefs.get()).toEqual({});
+  });
+
+  it("survives storage that refuses to write", async () => {
+    store.failOnWrite = true;
+    // A filter that cannot persist must not break the search on screen.
+    await expect(
+      localStoragePreferences(key).save({ distance: 1 }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("degrades to no filters where there is no storage at all", async () => {
+    delete (globalThis as { localStorage?: unknown }).localStorage;
+    const prefs = localStoragePreferences(key);
+    expect(await prefs.get()).toEqual({});
+    await expect(prefs.save({ distance: 1 })).resolves.toBeUndefined();
+  });
+});
+
+describe("PreferenceWriter — a reset is a barrier", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it("still resets when an edit follows it during the same flight", async () => {
+    // Reset and a later save are not alternatives: both have to happen, in
+    // that order. Collapsed into one slot, the save overwrote the reset and
+    // the partial update already on the server was never cleared.
+    const t = controllable();
+    const w = new PreferenceWriter(t.transport);
+
+    w.save({ distance: 1 });
+    vi.advanceTimersByTime(FILTER_DEBOUNCE_MS); // in flight
+    w.reset(); // queued behind it
+    w.save({ distance: 9 }); // must NOT take the reset's place
+    vi.advanceTimersByTime(FILTER_DEBOUNCE_MS);
+
+    await t.settle(); // first save completes → reset runs
+    await t.settle(); // reset completes → the post-reset save runs
+    await t.settle();
+
+    expect(t.calls.map((c) => c.kind)).toEqual(["save", "reset", "save"]);
+    expect(t.calls.at(-1)?.value).toEqual({ distance: 9 });
+  });
+});
+
+describe("adapterPreferences", () => {
+  function fakeAdapter() {
+    const saved: Array<Record<string, unknown>> = [];
+    let stored: Record<string, unknown> = {};
+    return {
+      saved,
+      setStored: (v: Record<string, unknown>) => {
+        stored = v;
+      },
+      methods: {
+        getPreferences: async () => stored as never,
+        savePreferences: async (f: never) => {
+          saved.push(f as Record<string, unknown>);
+        },
+        resetPreferences: async () => {
+          stored = {};
+        },
+      },
+    };
+  }
+
+  it("sends a cleared key explicitly, because the endpoint merges", async () => {
+    // `FilterPanel` represents a cleared control as `undefined`, which JSON
+    // drops — so under merge semantics the old value would survive and come
+    // back on the next mount.
+    const a = fakeAdapter();
+    const t = adapterPreferences(a.methods);
+
+    await t.save({ searchTitle: "vrd", distance: 50 });
+    await t.save({ distance: 50 });
+
+    expect(a.saved[0]).toEqual({ searchTitle: "vrd", distance: 50 });
+    expect(a.saved[1]).toEqual({ searchTitle: null, distance: 50 });
+  });
+
+  it("does not read a cleared key back as a set one", async () => {
+    const a = fakeAdapter();
+    a.setStored({ searchTitle: null, distance: 50 });
+    expect(await adapterPreferences(a.methods).get()).toEqual({ distance: 50 });
+  });
+
+  it("forgets what it sent once the preferences are reset", async () => {
+    const a = fakeAdapter();
+    const t = adapterPreferences(a.methods);
+    await t.save({ searchTitle: "vrd" });
+    await t.reset();
+    await t.save({ distance: 10 });
+    // No stale `searchTitle: null` — the reset already cleared the row.
+    expect(a.saved.at(-1)).toEqual({ distance: 10 });
+  });
+});
+
+describe("adapterPreferences — clearing what the server already held", () => {
+  it("clears a key that came from the server, not just one it sent", async () => {
+    // `lastSent` starts empty, so without seeding it from `get()` the payload
+    // would simply omit the key and the merge would keep the old value.
+    const saved: Array<Record<string, unknown>> = [];
+    const t = adapterPreferences({
+      getPreferences: async () => ({ searchTitle: "vrd" }) as never,
+      savePreferences: async (f: never) => {
+        saved.push(f as Record<string, unknown>);
+      },
+      resetPreferences: async () => {},
+    });
+
+    expect(await t.get()).toEqual({ searchTitle: "vrd" });
+    await t.save({}); // the reader cleared it, having changed nothing else
+
+    expect(saved[0]).toEqual({ searchTitle: null });
+  });
+});
+
+describe("adapterPreferences — a save that overtakes the first read", () => {
+  it("waits for the read, so the seed is in place before the payload is built", async () => {
+    // A slow preference load plus an edit inside the debounce window. Without
+    // serialising, the PATCH is built against an empty `lastSent` and the keys
+    // the server already held survive the merge.
+    const saved: Array<Record<string, unknown>> = [];
+    let release!: () => void;
+    const gate = new Promise<void>((r) => {
+      release = r;
+    });
+    const t = adapterPreferences({
+      getPreferences: async () => {
+        await gate;
+        return { searchTitle: "vrd" } as never;
+      },
+      savePreferences: async (f: never) => {
+        saved.push(f as Record<string, unknown>);
+      },
+      resetPreferences: async () => {},
+    });
+
+    const read = t.get();
+    const write = t.save({ distance: 50 });
+    expect(saved).toEqual([]); // still behind the read
+
+    release();
+    await read;
+    await write;
+
+    expect(saved[0]).toEqual({ searchTitle: null, distance: 50 });
+  });
+});
+
+describe("adapterPreferences — what it does NOT know about", () => {
+  it("stops nulling keys once it is told to forget them", async () => {
+    // A load that was read and deliberately discarded leaves the caller with a
+    // strict subset of what is stored. Without `forget` the next save reads as
+    // "these are all the filters there are" and clears the rest — filters the
+    // reader never saw, on a slow connection only.
+    const saved: Array<Record<string, unknown>> = [];
+    const t = adapterPreferences({
+      getPreferences: async () => ({ sponsor: "Janssen", phase: "2" }) as never,
+      savePreferences: async (f: never) => {
+        saved.push(f as Record<string, unknown>);
+      },
+      resetPreferences: async () => {},
+    });
+
+    await t.get();
+    t.forget();
+    await t.save({ searchTitle: "dara" });
+
+    expect(saved[0]).toEqual({ searchTitle: "dara" });
+  });
+
+  it("keeps its seed when a reset fails", async () => {
+    // Clearing the seed before the request resolves means a failed reset
+    // leaves us believing the server is empty. The next save then nulls
+    // nothing, and what the reader watched disappear is back on the next
+    // mount.
+    const saved: Array<Record<string, unknown>> = [];
+    const t = adapterPreferences({
+      getPreferences: async () => ({ sponsor: "Janssen" }) as never,
+      savePreferences: async (f: never) => {
+        saved.push(f as Record<string, unknown>);
+      },
+      resetPreferences: async () => {
+        throw new Error("503");
+      },
+    });
+
+    await t.get();
+    await expect(t.reset()).rejects.toThrow("503");
+    await t.save({ searchTitle: "dara" });
+
+    expect(saved[0]).toEqual({ sponsor: null, searchTitle: "dara" });
+  });
+});
+
+describe("localStoragePreferences", () => {
+  // This file runs in the node project, which has no DOM. A map is all the
+  // transport asks of `localStorage`.
+  let store: Record<string, string>;
+  beforeEach(() => {
+    store = {};
+    (globalThis as Record<string, unknown>).localStorage = {
+      getItem: (k: string) => store[k] ?? null,
+      setItem: (k: string, v: string) => {
+        store[k] = v;
+      },
+      removeItem: (k: string) => {
+        delete store[k];
+      },
+    };
+  });
+  afterEach(() => {
+    delete (globalThis as Record<string, unknown>).localStorage;
+  });
+
+  it("does not put the patient key on disk in the clear", async () => {
+    // `key` is the patient key, and for an inline payload that IS the patient
+    // record. It was a react-query cache key in memory; a storage key persists
+    // it per browser, unexpired, for every patient ever viewed.
+    const patient = JSON.stringify({ disease: "multiple myeloma", dob: "1961-04-02" });
+    await localStoragePreferences(`|${patient}`).save({ searchTitle: "vrd" });
+    const keys = Object.keys(store);
+    expect(keys).toHaveLength(1);
+    expect(keys[0]).not.toContain("myeloma");
+    expect(keys[0]).not.toContain("1961");
+  });
+
+  it("merges rather than replacing, and reads a cleared key as unset", async () => {
+    const t = localStoragePreferences("p1");
+    await t.save({ sponsor: "Janssen", searchTitle: "vrd" });
+    t.forget();
+    await t.save({ searchTitle: "dara" });
+    // `sponsor` was never mentioned by the second write, so it survives...
+    expect(await t.get()).toEqual({ sponsor: "Janssen", searchTitle: "dara" });
+
+    await t.save({ searchTitle: undefined });
+    // ...while a key that IS mentioned, as cleared, reads back as unset.
+    expect(await t.get()).toEqual({ sponsor: "Janssen" });
+  });
+});
+
+describe("PreferenceWriter — a transport that throws synchronously", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it("reports it instead of leaving an unhandled rejection", async () => {
+    // A host adapter can throw rather than reject — a misconfigured client,
+    // adapter-side validation. Outside the promise chain that bypassed
+    // `onError` entirely and never assigned `inFlight`, while the class
+    // promises a failed write is reported, not thrown.
+    const onError = vi.fn();
+    const w = new PreferenceWriter(
+      {
+        get: async () => ({}),
+        save: () => {
+          throw new Error("no client");
+        },
+        reset: async () => {},
+        forget: () => {},
+      },
+      { onError },
+    );
+
+    w.save({ distance: 1 });
+    vi.advanceTimersByTime(FILTER_DEBOUNCE_MS);
+    await w.settled();
+
+    expect(onError).toHaveBeenCalledOnce();
+  });
+});
+
+describe("adapterPreferences — a save that fails", () => {
+  it("does not record the payload as if it had landed", async () => {
+    // The failed PATCH was the one meant to clear `sponsor`. Believing it
+    // succeeded, the next payload stops nulling it and it comes back.
+    const saved: Array<Record<string, unknown>> = [];
+    let fail = true;
+    const t = adapterPreferences({
+      getPreferences: async () => ({ sponsor: "Janssen" }) as never,
+      savePreferences: async (f: never) => {
+        saved.push(f as Record<string, unknown>);
+        if (fail) {
+          fail = false;
+          throw new Error("503");
+        }
+      },
+      resetPreferences: async () => {},
+    });
+
+    await t.get();
+    await expect(t.save({ searchTitle: "dara" })).rejects.toThrow("503");
+    await t.save({ searchTitle: "dara" });
+
+    expect(saved[1]).toEqual({ sponsor: null, searchTitle: "dara" });
+  });
+});

--- a/frontend/src/federation/preferences.ts
+++ b/frontend/src/federation/preferences.ts
@@ -1,0 +1,369 @@
+// Saved search filters: where they are kept, and how writes are sequenced.
+//
+// The filter panel writes on every change. Two things make that harder than
+// it looks, and CB earned both the hard way:
+//
+//   * Ticking two checkboxes in one frame issues two writes. Without
+//     sequencing they can land out of order and the server keeps the older
+//     one — the panel then shows a filter the backend does not have.
+//   * Reset has to win. A save already on the wire when Reset is pressed
+//     would otherwise complete afterwards and restore what was just cleared.
+//
+// So writes go through a queue: one request in flight, at most one write
+// waiting behind it (a newer one replaces the waiting one — nobody needs the
+// intermediate states), and a generation counter that retires anything from
+// before a Reset. Debouncing sits in front of that to keep the common case —
+// dragging a slider — down to one request.
+//
+// The transport is injected. With a `TrialStateAdapter` it is PROMOP; with no
+// adapter at all it is `localStorage`, so the dev harness and any host that
+// supplies no state still keep filters across a reload instead of losing the
+// feature.
+
+import type { TrialStateAdapter } from "./state";
+import type { FilterState } from "./types";
+
+/** Just the preference half of `TrialStateAdapter`.
+ *
+ *  Narrowed on purpose: the caller holds the adapter behind a ref (it can be
+ *  rebuilt every render), so it passes three bound functions rather than the
+ *  object — and asking for the whole interface would force a cast that claims
+ *  more than is true. */
+export type PreferenceMethods = Pick<
+  TrialStateAdapter,
+  "getPreferences" | "savePreferences" | "resetPreferences"
+>;
+
+/** How long to coalesce rapid edits. Long enough to swallow a slider drag,
+ *  short enough that a deliberate change feels saved. */
+export const FILTER_DEBOUNCE_MS = 400;
+
+export interface PreferenceTransport {
+  get(): Promise<FilterState>;
+  save(filters: FilterState): Promise<void>;
+  reset(): Promise<void>;
+  /** "You no longer know what is stored — do not delete what you did not
+   *  write." Called when a load is read but deliberately NOT applied, which
+   *  leaves the caller holding a set that is a strict subset of what is
+   *  stored. Without it the next save reads as "these are all the filters
+   *  there are" and clears the rest. */
+  forget(): void;
+}
+
+/** PROMOP, through the host-supplied state adapter.
+ *
+ *  The endpoint MERGES a partial update, and `FilterPanel` represents a
+ *  cleared control as `undefined` — which JSON drops. Left alone, clearing a
+ *  filter would leave the old value on the server and it would come back on
+ *  the next mount. So a key that was in the last payload and is gone from this
+ *  one is sent explicitly as `null`, which the merge does overwrite, and
+ *  `get` strips those nulls again so a cleared filter does not read back as a
+ *  set one.
+ */
+export function adapterPreferences(
+  state: PreferenceMethods,
+): PreferenceTransport {
+  // What the server is believed to hold. Seeded by `get`, not just by our own
+  // writes: clearing a filter that came FROM the server has to send that key
+  // as null too, and with an empty starting set the payload would simply omit
+  // it and the merge would keep the old value.
+  let lastSent: FilterState = {};
+  // The first read, so a save cannot overtake it. A reader who edits inside
+  // the debounce window on a slow connection would otherwise PATCH before
+  // `lastSent` was seeded, and the keys the server already held would survive
+  // the merge and reappear on the next mount.
+  let firstRead: Promise<unknown> | null = null;
+  //
+  // NOT handled here, on purpose: clearing a filter the HOST seeded via
+  // `initialFilters` does not persist across a remount. The host's seed is its
+  // scope for that mount and reasserts itself — which is the same reason the
+  // baseline is excluded from what gets saved at all. Representing "the reader
+  // cleared the host's value" would need a sentinel that survives reads, and
+  // that is a product decision about whose scope wins, not a defect.
+  return {
+    get: async () => {
+      const read = (async () => {
+          const stored = (await state.getPreferences()) ?? {};
+        const out: FilterState = {};
+        for (const [k, v] of Object.entries(stored)) {
+          if (v !== null && v !== undefined) (out as Record<string, unknown>)[k] = v;
+        }
+        lastSent = { ...out };
+        return out;
+      })();
+      firstRead = read;
+      return read;
+    },
+    save: async (filters) => {
+      // Serialised behind the first read — see `firstRead` above.
+      if (firstRead) await firstRead.catch(() => {});
+      const payload: Record<string, unknown> = {};
+      for (const k of Object.keys(lastSent)) payload[k] = null;
+      for (const [k, v] of Object.entries(filters)) {
+        payload[k] = v === undefined ? null : v;
+      }
+      await state.savePreferences(payload as FilterState);
+      // AFTER it resolves, like `reset`. Recording the new set for a PATCH
+      // that failed means the next payload stops nulling the keys this one
+      // was meant to clear, and they come back on the next mount.
+      lastSent = { ...filters };
+    },
+    reset: async () => {
+      await state.resetPreferences();
+      // AFTER it resolves. Clearing the seed first means a failed reset leaves
+      // us believing the server is empty, so the next save nulls nothing — and
+      // the filters the reader watched disappear come back on the next mount.
+      lastSent = {};
+    },
+    forget: () => {
+      lastSent = {};
+    },
+  };
+}
+
+/** The no-adapter fallback.
+ *
+ *  Per-browser rather than per-person, which is the honest limit of storage
+ *  the host did not give us: it is keyed by patient so two patients in one
+ *  browser do not share filters, but it does not follow the patient to
+ *  another device. Losing the feature entirely would be worse — the panel
+ *  would silently forget on every reload.
+ */
+export function localStoragePreferences(key: string): PreferenceTransport {
+  // Hashed, because `key` is the patient key — for an inline `patientInfo`
+  // that is the serialized payload itself (disease, country, labs, dates).
+  // It was a react-query cache key living in memory; putting it in a storage
+  // key would leave a patient record on disk, per browser, unexpired, for
+  // every patient ever viewed, since `reset` only removes the current one.
+  const storageKey = `exact.filters.${hashKey(key)}`;
+  const storage = (): Storage | null => {
+    try {
+      // Absent in SSR, and throws outright in a sandboxed iframe or with
+      // site data blocked. Either way the caller gets the in-memory default.
+      return typeof localStorage === "undefined" ? null : localStorage;
+    } catch {
+      return null;
+    }
+  };
+  const readRaw = (store: Storage): Record<string, unknown> => {
+    try {
+      const parsed: unknown = JSON.parse(store.getItem(storageKey) ?? "");
+      return parsed && typeof parsed === "object" ? (parsed as Record<string, unknown>) : {};
+    } catch {
+      // Absent, or a corrupt entry: a half-written value, or a shape from an
+      // older build. Treat it as "no saved filters" rather than throwing on
+      // mount and taking the list down with it.
+      return {};
+    }
+  };
+  return {
+    get: async () => {
+      const store = storage();
+      if (!store) return {};
+      const out: FilterState = {};
+      for (const [k, v] of Object.entries(readRaw(store))) {
+        // A null is a key the reader cleared, not a set one.
+        if (v !== null && v !== undefined) (out as Record<string, unknown>)[k] = v;
+      }
+      return out;
+    },
+    save: async (filters) => {
+      try {
+        const store = storage();
+        if (!store) return;
+        // Merged over what is there, with an explicit null for a cleared key
+        // — the same shape the adapter sends, and for the same reason. A
+        // wholesale overwrite would delete keys the caller never knew about,
+        // which is exactly the state a deliberately-discarded load leaves it
+        // in. `get` strips the nulls again.
+        const existing = readRaw(store);
+        for (const [k, v] of Object.entries(filters)) {
+          existing[k] = v === undefined ? null : v;
+        }
+        store.setItem(storageKey, JSON.stringify(existing));
+      } catch {
+        // Quota, or private mode. A filter that fails to persist is not a
+        // reason to break the search that is already on screen.
+      }
+    },
+    reset: async () => {
+      try {
+        storage()?.removeItem(storageKey);
+      } catch {
+        /* as above */
+      }
+    },
+    // Nothing to forget: every write already merges, so this transport never
+    // deletes a key it was not told about.
+    forget: () => {},
+  };
+}
+
+/** A short stable digest of the patient key. djb2 — not a security boundary,
+ *  just enough that a storage key is not a readable patient record. */
+function hashKey(key: string): string {
+  let h = 5381;
+  for (let i = 0; i < key.length; i += 1) h = ((h << 5) + h + key.charCodeAt(i)) | 0;
+  return (h >>> 0).toString(36);
+}
+
+/** What is waiting behind the request in flight.
+ *
+ *  Two fields rather than one slot, because a reset and a save are not
+ *  alternatives: if the reader presses Reset and then changes a filter, BOTH
+ *  have to happen and in that order. Collapsing them into one slot let the
+ *  later save overwrite the reset, so the partial update already on the server
+ *  was never cleared and stale keys survived alongside the new edit.
+ */
+interface Pending {
+  reset: boolean;
+  save: FilterState | null;
+}
+
+/** One unit of work for the queue. */
+type Write = { kind: "save"; value: FilterState } | { kind: "reset" };
+
+export interface PreferenceWriterOptions {
+  debounceMs?: number;
+  /** Reported instead of thrown: a filter that failed to save must not take
+   *  down the list that is already rendered. */
+  onError?: (error: unknown) => void;
+}
+
+/**
+ * Debounce in front, a one-deep queue behind.
+ *
+ * `save` collapses rapid edits into one request. While a request is in
+ * flight a further `save` does not start a second one — it replaces whatever
+ * was waiting, because only the newest filter state matters. `reset` jumps
+ * the debounce (it is a deliberate click, not a drag) and invalidates every
+ * write issued before it.
+ */
+export class PreferenceWriter {
+  private readonly transport: PreferenceTransport;
+  private readonly debounceMs: number;
+  private readonly onError: (error: unknown) => void;
+
+  private timer: ReturnType<typeof setTimeout> | null = null;
+  private debounced: FilterState | null = null;
+  private inFlight: Promise<void> | null = null;
+  private pending: Pending = { reset: false, save: null };
+  /** Bumped by `reset`. A write started under an older generation has its
+   *  result ignored, and a queued one is dropped. */
+  private generation = 0;
+
+  constructor(transport: PreferenceTransport, opts: PreferenceWriterOptions = {}) {
+    this.transport = transport;
+    this.debounceMs = opts.debounceMs ?? FILTER_DEBOUNCE_MS;
+    this.onError =
+      opts.onError ??
+      ((error: unknown) => {
+        // Not silence by default. A persistently failing adapter otherwise
+        // presents as "filters just don't save", with nothing anywhere to say
+        // why — and this is a best-effort write, so nothing else reports it.
+        console.warn("[exact] saved filters could not be written", error);
+      });
+  }
+
+  /** Persist these filters, eventually. */
+  save(filters: FilterState): void {
+    this.debounced = filters;
+    if (this.timer !== null) clearTimeout(this.timer);
+    this.timer = setTimeout(() => {
+      this.timer = null;
+      const value = this.debounced;
+      this.debounced = null;
+      if (value !== null) this.enqueue({ kind: "save", value });
+    }, this.debounceMs);
+  }
+
+  /** Clear them, now, and retire anything already on the wire. */
+  reset(): void {
+    this.cancelDebounce();
+    this.generation += 1;
+    this.enqueue({ kind: "reset" });
+  }
+
+  /** Send a pending debounced write immediately. For unmount: a filter
+   *  changed in the last few hundred milliseconds should not be lost because
+   *  the user navigated away. */
+  flush(): void {
+    if (this.timer === null) return;
+    // Read before cancelling: `cancelDebounce` clears the pending value too,
+    // so taking it afterwards always reads null and flush sends nothing.
+    const value = this.debounced;
+    this.cancelDebounce();
+    if (value !== null) this.enqueue({ kind: "save", value });
+  }
+
+  /** Resolves when nothing is in FLIGHT. A write still sitting in the debounce
+   *  is not covered — call `flush()` first if you need that too, which is what
+   *  a host awaiting a save before navigating wants. */
+  async settled(): Promise<void> {
+    while (this.inFlight) await this.inFlight;
+  }
+
+  private cancelDebounce(): void {
+    if (this.timer !== null) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+    this.debounced = null;
+  }
+
+  private enqueue(write: { kind: "save"; value: FilterState } | { kind: "reset" }): void {
+    if (this.inFlight) {
+      if (write.kind === "reset") {
+        // A reset supersedes a queued save — that save was issued before it.
+        this.pending.reset = true;
+        this.pending.save = null;
+      } else if (this.pending.reset) {
+        // Waits behind the reset, not instead of it.
+        this.pending.save = write.value;
+      } else {
+        // Only the latest save matters; the intermediate states do not.
+        this.pending.save = write.value;
+      }
+      return;
+    }
+    void this.run(write);
+  }
+
+  private async run(write: Write): Promise<void> {
+    const generation = this.generation;
+    let request: Promise<void>;
+    try {
+      request =
+        write.kind === "reset"
+          ? this.transport.reset()
+          : this.transport.save(write.value);
+    } catch (error: unknown) {
+      // A host adapter that throws synchronously rather than rejecting. Left
+      // outside the chain it bypassed `onError`, never assigned `inFlight`,
+      // and surfaced only as an unhandled rejection — while the class
+      // promises that a failed write is reported, not thrown.
+      this.onError(error);
+      request = Promise.resolve();
+    }
+
+    this.inFlight = request
+      .catch((error: unknown) => {
+        this.onError(error);
+      })
+      .then(() => {
+        this.inFlight = null;
+        if (this.pending.reset) {
+          this.pending.reset = false;
+          void this.run({ kind: "reset" });
+          return;
+        }
+        const save = this.pending.save;
+        this.pending.save = null;
+        if (save === null) return;
+        // Drop a save issued before a reset: sending it now would restore
+        // exactly what the reset cleared.
+        if (generation !== this.generation) return;
+        void this.run({ kind: "save", value: save });
+      });
+  }
+}

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -1,8 +1,14 @@
-// Component-suite setup: jest-dom matchers plus a DOM teardown between tests.
+// Component-suite setup: jest-dom matchers plus a teardown between tests.
 import "@testing-library/jest-dom/vitest";
 import { cleanup } from "@testing-library/react";
 import { afterEach } from "vitest";
 
 afterEach(() => {
   cleanup();
+  // Filters persist now — through the host's state adapter when there is one,
+  // and through `localStorage` when there is not (see `preferences.ts`). jsdom
+  // hands every test in a file the same storage, so without this a test that
+  // changes a filter seeds the next one's mount and the failure surfaces
+  // somewhere unrelated.
+  localStorage.clear();
 });

--- a/trials/api/trials_views.py
+++ b/trials/api/trials_views.py
@@ -135,10 +135,14 @@ class TrialsViewSet(viewsets.ReadOnlyModelViewSet):
           the response was the whole corpus presented as the patient's
           registered trials — wrong in a way nothing on screen reveals.
 
-        Fail closed until the real path lands: the favorites list will be
-        supplied by PROMOP and pushed down as a bounded `trial_ids` filter
-        (see docs/federated-ui-parity-plan.md, phase 2). A 400 naming the
-        reason beats either a 500 or a plausible wrong answer.
+        This rejection is permanent, not a placeholder. The real path has
+        since landed and is a different shape: the favorites list lives in
+        PROMOP and comes down as a bounded `trial_ids` filter, which narrows
+        inside the queryset (`_resolve_trial_ids` below; the federated UI's
+        Favorites tab uses it and never sends this type). Accepting
+        `?type=favorites` would mean accepting a search type that narrows
+        nothing — the plausible wrong answer this exists to prevent. So the
+        400 stays, and names the path that works.
 
         `not_eligible` goes too, for the same reason wearing different
         clothes: it matches no branch in `add_potential_attrs_count`, so it


### PR DESCRIPTION
Part of #419 — deliberately **not** `Closes`. This completes the last unticked
EXACT-side item of phase 2 ("filters read and written through the adapter, with
debounce and a write queue"); the `trial_ids` body filter with its ≤500 cap, the
state adapter, and the bookmark control plus Favorites tab all landed earlier.
What keeps #419 open is the host side, which lives in other repos: passing
`promopClient` in from HealthTree PHR, and the CB adapter over the in-process
promop plugin.

The filter panel forgot everything on reload. It now persists through the host's
state adapter (PROMOP), falling back to `localStorage` when the host supplies no
adapter — a panel that forgets per browser is a better answer than one that
forgets per reload.

### What is saved

Only what the reader changed. `initialFilters` is the host's mount-time scope,
and persisting it would turn one mount's scope into the reader's standing
preference — a later mount with a different scope would find the stale one
saved and lose to it. Ownership is per patient and **sticky**: a reader who
saved a 50-mile radius against a 50-km baseline owns a field whose value
matches the baseline, so re-deriving ownership from the diff each time would
drop it on the next unrelated edit and take the units with it. Reset hands the
fields back.

### The queue

Writes are debounced (400 ms), one in flight at a time, with a reset acting as a
barrier rather than as another kind of save: if the reader presses Reset and then
changes a filter, both must happen, in that order. Collapsing them into one slot
let the later save overwrite the reset.

### Merge semantics, both ways

The endpoint merges a partial update and `FilterPanel` represents a cleared
control as `undefined`, which JSON drops — so a cleared key is sent explicitly as
`null`. The `localStorage` fallback merges every write for the same reason and
stores its own null tombstones, and its storage key is hashed: the key it derives
from is the patient payload for an inline `patientInfo`, and a react-query cache
key in memory is not the same thing as a patient record on disk.

### Reviews

Two full gate passes (fresh-context subagent + `codex review`), reconciled. Ten
findings fixed, the sharpest of which was a **silent data loss**: a slow load that
was read and then deliberately discarded left the writer holding a strict subset
of what was stored, so the next save deleted saved filters the reader had never
seen. The transport is now told to forget what it read. One finding was rejected
with reasoning and a note at the call site — clearing filters on a patient switch
would break a deliberate, tested product decision.

226 frontend tests pass; `tsc -b` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
