### PR TITLE
feat(federation): the high-risk MCL criteria, one criterion at a time

### DIFF
--- a/frontend/src/dev/mock-harness.tsx
+++ b/frontend/src/dev/mock-harness.tsx
@@ -111,6 +111,17 @@ const formSettings = {
       { value: "observational", label: "Observational" },
     ],
   },
+  // Names for the high-risk MCL panel. Without them the backend-free QA
+  // surface cannot show the feature at all — and that page is the only place
+  // the marks, the colours and the 640px layout get looked at by eye.
+  highRiskMclCriteria: {
+    options: [
+      { value: "tp53_mutation", label: "TP53 mutation" },
+      { value: "del17p", label: "del(17p)" },
+      { value: "ki67_30", label: "Ki-67 >= 30%" },
+      { value: "blastoid", label: "Blastoid morphology" },
+    ],
+  },
 };
 
 // Canned trial-detail payload (mirrors `TrialDetailsSerializer`): header meta,
@@ -136,6 +147,20 @@ function detailFor(id: string) {
       "this has on their treatment and outcomes.",
     matchScore: t.matchScore,
     goodnessScore: t.goodnessScore,
+    // One of each tone, so the panel can be checked by eye: a criterion met, a
+    // confirmed absence, a gap in the data, an alternative that costs nothing,
+    // and an exclusion the patient is clear of.
+    highRiskMclCriteriaBreakdown: {
+      aggregate: "matched",
+      minCount: 1,
+      matchedCount: 1,
+      required: [
+        { code: "tp53_mutation", status: "matched" },
+        { code: "del17p", status: "unknown" },
+      ],
+      sufficientAny: [{ code: "ki67_30", status: "not_matched" }],
+      excluded: [{ code: "blastoid", status: "matched" }],
+    },
     groupNames: [
       { value: "trialEligibilityAttributes", label: "Trial Eligibility Attributes" },
     ],

--- a/frontend/src/federation/HighRiskMclPanel.test.tsx
+++ b/frontend/src/federation/HighRiskMclPanel.test.tsx
@@ -1,0 +1,229 @@
+/** The high-risk MCL panel (#4408).
+ *
+ *  Rendered through `TrialMatches` rather than in isolation, because the
+ *  panel's job is to appear for the trials that carry a breakdown and to stay
+ *  away from the ones that do not — and that decision is made on the detail
+ *  page, not inside the component.
+ */
+import { describe, expect, it } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { fakeApi, renderTrialMatches } from "../test/renderTrialMatches";
+import type { HighRiskMclCriteriaBreakdown } from "./types";
+
+const openDetail = async (api: ReturnType<typeof fakeApi>) => {
+  await waitFor(() => expect(api.listRequests().length).toBe(1));
+  const cards = await screen.findAllByRole("button", { name: "View Trial" });
+  await userEvent.click(cards[0]);
+  await screen.findByText("Back to all trials");
+};
+
+const breakdown = (
+  overrides: Partial<HighRiskMclCriteriaBreakdown> = {},
+): HighRiskMclCriteriaBreakdown => ({
+  aggregate: "matched",
+  minCount: 1,
+  matchedCount: 1,
+  required: [
+    { code: "tp53_mutation", status: "matched" },
+    { code: "del17p", status: "not_matched" },
+  ],
+  excluded: [],
+  sufficientAny: [],
+  ...overrides,
+});
+
+describe("the high-risk MCL panel", () => {
+  it("stays away from a trial that gates on no criteria", async () => {
+    const api = fakeApi();
+    renderTrialMatches(api);
+    await openDetail(api);
+    expect(screen.queryByText("High-Risk MCL Criteria")).toBeNull();
+    // …and asks for no option catalog it has nothing to label with.
+    expect(api.requests.some((r) => r.url.includes("form-settings"))).toBe(false);
+  });
+
+  it("names each criterion from the catalog, not from its code", async () => {
+    const api = fakeApi();
+    api.setDetail({ highRiskMclCriteriaBreakdown: breakdown() });
+    renderTrialMatches(api);
+    await openDetail(api);
+
+    await screen.findByText("High-Risk MCL Criteria");
+    await screen.findByText("TP53 mutation");
+    await screen.findByText("del(17p)");
+    // The code itself is an identifier, and never the label.
+    expect(screen.queryByText("tp53_mutation")).toBeNull();
+  });
+
+  it("says how many of the required criteria are needed, and how many are met", async () => {
+    // The aggregate verdict alone cannot separate "1 of 3" from "3 of 3",
+    // and to a reader deciding whether to call, those are different trials.
+    const api = fakeApi();
+    api.setDetail({
+      highRiskMclCriteriaBreakdown: breakdown({ minCount: 2, matchedCount: 1, aggregate: "not_matched" }),
+    });
+    renderTrialMatches(api);
+    await openDetail(api);
+
+    await screen.findByText("Requires at least 2 of these — you have 1");
+  });
+
+  it("reads an excluded criterion the way the reader means it, not the way the server reports it", async () => {
+    // The server reports in eligibility terms, so on an EXCLUDED criterion
+    // `matched` means "confirmed absent, good" and `not_matched` means
+    // "present, ruled out". Printing the raw status word here would tell the
+    // reader the exact opposite of the truth.
+    const api = fakeApi();
+    api.setDetail({
+      highRiskMclCriteriaBreakdown: breakdown({
+        required: [],
+        excluded: [
+          { code: "blastoid", status: "matched" },
+          { code: "ki67_30", status: "not_matched" },
+        ],
+      }),
+    });
+    renderTrialMatches(api);
+    await openDetail(api);
+
+    const clear = (await screen.findByText("Blastoid morphology")).closest("li");
+    expect(clear).toHaveTextContent("you are clear of this");
+    const rulesOut = screen.getByText("Ki-67 >= 30%").closest("li");
+    expect(rulesOut).toHaveTextContent("you have this — it rules this trial out");
+  });
+
+  it("says a missing value is unknown rather than absent", async () => {
+    const api = fakeApi();
+    api.setDetail({
+      highRiskMclCriteriaBreakdown: breakdown({
+        required: [{ code: "tp53_mutation", status: "unknown" }],
+        aggregate: "unknown",
+      }),
+    });
+    renderTrialMatches(api);
+    await openDetail(api);
+
+    const row = (await screen.findByText("TP53 mutation")).closest("li");
+    expect(row).toHaveTextContent("not known from your data");
+    await screen.findByText(/data this rule needs is missing/);
+  });
+
+  it("does not treat an unmet alternative as a failure", async () => {
+    // Any one of them qualifies, so the others being absent costs nothing.
+    // Marking them in red put two failure marks under a heading saying exactly
+    // that, next to a verdict saying the patient qualifies.
+    const api = fakeApi();
+    api.setDetail({
+      highRiskMclCriteriaBreakdown: breakdown({
+        required: [],
+        sufficientAny: [
+          { code: "tp53_mutation", status: "matched" },
+          { code: "ki67_30", status: "not_matched" },
+        ],
+      }),
+    });
+    renderTrialMatches(api);
+    await openDetail(api);
+
+    const unmet = (await screen.findByText("Ki-67 >= 30%")).closest("li");
+    expect(unmet).toHaveTextContent("you do not have this");
+    expect(unmet?.className).toContain("is-neutral");
+    expect(unmet?.className).not.toContain("is-bad");
+  });
+
+  it("separates a confirmed absence from a gap in the data", async () => {
+    // #4399 keeps these apart on the server, and a patient who was sequenced
+    // and is negative should not read the same sentence as one who was never
+    // tested.
+    const api = fakeApi();
+    api.setDetail({
+      highRiskMclCriteriaBreakdown: breakdown({
+        required: [
+          { code: "tp53_mutation", status: "not_matched" },
+          { code: "del17p", status: "unknown" },
+        ],
+      }),
+    });
+    renderTrialMatches(api);
+    await openDetail(api);
+
+    expect((await screen.findByText("TP53 mutation")).closest("li")).toHaveTextContent(
+      "you do not have this",
+    );
+    expect(screen.getByText("del(17p)").closest("li")).toHaveTextContent(
+      "not known from your data",
+    );
+  });
+
+  it("presents the two inclusion lists as alternatives, because the server ORs them", async () => {
+    // With both lists populated the required block is one route of two. Headed
+    // "Requires", it told a patient who qualified through the alternatives
+    // that they had failed something the server never held them to.
+    const api = fakeApi();
+    api.setDetail({
+      highRiskMclCriteriaBreakdown: breakdown({
+        minCount: 2,
+        matchedCount: 1,
+        sufficientAny: [{ code: "ki67_30", status: "matched" }],
+      }),
+    });
+    renderTrialMatches(api);
+    await openDetail(api);
+
+    await screen.findByText("Either — at least 2 of these — you have 1");
+    await screen.findByText("Or — any one of these on its own");
+  });
+
+  it("renders a breakdown that arrives without one of the lists", async () => {
+    // A remote deployed ahead of the API, a gateway that prunes nulls, a
+    // hand-rolled host fixture. There is no ErrorBoundary above this, so a
+    // throw here takes the whole federated tree down and leaves the host with
+    // a blank trials area rather than a missing panel.
+    const api = fakeApi();
+    api.setDetail({
+      highRiskMclCriteriaBreakdown: {
+        aggregate: "matched",
+        required: [{ code: "tp53_mutation", status: "matched" }],
+      } as never,
+    });
+    renderTrialMatches(api);
+    await openDetail(api);
+
+    await screen.findByText("High-Risk MCL Criteria");
+    await screen.findByText("TP53 mutation");
+  });
+
+  it("waits for the catalog rather than showing raw codes first", async () => {
+    // The catalog fetch is gated on the breakdown having arrived, so it always
+    // resolves a round-trip later than the panel could paint. Without the wait
+    // the code fallback would be the NORMAL first frame and every reader would
+    // watch `tp53_mutation` turn into "TP53 mutation".
+    const api = fakeApi();
+    api.holdFormSettings();
+    api.setDetail({ highRiskMclCriteriaBreakdown: breakdown() });
+    renderTrialMatches(api);
+    await openDetail(api);
+
+    // The page itself is there; the panel is not, and neither is a raw code.
+    await screen.findByText("Trial Eligibility Attributes");
+    expect(screen.queryByText("High-Risk MCL Criteria")).toBeNull();
+    expect(screen.queryByText("tp53_mutation")).toBeNull();
+  });
+
+  it("falls back to the code when the catalog does not name it", async () => {
+    // Better an identifier than a label the catalog never wrote: these are
+    // clinical names, and inventing one by title-casing a code is a mislabel.
+    const api = fakeApi();
+    api.setDetail({
+      highRiskMclCriteriaBreakdown: breakdown({
+        required: [{ code: "some_new_code", status: "matched" }],
+      }),
+    });
+    renderTrialMatches(api);
+    await openDetail(api);
+
+    await screen.findByText("some_new_code");
+  });
+});

--- a/frontend/src/federation/HighRiskMclPanel.tsx
+++ b/frontend/src/federation/HighRiskMclPanel.tsx
@@ -1,0 +1,159 @@
+/** Per-criterion explainability for the high-risk MCL attribute (#4408).
+ *
+ *  EXACT has returned `highRiskMclCriteriaBreakdown` from `retrieve` since
+ *  #4408 and the remote dropped it on the floor. The eligibility table above
+ *  can only say "High Risk Mcl Criteria: matched" — one verdict over a rule
+ *  that is really "at least N of these, none of those, or any one of these".
+ *  For a reader deciding whether a trial is worth a phone call, WHICH
+ *  criterion they meet is the whole question.
+ */
+import type { HighRiskMclCriteriaBreakdown, MclCriterion } from "./types";
+import { CheckIcon } from "./bits";
+
+/** Which of the trial's three lists a criterion sits in. The same status means
+ *  a different thing in each, so nothing here is shared between them. */
+type ListKind = "required" | "sufficient" | "excluded";
+
+/** What a criterion's status means to the reader.
+ *
+ *  The server reports every criterion in ELIGIBILITY terms, so on an EXCLUDED
+ *  criterion `matched` means "confirmed absent, good" and `not_matched` means
+ *  "present, which rules you out". Printing the raw status word next to an
+ *  excluded criterion would tell the reader the exact opposite of the truth.
+ *
+ *  In a SUFFICIENT list an unmet criterion is not a failure — any one of them
+ *  qualifies on its own, so the others being absent costs nothing. Marking
+ *  them in red put two failure marks under a heading saying exactly that,
+ *  beside a verdict saying the patient qualifies.
+ *
+ *  And "you do not have this" is not "not known from your data": #4399 went to
+ *  some trouble to keep confirmed-absent apart from never-entered, and a
+ *  patient who was sequenced and is TP53-negative should not read the same
+ *  sentence as one who was never tested.
+ */
+function phrasing(
+  status: MclCriterion["status"],
+  kind: ListKind,
+): { text: string; tone: "good" | "bad" | "neutral" | "unknown" } {
+  if (status === "unknown") {
+    return { text: "not known from your data", tone: "unknown" };
+  }
+  if (kind === "excluded") {
+    return status === "matched"
+      ? { text: "you are clear of this", tone: "good" }
+      : { text: "you have this — it rules this trial out", tone: "bad" };
+  }
+  if (status === "matched") return { text: "you have this", tone: "good" };
+  return { text: "you do not have this", tone: kind === "sufficient" ? "neutral" : "bad" };
+}
+
+const MARK: Record<"good" | "bad" | "neutral" | "unknown", string> = {
+  good: "",
+  bad: "\u2715",
+  neutral: "\u2013",
+  unknown: "?",
+};
+
+function CriterionList({
+  heading,
+  codes,
+  kind,
+  titleOf,
+}: {
+  heading: string;
+  codes: MclCriterion[];
+  kind: ListKind;
+  titleOf: (code: string) => string;
+}) {
+  if (!codes.length) return null;
+  return (
+    <div className="exact-mcl__group">
+      <h3 className="exact-mcl__group-title">{heading}</h3>
+      <ul className="exact-mcl__list">
+        {codes.map((c) => {
+          const { text, tone } = phrasing(c.status, kind);
+          return (
+            <li key={c.code} className={`exact-mcl__item is-${tone}`}>
+              <span className="exact-mcl__mark" aria-hidden="true">
+                {tone === "good" ? <CheckIcon /> : MARK[tone]}
+              </span>
+              <span className="exact-mcl__name">{titleOf(c.code)}</span>
+              <span className="exact-mcl__status">{text}</span>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}
+
+const VERDICT: Record<string, string> = {
+  matched: "You meet this trial's high-risk criteria.",
+  not_matched: "You do not meet this trial's high-risk criteria.",
+  unknown: "Some of the data this rule needs is missing from your profile.",
+};
+
+export function HighRiskMclPanel({
+  breakdown,
+  titleOf,
+}: {
+  breakdown: HighRiskMclCriteriaBreakdown;
+  titleOf: (code: string) => string;
+}) {
+  // `?? []` on all three: a breakdown that arrives without one of them — a
+  // remote deployed ahead of the API, a gateway that prunes nulls, a
+  // hand-rolled host fixture — would otherwise throw inside the render, and
+  // with no ErrorBoundary above it React unmounts the whole federated tree.
+  // The host is then left with a blank trials area, not a missing panel.
+  const required = breakdown.required ?? [];
+  const excluded = breakdown.excluded ?? [];
+  const sufficientAny = breakdown.sufficientAny ?? [];
+  const minCount = breakdown.minCount ?? 1;
+  const matchedCount = breakdown.matchedCount ?? 0;
+  const verdict = VERDICT[breakdown.aggregate];
+  // The server ORs the two inclusion rules (`inclusion_rules` in
+  // `_match_criteria_count`), so with both lists populated the required block
+  // is one route of two, not a requirement. Heading it "Requires" told a
+  // patient who qualified via the alternatives that they had failed something.
+  const eitherOr = required.length > 0 && sufficientAny.length > 0;
+  const count =
+    required.length > 1 ? `at least ${minCount} of these — you have ${matchedCount}` : "";
+
+  return (
+    <section className="exact-panel exact-mcl">
+      <h2 className="exact-panel__title">High-Risk MCL Criteria</h2>
+      {verdict ? (
+        <p className={`exact-mcl__verdict is-${breakdown.aggregate}`}>{verdict}</p>
+      ) : null}
+      <CriterionList
+        // The count is part of the rule, not decoration: "1 of 3" and "3 of 3"
+        // are different trials to a reader, and the aggregate verdict alone
+        // cannot tell them apart.
+        heading={
+          eitherOr
+            ? count
+              ? `Either — ${count}`
+              : "Either"
+            : count
+              ? `Requires ${count}`
+              : "Requires"
+        }
+        codes={required}
+        kind="required"
+        titleOf={titleOf}
+      />
+      <CriterionList
+        heading={eitherOr ? "Or — any one of these on its own" : "Any one of these qualifies on its own"}
+        codes={sufficientAny}
+        kind="sufficient"
+        titleOf={titleOf}
+      />
+      <CriterionList
+        heading="Rules the trial out"
+        codes={excluded}
+        kind="excluded"
+        titleOf={titleOf}
+      />
+    </section>
+  );
+}

--- a/frontend/src/federation/TrialDetailPage.tsx
+++ b/frontend/src/federation/TrialDetailPage.tsx
@@ -14,9 +14,10 @@
 //
 // Still out of scope: editing a patient value (CB's pencil controls, phase 4)
 // and CB's share / Standard-of-Care buttons.
-import { useEffect } from "react";
+import { useEffect, useMemo } from "react";
 
 import {
+  CheckIcon,
   FavoriteToggle,
   Field,
   FieldTooltip,
@@ -25,7 +26,8 @@ import {
   asText,
   renderMd,
 } from "./bits";
-import { useTrialDetail } from "./hooks";
+import { HighRiskMclPanel } from "./HighRiskMclPanel";
+import { useFormSettings, useTrialDetail } from "./hooks";
 import { injectStyles } from "./injectStyles";
 import { FIELD_TOOLTIPS } from "./tooltips";
 import type { AdvancedStatus } from "./state";
@@ -98,22 +100,6 @@ const BackArrow = () => (
   </svg>
 );
 
-const CheckIcon = () => (
-  <svg
-    width="16"
-    height="16"
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="2"
-    strokeLinecap="round"
-    strokeLinejoin="round"
-    aria-hidden="true"
-  >
-    <path d="M21.801 10A10 10 0 1 1 17 3.335" />
-    <path d="m9 11 3 3L22 4" />
-  </svg>
-);
 
 /** Resolve a field value to its display label, honouring select options.
  *  Option values may be numbers while the field value arrives as a string
@@ -326,6 +312,33 @@ export function TrialDetailPage({
   const query = useTrialDetail({ apiClient, trialId, patientInfo, personId, filters });
   const data = query.data;
 
+  // Only MCL trials that gate on the criteria carry one; for everything else
+  // the server sends null and none of the below runs.
+  const mcl = data?.highRiskMclCriteriaBreakdown ?? null;
+  const formSettings = useFormSettings(
+    apiClient,
+    typeof patientInfo?.disease === "string" ? patientInfo.disease : undefined,
+    mcl != null,
+  );
+  const mclTitle = useMemo(() => {
+    const byCode = new Map<string, string>();
+    for (const o of formSettings.data?.highRiskMclCriteria?.options ?? []) {
+      byCode.set(String(o.value), o.label);
+    }
+    // Falls back to the CODE, not to a prettified version of it. `tp53_mutation`
+    // is at least honest about being an identifier; "Tp53 Mutation" reads as a
+    // clinical label the catalog never wrote, and the catalog is the one place
+    // allowed to name these.
+    return (code: string) => byCode.get(code) ?? code;
+  }, [formSettings.data]);
+  // Held until the catalog answers — success or failure. The fetch is gated on
+  // the breakdown having already arrived, so without this the code fallback is
+  // the NORMAL first paint rather than the edge case it was written for: every
+  // reader would see `tp53_mutation` for one round-trip before it became
+  // "TP53 mutation". A failed fetch still settles, so the fallback keeps its
+  // intended meaning — the catalog does not name this code.
+  const mclNamesSettled = formSettings.isFetched;
+
   const eligibility = data?.details?.trialEligibilityAttributes ?? [];
   const summary = data
     ? data.laySummary || data.briefSummary || data.participationCriteria || ""
@@ -451,6 +464,10 @@ export function TrialDetailPage({
               )}
             </section>
           </div>
+
+          {mcl && mclNamesSettled ? (
+            <HighRiskMclPanel breakdown={mcl} titleOf={mclTitle} />
+          ) : null}
 
           {canRegister ? (
             <RegisterInterest

--- a/frontend/src/federation/bits.tsx
+++ b/frontend/src/federation/bits.tsx
@@ -240,3 +240,25 @@ export function FavoriteToggle({
     </button>
   );
 }
+
+/** The tick the eligibility rows and the high-risk MCL panel share — two ticks
+ *  that differ read as two meanings. Here rather than in `TrialDetailPage`
+ *  because the panel imports it and that page imports the panel: a module
+ *  cycle that survives today only because nothing dereferences it at
+ *  module-evaluation time. */
+export const CheckIcon = () => (
+  <svg
+    width="16"
+    height="16"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+  >
+    <path d="M21.801 10A10 10 0 1 1 17 3.335" />
+    <path d="m9 11 3 3L22 4" />
+  </svg>
+);

--- a/frontend/src/federation/exact.css
+++ b/frontend/src/federation/exact.css
@@ -416,6 +416,93 @@
   color: var(--exact-color-text-tertiary);
 }
 
+/* High-risk MCL criteria panel (#4408) */
+.exact-root .exact-mcl {
+  margin-top: 16px;
+}
+
+.exact-root .exact-mcl__verdict {
+  margin: 0 0 12px;
+  font-weight: 600;
+}
+
+.exact-root .exact-mcl__verdict.is-matched {
+  color: var(--exact-color-success-700);
+}
+
+.exact-root .exact-mcl__verdict.is-not_matched {
+  color: var(--exact-color-error-700);
+}
+
+.exact-root .exact-mcl__verdict.is-unknown {
+  color: var(--exact-color-warning-700);
+}
+
+.exact-root .exact-mcl__group + .exact-mcl__group {
+  margin-top: 14px;
+}
+
+.exact-root .exact-mcl__group-title {
+  margin: 0 0 6px;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--exact-color-text-muted);
+}
+
+.exact-root .exact-mcl__list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.exact-root .exact-mcl__item {
+  display: grid;
+  grid-template-columns: 20px 1fr auto;
+  align-items: baseline;
+  gap: 8px;
+  padding: 4px 0;
+}
+
+.exact-root .exact-mcl__mark {
+  display: inline-flex;
+  justify-content: center;
+}
+
+.exact-root .exact-mcl__item.is-good .exact-mcl__mark {
+  color: var(--exact-color-eligible);
+}
+
+.exact-root .exact-mcl__item.is-bad .exact-mcl__mark {
+  color: var(--exact-color-not-eligible);
+}
+
+.exact-root .exact-mcl__item.is-unknown .exact-mcl__mark {
+  color: var(--exact-color-potential);
+}
+
+/* An unmet criterion in the "any one of these" group is not a failure — the
+   others cover it — so it is marked neutrally rather than in red. */
+.exact-root .exact-mcl__item.is-neutral .exact-mcl__mark {
+  color: var(--exact-color-text-tertiary);
+}
+
+.exact-root .exact-mcl__status {
+  font-size: 0.75rem;
+  /* Never the only carrier of the verdict: the mark beside it is coloured,
+     and colour alone is not a message. */
+  color: var(--exact-color-text-tertiary);
+}
+
+@media (max-width: 640px) {
+  .exact-root .exact-mcl__item {
+    grid-template-columns: 20px 1fr;
+  }
+
+  .exact-root .exact-mcl__status {
+    grid-column: 2;
+  }
+}
+
 /* Field tooltip: "?" icon + floating text box on hover/focus */
 .exact-root .exact-tooltip__wrap {
   position: relative;

--- a/frontend/src/federation/hooks.ts
+++ b/frontend/src/federation/hooks.ts
@@ -225,11 +225,17 @@ export function useTrialDetail({
 export function useFormSettings(
   apiClient: AxiosInstance,
   diseaseCode?: string,
+  // Off by default at the call site's discretion: the only caller today wants
+  // the option TITLES for a panel that most trials never render, and fetching
+  // a catalog for every detail view to label nothing would be a request per
+  // trial for no reader's benefit.
+  enabled = true,
 ): UseQueryResult<Record<string, { options: { value: string; label: string }[] }>> {
   return useQuery({
     queryKey: ["exact-form-settings", diseaseCode ?? null],
     queryFn: () => fetchFormSettings(apiClient, diseaseCode),
     staleTime: 5 * 60_000,
+    enabled,
   });
 }
 

--- a/frontend/src/federation/types.ts
+++ b/frontend/src/federation/types.ts
@@ -125,6 +125,32 @@ export interface TrialDetailField {
   [key: string]: unknown;
 }
 
+/** One high-risk MCL criterion, reported in ELIGIBILITY terms: on an
+ *  EXCLUDED criterion `matched` means the patient is confirmed clear of it and
+ *  `not_matched` means they have it and are ruled out — the inverse of an
+ *  inclusion criterion. `unknown` means the source data is missing either way. */
+export interface MclCriterion {
+  code: string;
+  status: "matched" | "not_matched" | "unknown";
+}
+
+/** `highRiskMclCriteriaBreakdown` from `GET /trials/{id}/` — per-criterion
+ *  explainability for an attribute whose rule is really "at least N of these,
+ *  none of those, or any one of these" (#4408). Absent, or null, for a trial
+ *  that gates on no high-risk criteria and for a request with no patient.
+ *
+ *  Codes only: titles live in the `highRiskMclCriteria` options from
+ *  `/form-settings/`, so the catalog stays the one place that names them. */
+export interface HighRiskMclCriteriaBreakdown {
+  aggregate: "matched" | "not_matched" | "unknown" | "not_evaluated" | string;
+  /** How many of `required` are needed. At least 1. */
+  minCount: number;
+  matchedCount: number;
+  required: MclCriterion[];
+  excluded: MclCriterion[];
+  sufficientAny: MclCriterion[];
+}
+
 export interface GroupName {
   value: string;
   label: string;
@@ -160,6 +186,9 @@ export interface TrialDetailResponse {
   matchingType?: MatchingType | null;
   details: Record<string, TrialDetailField[]>;
   groupNames: GroupName[];
+  /** Detail view only, and only with a patient. Null for a trial that gates on
+   *  no high-risk MCL criteria — which is every trial outside that disease. */
+  highRiskMclCriteriaBreakdown?: HighRiskMclCriteriaBreakdown | null;
   [key: string]: unknown;
 }
 

--- a/frontend/src/test/renderTrialMatches.tsx
+++ b/frontend/src/test/renderTrialMatches.tsx
@@ -43,6 +43,9 @@ export interface FakeApi {
   failNextWith: (status: number) => void;
   /** Replace what the list returns from now on. */
   setResponse: (response: Partial<TrialsResponse>) => void;
+  /** Leave `/form-settings/` unanswered, to see what renders while the option
+   *  catalog is still in flight. */
+  holdFormSettings: () => void;
   /** Override fields on every trial's detail response from now on.
    *  Whatever is NOT overridden follows the trial actually asked for — so
    *  the id and title track the row that was clicked unless a test pins
@@ -119,6 +122,17 @@ const FORM_SETTINGS = {
   phases: { options: [{ value: "", label: "ALL" }, { value: "PHASE3", label: "III" }] },
   register: { options: [{ value: "", label: "ALL" }] },
   allCountries: { options: [{ value: "", label: "Unknown" }] },
+  // Titles for the high-risk MCL panel. Deliberately NOT the codes with the
+  // underscores swapped out: the panel must be shown taking them from the
+  // catalog, not deriving them.
+  highRiskMclCriteria: {
+    options: [
+      { value: "tp53_mutation", label: "TP53 mutation" },
+      { value: "del17p", label: "del(17p)" },
+      { value: "blastoid", label: "Blastoid morphology" },
+      { value: "ki67_30", label: "Ki-67 >= 30%" },
+    ],
+  },
 };
 
 export function fakeApi(initial: Partial<TrialsResponse> = {}): FakeApi {
@@ -133,10 +147,17 @@ export function fakeApi(initial: Partial<TrialsResponse> = {}): FakeApi {
     ...initial,
   };
   let failWith: number | null = null;
+  let holdSettings = false;
   let detailOverrides: Partial<TrialDetailResponse> = {};
 
   const respond = (url: string, body?: unknown) => {
-    if (url.includes("form-settings")) return Promise.resolve({ data: FORM_SETTINGS });
+    if (url.includes("form-settings")) {
+      return holdSettings
+        ? new Promise(() => {
+            /* never settles */
+          })
+        : Promise.resolve({ data: FORM_SETTINGS });
+    }
     if (failWith != null) {
       const status = failWith;
       failWith = null;
@@ -204,6 +225,9 @@ export function fakeApi(initial: Partial<TrialsResponse> = {}): FakeApi {
     },
     setDetail: (next: Partial<TrialDetailResponse>) => {
       detailOverrides = { ...detailOverrides, ...next };
+    },
+    holdFormSettings: () => {
+      holdSettings = true;
     },
   };
 }

--- a/tests/views/test_trial_detail_match_post.py
+++ b/tests/views/test_trial_detail_match_post.py
@@ -68,3 +68,56 @@ class TestTrialDetailMatchPost:
         assert response.data['matchScore'] is not None, (
             'matchScore must be annotated on the detail path, not null'
         )
+
+    def test_response_carries_the_high_risk_mcl_breakdown(self, authed_client):
+        """The federated detail page renders a panel from this key, so its
+        shape is a contract now rather than an internal detail.
+
+        Per-criterion status is reported in ELIGIBILITY terms — on an excluded
+        criterion, confirmed absence is `matched`. The panel inverts the
+        phrasing for the reader; what must not drift is which side reports
+        which.
+        """
+        trial = TrialFactory(
+            disease='mantle cell lymphoma',
+            high_risk_mcl_criteria_required=['tp53_mutation', 'del17p'],
+            high_risk_mcl_criteria_excluded=['blastoid'],
+            high_risk_mcl_criteria_min_count=1,
+        )
+        response = authed_client.post(
+            f'/trials/{trial.id}/match/',
+            {'patient_info': {
+                'disease': 'mantle cell lymphoma',
+                'molecular_markers': 'tp53Mutation',
+                'morphologic_variant': 'classic',
+            }},
+            format='json',
+        )
+        assert response.status_code == 200
+        breakdown = response.data['highRiskMclCriteriaBreakdown']
+        assert breakdown['aggregate'] == 'matched'
+        assert breakdown['minCount'] == 1
+        assert breakdown['matchedCount'] == 1
+        assert breakdown['required'] == [
+            {'code': 'tp53_mutation', 'status': 'matched'},
+            # `unknown`, not `not_matched`: this payload carries no
+            # cytogenetics at all, so del(17p) was never ruled out — it was
+            # never looked at. The panel says so rather than showing an
+            # absence the patient could not have known about.
+            {'code': 'del17p', 'status': 'unknown'},
+        ]
+        # Clear of the exclusion, which is the good outcome and reads `matched`.
+        assert breakdown['excluded'] == [{'code': 'blastoid', 'status': 'matched'}]
+        assert breakdown['sufficientAny'] == []
+
+    def test_no_breakdown_for_a_trial_that_gates_on_no_criteria(self, authed_client):
+        """Null, not an empty skeleton — the panel keys off its absence, and an
+        empty one would render a heading over nothing for every MM trial."""
+        trial = TrialFactory(disease='Multiple Myeloma')
+        response = authed_client.post(
+            f'/trials/{trial.id}/match/',
+            {'patient_info': {'disease': 'multiple myeloma'}},
+            format='json',
+        )
+        assert response.status_code == 200
+        assert response.data['highRiskMclCriteriaBreakdown'] is None


### PR DESCRIPTION
Part of #420 — one more item of phase 3, not the whole phase. Map view, CSV
export, knowledge-graph UI and suitability weights remain.

EXACT has returned `highRiskMclCriteriaBreakdown` from `retrieve` since #4408
and the remote dropped it on the floor. The eligibility table above could only
say "High Risk Mcl Criteria: matched" — one verdict over a rule that is really
"at least N of these, none of those, or any one of these". For a reader
deciding whether a trial is worth a phone call, **which** criterion they meet is
the whole question.

### The part that carries the risk: phrasing is per list

The server reports every criterion in **eligibility** terms. On an *excluded*
criterion `matched` means "confirmed absent, good" and `not_matched` means
"present, ruled out" — so printing the status word there would tell the reader
the exact opposite of the truth. The excluded list says "you are clear of this"
and "you have this — it rules this trial out" instead.

Three more distinctions the wording has to keep:

* **"you do not have this" ≠ "not known from your data".** #4399 keeps
  confirmed-absent apart from never-entered on the server; a patient who was
  sequenced and is TP53-negative should not read the same sentence as one who
  was never tested.
* **An unmet alternative is not a failure.** Any one of `sufficientAny`
  qualifies, so the others cost nothing — marking them red put two failure
  marks under a heading saying exactly that, beside a verdict saying the
  patient qualifies. They are neutral now.
* **The server ORs the two inclusion rules.** With both lists populated the
  required block is one route of two; headed "Requires" it told a patient who
  qualified via the alternatives that they had failed something. It reads
  "Either — …" / "Or — any one of these on its own".

### Other decisions

Titles come from the `highRiskMclCriteria` options in `/form-settings/`, so the
catalog stays the one place that names these criteria. The panel waits for that
answer instead of painting codes first, and an unknown code falls back to the
code itself rather than a title-cased version — these are clinical names, and
inventing one is a mislabel. The catalog is fetched only when a breakdown is
present; most trials never render this panel.

The three lists are read through `?? []`: there is no `ErrorBoundary` above the
remote, so a throw here blanks the host's whole trials area rather than one
panel.

### Reviews

Full gate (fresh-context subagent + `codex review`), reconciled. Seven findings,
all fixed — the medium one was the missing guards above; the rest were the
phrasing distinctions, a module cycle (`CheckIcon` now lives in `bits.tsx`), and
the dev harness lacking the fixtures to render the feature at all, which matters
because `mock-preview.html` is the only place the marks, colours and 640px
layout get looked at by eye.

971 backend tests pass; 237 frontend tests pass; `tsc -b` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
