### PR TITLE
feat(federation): the filter panel, saved where the patient left it (#419)

### DIFF
--- a/frontend/src/federation/TrialMatches.test.tsx
+++ b/frontend/src/federation/TrialMatches.test.tsx
@@ -403,7 +403,20 @@ describe("a host's initialFilters.trialType", () => {
       expect(screen.getByRole("button", { name: /Filters \(2\)/ })).toBeInTheDocument(),
     );
 
+    // The whole panel belongs to the patient it was filled in for, not just
+    // the trial type: a new patient gets the host's scope back, and (with a
+    // state adapter) their own saved filters over it. So nothing of the
+    // previous reader's is counted here.
     view.rerender(ui({ disease: "multiple myeloma", ref: "B" }));
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /Filter Results/ })).toBeInTheDocument(),
+    );
+
+    // Re-armed under the new patient, so Reset has something to clear.
+    await userEvent.selectOptions(
+      await screen.findByLabelText("Recruitment status"),
+      "RECRUITING",
+    );
     await waitFor(() =>
       expect(screen.getByRole("button", { name: /Filters \(1\)/ })).toBeInTheDocument(),
     );
@@ -1682,5 +1695,1126 @@ describe("the controls on the detail page", () => {
 
     await screen.findByText(/Nothing is sent to the trial's coordinators/);
     expect(screen.queryByText(/coordinator will reach out/i)).toBeNull();
+  });
+});
+
+describe("the filters the patient saved", () => {
+  const openPanel = async () =>
+    userEvent.click(await screen.findByRole("button", { name: /Filter/ }));
+
+  it("applies them to the first search, without a second request", async () => {
+    // Seeded into state they would arrive a render too late: a render-phase
+    // `setState` re-runs the component but does not un-send what the query
+    // observer was already told to fetch. So the first request went out
+    // with the defaults and a second followed — two matcher runs, and a
+    // flash of results nobody asked for.
+    const api = fakeApi();
+    const state = fakeState({ preferences: { phase: "PHASE3", sponsor: "Acme" } });
+    renderTrialMatches(api, { state: state.adapter });
+
+    await waitFor(() => expect(listed(api).length).toBe(1));
+    expect(listed(api)[0].params.phase).toBe("PHASE3");
+    expect(listed(api)[0].params.sponsor).toBe("Acme");
+    await new Promise((r) => setTimeout(r, 60));
+    expect(listed(api).length).toBe(1);
+  });
+
+  it("counts them on the badge, because they are the reader's own", async () => {
+    const api = fakeApi();
+    renderTrialMatches(api, {
+      state: fakeState({ preferences: { phase: "PHASE3" } }).adapter,
+    });
+    await screen.findByRole("button", { name: /Filters \(1\)/ });
+  });
+
+  it("shows them in the panel", async () => {
+    const api = fakeApi();
+    renderTrialMatches(api, {
+      state: fakeState({ preferences: { searchTitle: "myeloma" } }).adapter,
+    });
+    await waitFor(() => expect(listed(api).length).toBe(1));
+    await openPanel();
+    expect(await screen.findByLabelText("Title")).toHaveValue("myeloma");
+  });
+
+  it("asks for nothing when the host gave no adapter", async () => {
+    const api = fakeApi();
+    renderTrialMatches(api);
+    await waitFor(() => expect(listed(api).length).toBe(1));
+    expect(listed(api)[0].params.phase).toBeUndefined();
+  });
+
+  it("saves a change, once, after the typing stops", async () => {
+    // Every keystroke is a network write otherwise: "myeloma" is seven
+    // PATCHes.
+    const api = fakeApi();
+    const state = fakeState();
+    renderTrialMatches(api, { state: state.adapter });
+    await waitFor(() => expect(listed(api).length).toBe(1));
+    await openPanel();
+
+    await userEvent.type(await screen.findByLabelText("Title"), "mm");
+    await waitFor(() => expect(state.preferences()).toEqual({ searchTitle: "mm" }), {
+      timeout: 2000,
+    });
+    expect(state.adapter.savePreferences).toHaveBeenCalledTimes(1);
+  });
+
+  it("saves only the fields the panel owns", async () => {
+    // `type` and `sort` belong to other controls, and `country` is derived
+    // from the patient — a stored copy of a fact that can change.
+    const api = fakeApi();
+    const state = fakeState();
+    renderTrialMatches(api, {
+      state: state.adapter,
+      patientInfo: { disease: "mm", country: "US" },
+      initialFilters: { type: "potential" },
+    });
+    await waitFor(() => expect(listed(api).length).toBe(1));
+    await openPanel();
+
+    await userEvent.selectOptions(
+      await screen.findByLabelText("Recruitment status"),
+      "RECRUITING",
+    );
+    await waitFor(
+      () => expect(state.preferences()).toEqual({ recruitmentStatus: "RECRUITING" }),
+      { timeout: 2000 },
+    );
+  });
+
+  it("never has two saves in flight at once", async () => {
+    // The debounce only collapses changes inside its own window: type, wait
+    // it out, type again while that PATCH is still travelling, and two are
+    // in flight — applied in whatever order they arrive, so the older set
+    // can be the one that sticks.
+    const api = fakeApi();
+    let inFlight = 0;
+    let overlapped = false;
+    const release: (() => void)[] = [];
+    const state = fakeState({
+      overrides: {
+        savePreferences: vi.fn(() => {
+          inFlight += 1;
+          if (inFlight > 1) overlapped = true;
+          return new Promise<void>((resolve) => {
+            release.push(() => {
+              inFlight -= 1;
+              resolve();
+            });
+          });
+        }),
+      },
+    });
+    renderTrialMatches(api, { state: state.adapter });
+    await waitFor(() => expect(listed(api).length).toBe(1));
+    await openPanel();
+
+    const title = await screen.findByLabelText("Title");
+    await userEvent.type(title, "a");
+    await waitFor(() => expect(release.length).toBe(1), { timeout: 2000 });
+    await userEvent.type(title, "b");
+    // Past the debounce, so the second write is due and the only thing
+    // holding it back is the one already on the wire.
+    await new Promise((r) => setTimeout(r, 800));
+    expect(state.adapter.savePreferences).toHaveBeenCalledTimes(1);
+
+    // A third change, also while the first write is still travelling. It
+    // replaces the queued one rather than lining up behind it: within one
+    // patient a write is absolute, so the newer says everything the older
+    // would have, and sending both is a round trip for a set nobody will
+    // ever see.
+    await userEvent.type(title, "c");
+    await new Promise((r) => setTimeout(r, 800));
+
+    release[0]();
+    await waitFor(() => expect(state.adapter.savePreferences).toHaveBeenCalledTimes(2));
+    expect(overlapped).toBe(false);
+    // The second write carries the latest text, not a stale one.
+    expect(
+      (state.adapter.savePreferences as unknown as { mock: { calls: unknown[][] } }).mock
+        .calls[1][0],
+    ).toEqual({ searchTitle: "abc" });
+    release.forEach((fn) => fn());
+    await new Promise((r) => setTimeout(r, 50));
+    expect(state.adapter.savePreferences).toHaveBeenCalledTimes(2);
+    release.forEach((fn) => fn());
+  });
+
+  it("clears them through reset, not by saving an empty set", async () => {
+    const api = fakeApi();
+    const state = fakeState({ preferences: { phase: "PHASE3" } });
+    renderTrialMatches(api, { state: state.adapter });
+    await waitFor(() => expect(listed(api).length).toBe(1));
+    await openPanel();
+
+    await userEvent.click(await screen.findByRole("button", { name: "Reset filters" }));
+    await waitFor(() => expect(state.preferences()).toEqual({}));
+    expect(state.adapter.resetPreferences).toHaveBeenCalled();
+    expect(state.adapter.savePreferences).not.toHaveBeenCalled();
+  });
+
+  it("drops a save that was scheduled before the reset", async () => {
+    // It would otherwise land afterwards and put the filter it carries back.
+    const api = fakeApi();
+    const state = fakeState();
+    renderTrialMatches(api, { state: state.adapter });
+    await waitFor(() => expect(listed(api).length).toBe(1));
+    await openPanel();
+
+    await userEvent.type(await screen.findByLabelText("Title"), "mm");
+    await userEvent.click(screen.getByRole("button", { name: "Reset filters" }));
+    await new Promise((r) => setTimeout(r, 900));
+    expect(state.adapter.savePreferences).not.toHaveBeenCalled();
+    expect(state.preferences()).toEqual({});
+  });
+
+  it("sends a change the reader made just before leaving", async () => {
+    // A host unmounting the remote — a route change, a closed tab — is not
+    // the reader changing their mind.
+    const api = fakeApi();
+    const state = fakeState();
+    const view = renderTrialMatches(api, { state: state.adapter });
+    await waitFor(() => expect(listed(api).length).toBe(1));
+    await openPanel();
+
+    await userEvent.type(await screen.findByLabelText("Title"), "mm");
+    view.unmount();
+    await waitFor(() => expect(state.preferences()).toEqual({ searchTitle: "mm" }));
+  });
+
+  it("does not resurrect the filters when a reset is followed by leaving", async () => {
+    // Reset drops what the debounce was holding, not just the write it was
+    // going to become: left in place, the flush on unmount would send it
+    // afterwards and put the filters back.
+    const api = fakeApi();
+    const state = fakeState();
+    const view = renderTrialMatches(api, { state: state.adapter });
+    await waitFor(() => expect(listed(api).length).toBe(1));
+    await openPanel();
+
+    await userEvent.type(await screen.findByLabelText("Title"), "mm");
+    await userEvent.click(screen.getByRole("button", { name: "Reset filters" }));
+    view.unmount();
+    await new Promise((r) => setTimeout(r, 60));
+    expect(state.adapter.savePreferences).not.toHaveBeenCalled();
+    expect(state.preferences()).toEqual({});
+  });
+
+  it("does not hand a stored value of the wrong type to a control", async () => {
+    // The payload is opaque JSON on the server and this remote is not its
+    // only writer. Unchecked, the title input is handed an object and
+    // renders "[object Object]" — a filter the reader cannot read and did
+    // not set.
+    const api = fakeApi();
+    renderTrialMatches(api, {
+      state: fakeState({
+        preferences: { searchTitle: { not: "a string" }, phase: 42 },
+      }).adapter,
+    });
+    await waitFor(() => expect(listed(api).length).toBe(1));
+    expect(listed(api)[0].params.phase).toBeUndefined();
+
+    await openPanel();
+    expect(await screen.findByLabelText("Title")).toHaveValue("");
+  });
+
+  it("keeps its own cache true, since it will never refetch", async () => {
+    // `staleTime: Infinity` buys a panel that does not move under the
+    // reader's hands, and costs this: a host sharing one QueryClient across
+    // a route change remounts the remote onto the answer from before the
+    // write, so a filter the reader saved is simply gone.
+    const api = fakeApi();
+    const state = fakeState();
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, refetchOnWindowFocus: false } },
+    });
+    const ui = () => (
+      <QueryClientProvider client={queryClient}>
+        <TrialMatches
+          apiClient={api.client}
+          queryClient={queryClient}
+          patientInfo={{ disease: "multiple myeloma" }}
+          state={state.adapter}
+        />
+      </QueryClientProvider>
+    );
+    const view = render(ui());
+    await waitFor(() => expect(listed(api).length).toBe(1));
+    await openPanel();
+    await userEvent.type(await screen.findByLabelText("Title"), "mm");
+    await waitFor(() => expect(state.preferences()).toEqual({ searchTitle: "mm" }), {
+      timeout: 2000,
+    });
+
+    view.unmount();
+    render(ui());
+    await openPanel();
+    expect(await screen.findByLabelText("Title")).toHaveValue("mm");
+    // Served from the cache, exactly as intended — which is why the cache
+    // had to be told.
+    expect(state.adapter.getPreferences).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not lose a change queued behind the previous patient's write", async () => {
+    const api = fakeApi();
+    const release: (() => void)[] = [];
+    const state = fakeState({
+      overrides: {
+        savePreferences: vi.fn(
+          () => new Promise<void>((resolve) => release.push(resolve)),
+        ),
+      },
+    });
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, refetchOnWindowFocus: false } },
+    });
+    const ui = (patient: Record<string, unknown>) => (
+      <QueryClientProvider client={queryClient}>
+        <TrialMatches
+          apiClient={api.client}
+          queryClient={queryClient}
+          patientInfo={patient}
+          state={state.adapter}
+        />
+      </QueryClientProvider>
+    );
+    const view = render(ui({ disease: "mm", ref: "A" }));
+    await waitFor(() => expect(listed(api).length).toBe(1));
+    await openPanel();
+    await userEvent.type(await screen.findByLabelText("Title"), "aa");
+    await waitFor(() => expect(release.length).toBe(1), { timeout: 2000 });
+
+    // The panel stays open across the swap; clicking the trigger again
+    // would close it.
+    view.rerender(ui({ disease: "mm", ref: "B" }));
+    await waitFor(() => expect(screen.getByLabelText("Title")).toHaveValue(""));
+    await userEvent.type(screen.getByLabelText("Title"), "bb");
+    await new Promise((r) => setTimeout(r, 800));
+    // Still behind A's write, as it must be — one at a time.
+    expect(state.adapter.savePreferences).toHaveBeenCalledTimes(1);
+
+    release[0]();
+    // And when it goes out it is B's, under B's key. Carrying A's key — the
+    // key of the write it was queued behind — it was dropped on the floor
+    // and B's choice was never saved at all.
+    await waitFor(() =>
+      expect(state.adapter.savePreferences).toHaveBeenCalledTimes(2),
+    );
+    expect(
+      (state.adapter.savePreferences as unknown as { mock: { calls: unknown[][] } }).mock
+        .calls[1][0],
+    ).toEqual({ searchTitle: "bb" });
+    release.forEach((fn) => fn());
+  });
+
+  it("does not let a reset and a save be in flight together", async () => {
+    // The server applies them in whichever order they arrive, and the
+    // losing order clears a filter the panel still shows as applied.
+    const api = fakeApi();
+    const order: string[] = [];
+    let releaseReset: () => void = () => {};
+    const state = fakeState({
+      // Something for Reset to clear: a stored filter is the reader's own,
+      // so it counts — a host's `initialFilters` is the baseline and would
+      // leave the button disarmed.
+      preferences: { phase: "PHASE3" },
+      overrides: {
+        resetPreferences: vi.fn(() => {
+          order.push("reset:start");
+          return new Promise<void>((resolve) => {
+            releaseReset = () => {
+              order.push("reset:done");
+              resolve();
+            };
+          });
+        }),
+        savePreferences: vi.fn(async () => {
+          order.push("save:start");
+        }),
+      },
+    });
+    renderTrialMatches(api, { state: state.adapter });
+    await waitFor(() => expect(listed(api).length).toBe(1));
+    await openPanel();
+
+    await userEvent.click(await screen.findByRole("button", { name: "Reset filters" }));
+    await waitFor(() => expect(order).toEqual(["reset:start"]));
+
+    await userEvent.selectOptions(
+      await screen.findByLabelText("Recruitment status"),
+      "RECRUITING",
+    );
+    await new Promise((r) => setTimeout(r, 800));
+    expect(order).toEqual(["reset:start"]);
+
+    releaseReset();
+    await waitFor(() =>
+      expect(order).toEqual(["reset:start", "reset:done", "save:start"]),
+    );
+  });
+
+  it("does not overwrite filters it could not read", async () => {
+    // The worst thing this could do. A save is ABSOLUTE — it replaces the
+    // stored set — so writing one field while the rest are unknown discards
+    // everything the patient had saved, on the strength of a panel showing
+    // the defaults precisely BECAUSE they could not be read.
+    const api = fakeApi();
+    const state = fakeState({
+      preferences: { sponsor: "Acme", phase: "PHASE3" },
+      overrides: {
+        getPreferences: vi.fn(async () => {
+          throw new Error("promop unreachable");
+        }),
+      },
+    });
+    renderTrialMatches(api, { state: state.adapter });
+    await waitFor(() => expect(listed(api).length).toBe(1));
+    await openPanel();
+
+    await userEvent.type(await screen.findByLabelText("Title"), "mm");
+    await new Promise((r) => setTimeout(r, 900));
+    expect(state.adapter.savePreferences).not.toHaveBeenCalled();
+    // And the reader is told, before they spend any more effort on it.
+    await screen.findByText(/won't be saved/);
+  });
+
+  it("is not editable until the stored set is known", async () => {
+    // Same hazard as above, narrower window. Editable during the read, one
+    // change marks the session as touched — and the stored filters, when
+    // they land, are then never adopted. The reader's NEXT change saves
+    // that incomplete set as the absolute record and deletes everything
+    // they had.
+    const api = fakeApi();
+    let release: (value: Record<string, unknown>) => void = () => {};
+    const state = fakeState({
+      overrides: {
+        getPreferences: vi.fn(
+          () => new Promise<Record<string, unknown>>((resolve) => {
+            release = resolve;
+          }),
+        ),
+      },
+    });
+    renderTrialMatches(api, { state: state.adapter });
+    await openPanel();
+    await screen.findByText("Loading your saved filters…");
+    expect(screen.queryByLabelText("Title")).toBeNull();
+
+    release({ sponsor: "Acme" });
+    // And once they land they are what the panel shows.
+    await waitFor(() => expect(screen.getByLabelText("Sponsor")).toHaveValue("Acme"));
+  });
+
+  it("does not clear on the server what it could not read", async () => {
+    // The banner says changes won't be saved. Reset bypassing that gate
+    // would make it a lie in the most expensive direction — destroying the
+    // stored set we had just admitted we could not read.
+    const api = fakeApi();
+    const state = fakeState({
+      preferences: { sponsor: "Acme" },
+      overrides: {
+        getPreferences: vi.fn(async () => {
+          throw new Error("promop unreachable");
+        }),
+      },
+    });
+    renderTrialMatches(api, { state: state.adapter });
+    await waitFor(() => expect(listed(api).length).toBe(1));
+    await openPanel();
+
+    await userEvent.selectOptions(
+      await screen.findByLabelText("Recruitment status"),
+      "RECRUITING",
+    );
+    await userEvent.click(await screen.findByRole("button", { name: "Reset filters" }));
+    await new Promise((r) => setTimeout(r, 60));
+    expect(state.adapter.resetPreferences).not.toHaveBeenCalled();
+    expect(state.preferences()).toEqual({ sponsor: "Acme" });
+  });
+
+  it("says the panel is showing defaults when the adapter cannot be asked", async () => {
+    const api = fakeApi();
+    const state = fakeState();
+    delete (state.adapter as Partial<typeof state.adapter>).getPreferences;
+    renderTrialMatches(api, { state: state.adapter });
+    await screen.findByText(/Couldn't load your saved filters/);
+  });
+
+  it("does not say there are no trials while it is still waiting to ask", async () => {
+    // The read DISABLES the trials query, and a disabled query reports
+    // `isLoading` false — so nothing said the list was loading and the
+    // empty state fired. Every reader with saved filters saw "No trials
+    // found" for a moment before their trials arrived.
+    const api = fakeApi();
+    let release: (value: Record<string, unknown>) => void = () => {};
+    const state = fakeState({
+      overrides: {
+        getPreferences: vi.fn(
+          () => new Promise<Record<string, unknown>>((resolve) => {
+            release = resolve;
+          }),
+        ),
+      },
+    });
+    renderTrialMatches(api, { state: state.adapter });
+    await screen.findByText("Loading trials…");
+    expect(screen.queryByText("No trials found")).toBeNull();
+
+    release({});
+    await waitFor(() => expect(listed(api).length).toBe(1));
+  });
+
+  it("does not half-work for an adapter that can read but not write", async () => {
+    // Half the methods is not a smaller feature, it is a wrong one: filters
+    // that load and then cannot be changed. The panel works locally and
+    // says so instead.
+    const api = fakeApi();
+    const state = fakeState({ preferences: { sponsor: "Acme" } });
+    delete (state.adapter as Partial<typeof state.adapter>).savePreferences;
+    renderTrialMatches(api, { state: state.adapter });
+    await waitFor(() => expect(listed(api).length).toBe(1));
+    await screen.findByText(/Couldn't load your saved filters/);
+    expect(state.adapter.getPreferences).not.toHaveBeenCalled();
+
+    await openPanel();
+    await userEvent.type(await screen.findByLabelText("Title"), "mm");
+    // Applied to this search, as the banner promises.
+    await waitFor(() => {
+      const last = listed(api)[listed(api).length - 1];
+      expect(last.params.searchTitle).toBe("mm");
+    });
+  });
+
+  it("is not deadlocked by an adapter that throws synchronously", async () => {
+    // The throw escapes before the promise chain is built, so `.finally`
+    // never runs and `inFlight` stays true — every later write queued
+    // behind one that already failed, for ever.
+    const api = fakeApi();
+    let broken = true;
+    const state = fakeState({
+      overrides: {
+        savePreferences: vi.fn((next: Record<string, unknown>) => {
+          if (broken) throw new TypeError("not a function");
+          return Promise.resolve(next).then(() => undefined);
+        }),
+      },
+    });
+    renderTrialMatches(api, { state: state.adapter });
+    await waitFor(() => expect(listed(api).length).toBe(1));
+    await openPanel();
+
+    const title = await screen.findByLabelText("Title");
+    await userEvent.type(title, "m");
+    await screen.findByRole("alert", {}, { timeout: 2000 });
+
+    broken = false;
+    await userEvent.type(title, "m");
+    await waitFor(
+      () => expect(state.adapter.savePreferences).toHaveBeenCalledTimes(2),
+      { timeout: 2000 },
+    );
+  });
+
+  it("does not wait on a read that cannot succeed", async () => {
+    // The list waits for the stored filters so the opening search carries
+    // them. Under the host's own client — three retries with backoff — a
+    // PROMOP outage held every tab on "Loading trials…" for seven seconds.
+    const api = fakeApi();
+    const state = fakeState({
+      overrides: {
+        getPreferences: vi.fn(async () => {
+          throw new Error("promop unreachable");
+        }),
+      },
+    });
+    // A client with the DEFAULTS a host would have, not the suite's
+    // retry-free one — the retries are the point.
+    const queryClient = new QueryClient();
+    render(
+      <QueryClientProvider client={queryClient}>
+        <TrialMatches
+          apiClient={api.client}
+          queryClient={queryClient}
+          patientInfo={{ disease: "multiple myeloma" }}
+          state={state.adapter}
+        />
+      </QueryClientProvider>,
+    );
+    await waitFor(() => expect(listed(api).length).toBe(1), { timeout: 1500 });
+  });
+
+  it("does not wait on an adapter that cannot be asked", async () => {
+    const api = fakeApi();
+    const state = fakeState();
+    delete (state.adapter as Partial<typeof state.adapter>).getPreferences;
+    renderTrialMatches(api, { state: state.adapter });
+    await waitFor(() => expect(listed(api).length).toBe(1), { timeout: 1500 });
+  });
+
+  it("keeps the rest of the saved filters in the request on the first edit", async () => {
+    // The debounce is seeded at mount, when the stored filters are not
+    // there yet. Left to catch up, the first edit flipped the request onto
+    // held values that were still empty: for 400ms the Sponsor box read
+    // "Acme", the badge counted it, and the request did not carry it.
+    // All five debounced fields, not one: each needs the seeding and the
+    // rule is written out five times.
+    const api = fakeApi();
+    renderTrialMatches(api, {
+      state: fakeState({
+        preferences: {
+          sponsor: "Acme",
+          searchTitle: "myeloma",
+          searchTreatment: "len",
+          distance: 50,
+          distanceUnits: "km",
+        },
+      }).adapter,
+    });
+    await waitFor(() => expect(listed(api).length).toBe(1));
+    await openPanel();
+
+    await userEvent.selectOptions(
+      await screen.findByLabelText("Recruitment status"),
+      "RECRUITING",
+    );
+    await waitFor(() => expect(listed(api).length).toBe(2));
+    for (const request of listed(api)) {
+      expect(request.params.sponsor).toBe("Acme");
+      expect(request.params.searchTitle).toBe("myeloma");
+      expect(request.params.searchTreatment).toBe("len");
+      expect(request.params.distance).toBe("50");
+      expect(request.params.distanceUnits).toBe("km");
+    }
+  });
+
+  it("does not save the host's own filters as the patient's", async () => {
+    const api = fakeApi();
+    const state = fakeState();
+    renderTrialMatches(api, {
+      state: state.adapter,
+      initialFilters: { recruitmentStatus: "RECRUITING" },
+    });
+    await waitFor(() => expect(listed(api).length).toBe(1));
+    await openPanel();
+
+    await userEvent.type(await screen.findByLabelText("Title"), "mm");
+    await waitFor(() => expect(state.preferences()).toEqual({ searchTitle: "mm" }), {
+      timeout: 2000,
+    });
+  });
+
+  it("prefers what the patient saved over what the host asked for", async () => {
+    const api = fakeApi();
+    renderTrialMatches(api, {
+      state: fakeState({ preferences: { phase: "PHASE3" } }).adapter,
+      initialFilters: { phase: "PHASE2" },
+    });
+    await waitFor(() => expect(listed(api).length).toBe(1));
+    expect(listed(api)[0].params.phase).toBe("PHASE3");
+  });
+
+  it("clears the panel on Reset without waiting for the server", async () => {
+    const api = fakeApi();
+    const state = fakeState({
+      preferences: { phase: "PHASE3" },
+      overrides: { resetPreferences: vi.fn(() => new Promise<void>(() => {})) },
+    });
+    renderTrialMatches(api, { state: state.adapter });
+    await waitFor(() => expect(listed(api).length).toBe(1));
+    await openPanel();
+
+    await userEvent.click(await screen.findByRole("button", { name: "Reset filters" }));
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /Filter Results/ })).toBeInTheDocument(),
+    );
+  });
+
+  it("clears the save error once a save succeeds", async () => {
+    const api = fakeApi();
+    let fail = true;
+    const state = fakeState({
+      overrides: {
+        savePreferences: vi.fn(async () => {
+          if (fail) throw new Error("nope");
+        }),
+      },
+    });
+    renderTrialMatches(api, { state: state.adapter });
+    await waitFor(() => expect(listed(api).length).toBe(1));
+    await openPanel();
+
+    const title = await screen.findByLabelText("Title");
+    await userEvent.type(title, "m");
+    await screen.findByRole("alert", {}, { timeout: 2000 });
+
+    fail = false;
+    await userEvent.type(title, "m");
+    await waitFor(() => expect(screen.queryByRole("alert")).toBeNull(), {
+      timeout: 2000,
+    });
+  });
+
+  it("does not show one patient's save failure to the next", async () => {
+    const api = fakeApi();
+    const state = fakeState({
+      overrides: {
+        savePreferences: vi.fn(async () => {
+          throw new Error("nope");
+        }),
+      },
+    });
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, refetchOnWindowFocus: false } },
+    });
+    const ui = (patient: Record<string, unknown>) => (
+      <QueryClientProvider client={queryClient}>
+        <TrialMatches
+          apiClient={api.client}
+          queryClient={queryClient}
+          patientInfo={patient}
+          state={state.adapter}
+        />
+      </QueryClientProvider>
+    );
+    const view = render(ui({ disease: "mm", ref: "A" }));
+    await waitFor(() => expect(listed(api).length).toBe(1));
+    await openPanel();
+    await userEvent.type(await screen.findByLabelText("Title"), "mm");
+    await screen.findByRole("alert", {}, { timeout: 2000 });
+
+    view.rerender(ui({ disease: "mm", ref: "B" }));
+    await waitFor(() => expect(screen.queryByRole("alert")).toBeNull());
+  });
+
+  it("queues a reset behind a save that is already on the wire", async () => {
+    // The mirror of the test above it, and the one the queue was written
+    // for: unserialised, the server applies them in whichever order they
+    // arrive, and the losing order leaves the filters the reader just
+    // cleared.
+    const api = fakeApi();
+    const order: string[] = [];
+    let releaseSave: () => void = () => {};
+    const state = fakeState({
+      preferences: { phase: "PHASE3" },
+      overrides: {
+        savePreferences: vi.fn(() => {
+          order.push("save:start");
+          return new Promise<void>((resolve) => {
+            releaseSave = () => {
+              order.push("save:done");
+              resolve();
+            };
+          });
+        }),
+        resetPreferences: vi.fn(async () => {
+          order.push("reset");
+        }),
+      },
+    });
+    renderTrialMatches(api, { state: state.adapter });
+    await waitFor(() => expect(listed(api).length).toBe(1));
+    await openPanel();
+
+    await userEvent.type(await screen.findByLabelText("Title"), "mm");
+    await waitFor(() => expect(order).toEqual(["save:start"]), { timeout: 2000 });
+
+    await userEvent.click(screen.getByRole("button", { name: "Reset filters" }));
+    await new Promise((r) => setTimeout(r, 50));
+    expect(order).toEqual(["save:start"]);
+
+    releaseSave();
+    await waitFor(() => expect(order).toEqual(["save:start", "save:done", "reset"]));
+  });
+
+  it("does not write a finished save into the next patient's cache", async () => {
+    // The write resolves after the host has swapped patients, and what it
+    // puts into the cache is the filter set of the patient it was made for.
+    // Filed under the current key it would become patient B's stored
+    // filters — without ever being written to B's row on the server.
+    const api = fakeApi();
+    let release: () => void = () => {};
+    const state = fakeState({
+      overrides: {
+        savePreferences: vi.fn(
+          () => new Promise<void>((resolve) => {
+            release = resolve;
+          }),
+        ),
+      },
+    });
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, refetchOnWindowFocus: false } },
+    });
+    const ui = (patient: Record<string, unknown>) => (
+      <QueryClientProvider client={queryClient}>
+        <TrialMatches
+          apiClient={api.client}
+          queryClient={queryClient}
+          patientInfo={patient}
+          state={state.adapter}
+        />
+      </QueryClientProvider>
+    );
+    const view = render(ui({ disease: "mm", ref: "A" }));
+    await waitFor(() => expect(listed(api).length).toBe(1));
+    await openPanel();
+    await userEvent.type(await screen.findByLabelText("Title"), "aa");
+    await waitFor(() => expect(state.adapter.savePreferences).toHaveBeenCalled(), {
+      timeout: 2000,
+    });
+
+    view.rerender(ui({ disease: "mm", ref: "B" }));
+    await waitFor(() => expect(screen.getByLabelText("Title")).toHaveValue(""));
+    release();
+    await new Promise((r) => setTimeout(r, 60));
+    expect(screen.getByLabelText("Title")).toHaveValue("");
+  });
+
+  it("says so when they cannot be read", async () => {
+    // Every control then looks exactly as it would if the reader had saved
+    // nothing at all.
+    const api = fakeApi();
+    const state = fakeState({
+      overrides: {
+        getPreferences: vi.fn(async () => {
+          throw new Error("promop unreachable");
+        }),
+      },
+    });
+    renderTrialMatches(api, { state: state.adapter });
+    await screen.findByText(/Couldn't load your saved filters/);
+    // And the search still runs, rather than waiting for a read that has
+    // already failed.
+    await waitFor(() => expect(listed(api).length).toBe(1));
+  });
+
+  it("says so when a change cannot be saved", async () => {
+    const api = fakeApi();
+    const state = fakeState({
+      overrides: {
+        savePreferences: vi.fn(async () => {
+          throw new Error("nope");
+        }),
+      },
+    });
+    renderTrialMatches(api, { state: state.adapter });
+    await waitFor(() => expect(listed(api).length).toBe(1));
+    await openPanel();
+
+    await userEvent.type(await screen.findByLabelText("Title"), "mm");
+    const alert = await screen.findByRole("alert", {}, { timeout: 2000 });
+    expect(alert).toHaveTextContent("Couldn't save your filters");
+  });
+
+  it("does not let a stored tab switch the corpus", async () => {
+    // `type: "all"` is not a filter: it moves the server to the admin
+    // branch, which skips the eligibility filter and several study
+    // preferences with it (#424), and suppresses the tab counts.
+    const api = fakeApi();
+    renderTrialMatches(api, {
+      state: fakeState({ preferences: { type: "all", sort: "distance" } }).adapter,
+    });
+    await waitFor(() => expect(listed(api).length).toBe(1));
+    expect(listed(api)[0].params.type).toBeUndefined();
+    expect(listed(api)[0].params.sort).toBe("goodnessScore");
+  });
+
+  it("sends a pending write to the patient it was made for", async () => {
+    // The write carries the adapter it was made with, and an adapter is
+    // bound to one person (`createPromopState` bakes the person_id in).
+    // Checked against the CURRENT patient instead, a change made a moment
+    // before the host moved on was dropped on the floor.
+    const api = fakeApi();
+    const a = fakeState();
+    const b = fakeState();
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, refetchOnWindowFocus: false } },
+    });
+    const ui = (ref: string, state: typeof a) => (
+      <QueryClientProvider client={queryClient}>
+        <TrialMatches
+          apiClient={api.client}
+          queryClient={queryClient}
+          patientInfo={{ disease: "mm", ref }}
+          state={state.adapter}
+        />
+      </QueryClientProvider>
+    );
+    const view = render(ui("A", a));
+    await waitFor(() => expect(listed(api).length).toBe(1));
+    await openPanel();
+    await userEvent.type(await screen.findByLabelText("Title"), "mm");
+
+    // Before the debounce elapses.
+    view.rerender(ui("B", b));
+    await waitFor(() => expect(a.preferences()).toEqual({ searchTitle: "mm" }), {
+      timeout: 2000,
+    });
+    expect(b.adapter.savePreferences).not.toHaveBeenCalled();
+  });
+
+  it("sends a debounced edit when the next patient starts typing", async () => {
+    // The debounce is one slot. Cleared by B's first keystroke, A's change
+    // — made seconds earlier, still inside its 500ms — was simply gone.
+    const api = fakeApi();
+    const a = fakeState();
+    const b = fakeState();
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, refetchOnWindowFocus: false } },
+    });
+    const ui = (ref: string, state: typeof a) => (
+      <QueryClientProvider client={queryClient}>
+        <TrialMatches
+          apiClient={api.client}
+          queryClient={queryClient}
+          patientInfo={{ disease: "mm", ref }}
+          state={state.adapter}
+        />
+      </QueryClientProvider>
+    );
+    const view = render(ui("A", a));
+    await waitFor(() => expect(listed(api).length).toBe(1));
+    await openPanel();
+    await userEvent.type(await screen.findByLabelText("Title"), "aa");
+
+    view.rerender(ui("B", b));
+    await waitFor(() => expect(screen.getByLabelText("Title")).toHaveValue(""));
+    await userEvent.type(screen.getByLabelText("Title"), "bb");
+
+    await waitFor(() => expect(a.preferences()).toEqual({ searchTitle: "aa" }), {
+      timeout: 2000,
+    });
+    await waitFor(() => expect(b.preferences()).toEqual({ searchTitle: "bb" }), {
+      timeout: 2000,
+    });
+  });
+
+  it("does not rebuild a filter the reset is still clearing", async () => {
+    // The cached stored set is the PRE-reset one until the write lands, and
+    // that is what tells a save to keep a value the host happens to agree
+    // with. An edit made in that window rebuilt the very preference the
+    // reset was clearing and wrote it back afterwards.
+    const api = fakeApi();
+    let releaseReset: () => void = () => {};
+    const state = fakeState({
+      // `phase` is the one at risk: stored AND asked for by the host, so
+      // it is kept only because the cache says the patient owns it.
+      // `sponsor` is there to arm the Reset button.
+      preferences: { phase: "PHASE3", sponsor: "Acme" },
+      overrides: {
+        resetPreferences: vi.fn(
+          () => new Promise<void>((resolve) => {
+            releaseReset = resolve;
+          }),
+        ),
+      },
+    });
+    renderTrialMatches(api, {
+      state: state.adapter,
+      initialFilters: { phase: "PHASE3" },
+    });
+    await waitFor(() => expect(listed(api).length).toBe(1));
+    await openPanel();
+
+    await userEvent.click(await screen.findByRole("button", { name: "Reset filters" }));
+    await userEvent.type(await screen.findByLabelText("Title"), "mm");
+    releaseReset();
+
+    await waitFor(
+      () =>
+        expect(
+          (state.adapter.savePreferences as unknown as { mock: { calls: unknown[][] } })
+            .mock.calls[0]?.[0],
+        ).toEqual({ searchTitle: "mm" }),
+      { timeout: 2000 },
+    );
+  });
+
+  it("sends a debounced edit when the next patient clicks Reset", async () => {
+    // The same rule as the test above, through the other door. It was
+    // written in one path and not the other, so a change made seconds
+    // earlier vanished if the next reader happened to click Reset rather
+    // than type.
+    const api = fakeApi();
+    const a = fakeState();
+    const b = fakeState({ preferences: { phase: "PHASE3" } });
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, refetchOnWindowFocus: false } },
+    });
+    const ui = (ref: string, state: typeof a) => (
+      <QueryClientProvider client={queryClient}>
+        <TrialMatches
+          apiClient={api.client}
+          queryClient={queryClient}
+          patientInfo={{ disease: "mm", ref }}
+          state={state.adapter}
+        />
+      </QueryClientProvider>
+    );
+    const view = render(ui("A", a));
+    await waitFor(() => expect(listed(api).length).toBe(1));
+    await openPanel();
+    await userEvent.type(await screen.findByLabelText("Title"), "aa");
+
+    view.rerender(ui("B", b));
+    await userEvent.click(await screen.findByRole("button", { name: "Reset filters" }));
+
+    await waitFor(() => expect(a.preferences()).toEqual({ searchTitle: "aa" }));
+    expect(b.adapter.resetPreferences).toHaveBeenCalled();
+  });
+
+  it("treats an adapter rebuilt every render as the same patient", async () => {
+    // `state={createPromopState({client, personId})}` is the obvious way for
+    // a host to write it, and it hands over a NEW object on every render of
+    // the host — all of them the same person. Grouped by adapter identity,
+    // each of the reader's changes would queue a write of its own instead
+    // of superseding the last, and the same person would be written twice
+    // over with a set nobody will ever see.
+    const api = fakeApi();
+    const release: (() => void)[] = [];
+    const shared = fakeState({
+      overrides: {
+        savePreferences: vi.fn(
+          () => new Promise<void>((resolve) => {
+            release.push(resolve);
+          }),
+        ),
+      },
+    });
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, refetchOnWindowFocus: false } },
+    });
+    // A fresh object each time the host renders, delegating to the same
+    // methods — which is what an inline `createPromopState` produces.
+    const ui = () => (
+      <QueryClientProvider client={queryClient}>
+        <TrialMatches
+          apiClient={api.client}
+          queryClient={queryClient}
+          patientInfo={{ disease: "mm" }}
+          state={{ ...shared.adapter }}
+        />
+      </QueryClientProvider>
+    );
+    const view = render(ui());
+    await waitFor(() => expect(listed(api).length).toBe(1));
+    await openPanel();
+
+    const title = await screen.findByLabelText("Title");
+    await userEvent.type(title, "a");
+    await waitFor(() => expect(release.length).toBe(1), { timeout: 2000 });
+
+    view.rerender(ui());
+    await userEvent.type(screen.getByLabelText("Title"), "b");
+    await new Promise((r) => setTimeout(r, 700));
+    view.rerender(ui());
+    await userEvent.type(screen.getByLabelText("Title"), "c");
+    await new Promise((r) => setTimeout(r, 700));
+
+    release[0]();
+    await waitFor(() => expect(release.length).toBe(2), { timeout: 2000 });
+    release[1]();
+    await new Promise((r) => setTimeout(r, 80));
+    // Two writes, not three: the queued ones are one patient's, and the
+    // later says everything the earlier would have.
+    expect(shared.adapter.savePreferences).toHaveBeenCalledTimes(2);
+    view.unmount();
+  });
+
+  it("does not let one patient's edit swallow another's queued reset", async () => {
+    // A write supersedes an earlier one only WITHIN one patient: B's
+    // filters say nothing about A's. Sharing one queue slot, A's reset was
+    // overwritten by B's next edit and A kept exactly what they cleared.
+    const api = fakeApi();
+    let releaseSave: () => void = () => {};
+    const a = fakeState({
+      preferences: { phase: "PHASE3" },
+      overrides: {
+        savePreferences: vi.fn(
+          () => new Promise<void>((resolve) => {
+            releaseSave = resolve;
+          }),
+        ),
+      },
+    });
+    const b = fakeState();
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, refetchOnWindowFocus: false } },
+    });
+    const ui = (ref: string, state: typeof a) => (
+      <QueryClientProvider client={queryClient}>
+        <TrialMatches
+          apiClient={api.client}
+          queryClient={queryClient}
+          patientInfo={{ disease: "mm", ref }}
+          state={state.adapter}
+        />
+      </QueryClientProvider>
+    );
+    const view = render(ui("A", a));
+    await waitFor(() => expect(listed(api).length).toBe(1));
+    await openPanel();
+    await userEvent.type(await screen.findByLabelText("Title"), "mm");
+    await waitFor(() => expect(a.adapter.savePreferences).toHaveBeenCalled(), {
+      timeout: 2000,
+    });
+    // Queued behind the save that is on the wire.
+    await userEvent.click(screen.getByRole("button", { name: "Reset filters" }));
+
+    view.rerender(ui("B", b));
+    await waitFor(() => expect(screen.getByLabelText("Title")).toHaveValue(""));
+    await userEvent.type(screen.getByLabelText("Title"), "bb");
+    await new Promise((r) => setTimeout(r, 700));
+
+    releaseSave();
+    // Both survive: A's reset, and B's edit behind it.
+    await waitFor(() => expect(a.adapter.resetPreferences).toHaveBeenCalled());
+    await waitFor(() => expect(b.preferences()).toEqual({ searchTitle: "bb" }));
+  });
+
+  it("finishes a reset queued behind a save even after the patient changes", async () => {
+    // The in-flight save has already persisted A's filters. Drop the reset
+    // queued behind it and A is left holding exactly what they cleared.
+    const api = fakeApi();
+    let releaseSave: () => void = () => {};
+    const a = fakeState({
+      preferences: { phase: "PHASE3" },
+      overrides: {
+        savePreferences: vi.fn(
+          () => new Promise<void>((resolve) => {
+            releaseSave = resolve;
+          }),
+        ),
+      },
+    });
+    const b = fakeState();
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, refetchOnWindowFocus: false } },
+    });
+    const ui = (ref: string, state: typeof a) => (
+      <QueryClientProvider client={queryClient}>
+        <TrialMatches
+          apiClient={api.client}
+          queryClient={queryClient}
+          patientInfo={{ disease: "mm", ref }}
+          state={state.adapter}
+        />
+      </QueryClientProvider>
+    );
+    const view = render(ui("A", a));
+    await waitFor(() => expect(listed(api).length).toBe(1));
+    await openPanel();
+    await userEvent.type(await screen.findByLabelText("Title"), "mm");
+    await waitFor(() => expect(a.adapter.savePreferences).toHaveBeenCalled(), {
+      timeout: 2000,
+    });
+
+    await userEvent.click(screen.getByRole("button", { name: "Reset filters" }));
+    view.rerender(ui("B", b));
+    releaseSave();
+
+    await waitFor(() => expect(a.adapter.resetPreferences).toHaveBeenCalled());
+    expect(b.adapter.resetPreferences).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/federation/TrialMatches.tsx
+++ b/frontend/src/federation/TrialMatches.tsx
@@ -5,15 +5,31 @@
 // CB contract) or `personId` (CTOMOP federation path added in #102).
 import { useEffect, useMemo, useState, useRef } from "react";
 
-function useDebounced<T>(value: T, delay: number): T {
+/** Debounced, unless `immediate` — then the value passes straight through
+ *  AND the held value is kept in step behind it.
+ *
+ *  The delay is there so a keystroke is not a request. A value that arrives
+ *  from the patient's stored filters is not a keystroke: run through the
+ *  delay, it is `undefined` for the first 400ms, so the opening search goes
+ *  out without their saved sponsor and a second one follows with it.
+ *
+ *  Keeping the held value in step is the half that is easy to miss. Without
+ *  it, the first edit flips `immediate` off and hands back a held value
+ *  that never caught up — so for 400ms the Sponsor box reads "Acme", the
+ *  badge counts it, and the request does not carry it. */
+function useDebounced<T>(value: T, delay: number, immediate = false): T {
   const [debounced, setDebounced] = useState<T>(value);
   const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
   useEffect(() => {
+    if (immediate) {
+      setDebounced(value);
+      return;
+    }
     if (timer.current) clearTimeout(timer.current);
     timer.current = setTimeout(() => setDebounced(value), delay);
     return () => { if (timer.current) clearTimeout(timer.current); };
-  }, [value, delay]);
-  return debounced;
+  }, [value, delay, immediate]);
+  return immediate ? value : debounced;
 }
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
@@ -36,6 +52,7 @@ import {
 import {
   canReadAdvanced,
   useAdvancedEnrollments,
+  useFilterPersistence,
   useSetTrialState,
   useStateIds,
   useTrials,
@@ -88,6 +105,50 @@ function TrialMatchesInner({
     setSelectedTrial(null);
     setPage(1);
   }, [personId, patientInfoKey]);
+
+  // BOTH props, not the precedence winner.
+  //
+  // `patientIdentity` answers "which prop names this patient", which is the
+  // right question for the matcher and the wrong one for a cache key. With
+  // both supplied it resolves to the inline payload — so two readers whose
+  // payload is the same minimal `{disease}` share a key, and the second one
+  // is served the first one's bookmarks for as long as they stay fresh.
+  // A cache key wants maximum discrimination: any difference in either prop
+  // is a different key.
+  const stateKey = `${personId ?? ""}|${patientInfoKey ?? ""}`;
+
+  // The reader's saved filters.
+  //
+  // DERIVED into what the panel shows, not seeded into `filters` — the same
+  // rule `country` follows, and for the same reason: a render-phase
+  // `setState` re-runs the component but does not un-send what the query
+  // observer was already told to fetch, so seeding put one unfiltered
+  // request on the wire before the saved filters could apply.
+  const persistence = useFilterPersistence(state, stateKey, initialFilters);
+  // What applies when the reader has not touched the panel this session:
+  // the host's scope, with the patient's own saved filters over it.
+  const unedited = useMemo(
+    () => ({ ...(initialFilters ?? {}), ...(persistence.stored ?? {}) }),
+    [initialFilters, persistence.stored],
+  );
+  // `touched` is per patient: their edits are not the next reader's.
+  //
+  // The identity it uses is `stateKey`, which was chosen for maximum
+  // discrimination as a CACHE key — for the inline path it is the payload
+  // itself. So a host that changes the payload's content for the same
+  // person (the profile was edited, a field was added) reads here as a
+  // different patient, and the panel drops back to the stored filters,
+  // discarding edits the reader had not finished. Narrow — the content has
+  // to actually change — and widening it means guessing which key inside a
+  // host's opaque payload names the person, which is worse. #438.
+  //
+  // The WRITE half of that question is answered elsewhere and better: a
+  // pending write carries the adapter it was made with, and an adapter is
+  // bound to one person, so it lands where it belongs no matter what the
+  // props do afterwards.
+  const [touched, setTouched] = useState<string | null>(null);
+  const filtersAreMine = touched === stateKey;
+  const panelFilters = filtersAreMine ? filters : unedited;
 
   const diseaseCode = useMemo(() => {
     const d = (patientInfo as Record<string, unknown> | null | undefined)?.["disease"];
@@ -157,13 +218,13 @@ function TrialMatchesInner({
   //
   // Falling back to the baseline's value makes the two agree by
   // construction, so the baseline itself needs no mask at all.
-  const trialType = trialTypeIsStale
-    ? initialFilters?.trialType
-    : filters.trialType;
+  // A stale pick falls back to what would apply if the reader had made
+  // none — which now includes their saved filters, not only the host's.
+  const trialType = trialTypeIsStale ? unedited.trialType : panelFilters.trialType;
 
   const effectiveFilters = useMemo(
-    () => ({ ...filters, country, trialType }),
-    [filters, country, trialType],
+    () => ({ ...panelFilters, country, trialType }),
+    [panelFilters, country, trialType],
   );
 
   const baseline = useMemo(
@@ -172,11 +233,11 @@ function TrialMatchesInner({
   );
   const activeFilterCount = countActiveFilters(effectiveFilters, baseline);
 
-  const debouncedTitle = useDebounced(filters.searchTitle, 400);
-  const debouncedTreatment = useDebounced(filters.searchTreatment, 400);
-  const debouncedSponsor = useDebounced(filters.sponsor, 400);
-  const debouncedDistance = useDebounced(filters.distance, 400);
-  const debouncedDistanceUnits = useDebounced(filters.distanceUnits, 400);
+  const debouncedTitle = useDebounced(effectiveFilters.searchTitle, 400, !filtersAreMine);
+  const debouncedTreatment = useDebounced(effectiveFilters.searchTreatment, 400, !filtersAreMine);
+  const debouncedSponsor = useDebounced(effectiveFilters.sponsor, 400, !filtersAreMine);
+  const debouncedDistance = useDebounced(effectiveFilters.distance, 400, !filtersAreMine);
+  const debouncedDistanceUnits = useDebounced(effectiveFilters.distanceUnits, 400, !filtersAreMine);
   // The bar depends on whether a host gave us somewhere to keep bookmarks.
   const tabs = useMemo(() => tabsFor(state != null), [state]);
   // A host can take the adapter away — on logout, or when reconfiguring it.
@@ -190,16 +251,6 @@ function TrialMatchesInner({
   }
   const activeTabDef = tabs.find((t) => t.value === activeTab) ?? tabs[0];
 
-  // BOTH props, not the precedence winner.
-  //
-  // `patientIdentity` answers "which prop names this patient", which is the
-  // right question for the matcher and the wrong one for a cache key. With
-  // both supplied it resolves to the inline payload — so two readers whose
-  // payload is the same minimal `{disease}` share a key, and the second one
-  // is served the first one's bookmarks for as long as they stay fresh.
-  // A cache key wants maximum discrimination: any difference in either prop
-  // is a different key.
-  const stateKey = `${personId ?? ""}|${patientInfoKey ?? ""}`;
   const favorites = useStateIds(state, "favorites", stateKey);
   const registered = useStateIds(state, "registered", stateKey);
   // Not a display concern: this is what stops the register control being
@@ -359,7 +410,16 @@ function TrialMatchesInner({
     // `!idsFailed` too: without it a failed Favorites read still fires an
     // ordinary unfiltered search behind the error message — rows nobody
     // shows, and a full matcher run to produce them.
-    enabled: !waitingForIds && !tooManySavedIds && !idsFailed,
+    enabled:
+      !waitingForIds &&
+      !tooManySavedIds &&
+      !idsFailed &&
+      // Not merely cosmetic: without this the first search goes out with
+      // the defaults and a second one follows with the saved filters —
+      // two matcher runs, and a flash of results the reader did not ask
+      // for. A failed read is not a reason to wait (`isPending` is false
+      // once it has rejected); the panel shows the defaults and says so.
+      !persistence.isPending,
   });
 
   // While the ids are loading, the rows on screen belong to the previous
@@ -450,7 +510,9 @@ function TrialMatchesInner({
     if (next.trialType !== effectiveFilters.trialType) {
       setTrialTypeOwner(patientIdentity);
     }
+    setTouched(stateKey);
     setFilters(next);
+    persistence.save(next);
   };
   // Reset goes back to the baseline, not to `{}`: clearing the seeded
   // country would silently widen the search to every country in the
@@ -460,7 +522,15 @@ function TrialMatchesInner({
   // produce the same value — and a mutation test confirmed the line was
   // dead. It was load-bearing only under the earlier "mask to undefined"
   // rule, which is gone.
-  const handleFiltersReset = () => setFilters(baseline);
+  const handleFiltersReset = () => {
+    // `touched` is set here too: without it the panel would go on showing
+    // the stored filters — `unedited` still carries them — until the read
+    // that will never be refetched said otherwise, so Reset would appear to
+    // do nothing.
+    setTouched(stateKey);
+    setFilters(baseline);
+    persistence.reset();
+  };
 
   const handleSelect = (trial: TrialMatch) => {
     setSelectedTrial(trial);
@@ -583,7 +653,21 @@ function TrialMatchesInner({
         </button>
       </div>
 
-      {filtersOpen ? (
+      {/* Not editable until the stored set is known.
+          
+          The panel is otherwise live during the read, and an edit there
+          marks the session as touched — after which the stored filters,
+          when they land, are never adopted. The reader's next change then
+          saves that incomplete set as the absolute record and deletes
+          everything they had. The window is one round trip, and the list
+          itself is waiting on the same read. */}
+      {filtersOpen && persistence.isPending ? (
+        <p style={{ color: "var(--exact-color-text-muted)" }}>
+          Loading your saved filters…
+        </p>
+      ) : null}
+
+      {filtersOpen && !persistence.isPending ? (
         <FilterPanel
           apiClient={apiClient}
           filters={effectiveFilters}
@@ -594,7 +678,15 @@ function TrialMatchesInner({
         />
       ) : null}
 
-      {query.isLoading || waitingForIds || showingOtherTabsRows ? (
+      {/* `persistence.isPending` too: it DISABLES the trials query, and a
+          disabled query reports `isLoading` false — so nothing said the
+          list was loading and the empty state fired instead. Every reader
+          with saved filters saw "No trials found" for a moment before
+          their trials arrived. */}
+      {query.isLoading ||
+      persistence.isPending ||
+      waitingForIds ||
+      showingOtherTabsRows ? (
         <p style={{ color: "var(--exact-color-text-muted)" }}>Loading trials…</p>
       ) : null}
 
@@ -603,6 +695,26 @@ function TrialMatchesInner({
           You have saved {savedIds?.length} trials, and this view can show at
           most {MAX_TRIAL_IDS} at a time. Remove a few, or use the other tabs
           to find them.
+        </p>
+      ) : null}
+
+      {/* The panel is showing the defaults instead of what the reader saved,
+          and every control looks exactly as it would if they had saved
+          nothing. The second sentence is the important one: a save replaces
+          the stored set whole, so until this read succeeds nothing is
+          written — otherwise changing one control here would discard every
+          filter the patient had. */}
+      {persistence.unavailable ? (
+        <p style={{ color: "var(--exact-color-not-eligible)" }}>
+          Couldn't load your saved filters, so the panel is showing the
+          defaults. Changes you make now apply to this search but won't be
+          saved.
+        </p>
+      ) : null}
+
+      {persistence.failed ? (
+        <p style={{ color: "var(--exact-color-not-eligible)" }} role="alert">
+          Couldn't save your filters. They still apply to this search.
         </p>
       ) : null}
 
@@ -698,6 +810,7 @@ function TrialMatchesInner({
       ) : null}
 
       {!query.isLoading &&
+      !persistence.isPending &&
       !waitingForIds &&
       !idsFailed &&
       !tooManySavedIds &&

--- a/frontend/src/federation/filters.test.ts
+++ b/frontend/src/federation/filters.test.ts
@@ -2,11 +2,14 @@ import { describe, expect, it } from "vitest";
 
 import {
   DISTANCE_UNITS,
+  PERSISTED_FIELDS,
   baselineFilters,
   countActiveFilters,
   countryFor,
+  filtersToStore,
   hasActiveFilters,
   isActiveDistance,
+  sanitizeStoredFilters,
 } from "./filters";
 
 describe("baselineFilters", () => {
@@ -197,5 +200,223 @@ describe("isActiveDistance", () => {
     expect(isActiveDistance("25")).toBe(false);
     expect(isActiveDistance(Number.NaN)).toBe(false);
     expect(isActiveDistance(Number.POSITIVE_INFINITY)).toBe(false);
+  });
+});
+
+describe("what is saved", () => {
+  it("saves only what the panel can change", () => {
+    // `type` and `sort` belong to other controls; `country` is derived from
+    // the patient; `region`/`studyType`/`validatedOnly` can only come from
+    // the host, and saving them would pin its scope into the patient's own
+    // preferences, outliving a host that stopped sending it.
+    expect(
+      filtersToStore({
+        searchTitle: "myeloma",
+        type: "potential",
+        sort: "distance",
+        country: "US",
+        region: "EU",
+        studyType: "INTERVENTIONAL",
+        validatedOnly: true,
+      }),
+    ).toEqual({ searchTitle: "myeloma" });
+  });
+
+  it("leaves out what is not set, so the stored object says only what was", () => {
+    expect(filtersToStore({ searchTitle: "", sponsor: undefined })).toEqual({});
+  });
+
+  it("keeps a distance only when the backend would honour it", () => {
+    // Zero applies no limit and a negative one becomes a negative radius —
+    // an empty result set for a reason nothing on screen explains.
+    expect(filtersToStore({ distance: 50, distanceUnits: "km" })).toEqual({
+      distance: 50,
+      distanceUnits: "km",
+    });
+    expect(filtersToStore({ distance: 0, distanceUnits: "km" })).toEqual({});
+    expect(filtersToStore({ distance: -5, distanceUnits: "km" })).toEqual({});
+  });
+
+  it("does not save a unit for a distance that is not there", () => {
+    expect(filtersToStore({ distanceUnits: "miles" })).toEqual({});
+  });
+
+  it("truncates rather than storing something no request could carry", () => {
+    const stored = filtersToStore({ searchTitle: "x".repeat(5000) });
+    expect((stored.searchTitle as string).length).toBe(200);
+  });
+});
+
+describe("what is trusted on the way back", () => {
+  it("keeps the fields it knows", () => {
+    expect(
+      sanitizeStoredFilters({ searchTitle: "myeloma", phase: "PHASE3" }),
+    ).toEqual({ searchTitle: "myeloma", phase: "PHASE3" });
+  });
+
+  it("drops a key it does not know", () => {
+    // The payload is opaque JSON on the server and this remote is not its
+    // only writer. An unknown key riding into the request is a filter the
+    // reader cannot see and cannot turn off.
+    expect(sanitizeStoredFilters({ searchTitle: "a", favouriteColour: "blue" })).toEqual(
+      { searchTitle: "a" },
+    );
+  });
+
+  it("refuses a tab or a sort order smuggled in as a filter", () => {
+    // `type: "all"` is not a filter: it switches the server to the admin
+    // corpus, which skips the eligibility filter and several study
+    // preferences with it (#424), and suppresses the tab counts.
+    expect(sanitizeStoredFilters({ type: "all", sort: "distance" })).toEqual({});
+  });
+
+  it("drops a value of the wrong type rather than handing it to a control", () => {
+    expect(
+      sanitizeStoredFilters({ searchTitle: { toString: 1 }, phase: 42, sponsor: null }),
+    ).toEqual({});
+  });
+
+  it("drops a distance that is not a usable radius", () => {
+    expect(sanitizeStoredFilters({ distance: "50" })).toEqual({});
+    expect(sanitizeStoredFilters({ distance: 0 })).toEqual({});
+    expect(sanitizeStoredFilters({ distance: Number.NaN })).toEqual({});
+  });
+
+  it("drops a unit that qualifies nothing", () => {
+    expect(sanitizeStoredFilters({ distanceUnits: "km" })).toEqual({});
+    expect(sanitizeStoredFilters({ distance: 10, distanceUnits: "furlongs" })).toEqual({
+      distance: 10,
+    });
+  });
+
+  it("reads a payload that is not an object at all as no filters", () => {
+    // PROMOP now refuses these on the way in, but rows written before that
+    // guard — or by another client against an older build — are still there.
+    for (const junk of [null, undefined, [], "phase=3", 42]) {
+      expect(sanitizeStoredFilters(junk)).toEqual({});
+    }
+  });
+
+  it("refuses a string longer than it would store", () => {
+    expect(sanitizeStoredFilters({ searchTitle: "x".repeat(201) })).toEqual({});
+  });
+});
+
+describe("which fields are persisted at all", () => {
+  it("is exactly this list", () => {
+    // Pinned by name. Five of them were carried by no other test: a field
+    // could drop out of the list, stop being saved, and nothing would say
+    // so — the reader's filter would simply not be there next time.
+    expect([...PERSISTED_FIELDS]).toEqual([
+      "searchTitle",
+      "searchTreatment",
+      "sponsor",
+      "trialPurpose",
+      "recruitmentStatus",
+      "phase",
+      "register",
+      "lastUpdate",
+      "distance",
+      "distanceUnits",
+    ]);
+  });
+
+  it("saves every one of them", () => {
+    const everything = {
+      searchTitle: "a",
+      searchTreatment: "b",
+      sponsor: "c",
+      trialPurpose: "treatment",
+      recruitmentStatus: "RECRUITING",
+      phase: "PHASE3",
+      register: "NCT",
+      lastUpdate: "2",
+      distance: 10,
+      distanceUnits: "km" as const,
+    };
+    expect(filtersToStore(everything)).toEqual(everything);
+    expect(sanitizeStoredFilters(everything)).toEqual(everything);
+  });
+
+  it("does not save the trial type", () => {
+    // It is scoped to the disease: a type chosen under one has no matching
+    // option under another, and `by_trial_type` has no leniency for a value
+    // that is not there — an empty list from a control rendering blank
+    // (#437).
+    expect(filtersToStore({ trialType: "drug" })).toEqual({});
+    expect(sanitizeStoredFilters({ trialType: "drug" })).toEqual({});
+  });
+
+  it("survives the round trip at the length limit", () => {
+    // One side truncates and the other drops what is too long; if they ever
+    // disagree by one character, a saved filter comes back as nothing.
+    const stored = filtersToStore({ searchTitle: "x".repeat(5000) });
+    expect(sanitizeStoredFilters(stored)).toEqual(stored);
+  });
+});
+
+describe("what the host asked for is not the patient's own", () => {
+  it("leaves a host filter out of the save", () => {
+    // The panel is fed the effective filters, so a host's initialFilters
+    // ride along in every field they touched. Saved, they outrank the host
+    // on the next mount and outlive a host that stopped sending them.
+    expect(
+      filtersToStore(
+        { searchTitle: "mm", recruitmentStatus: "RECRUITING", phase: "PHASE2" },
+        { recruitmentStatus: "RECRUITING", phase: "PHASE2" },
+      ),
+    ).toEqual({ searchTitle: "mm" });
+  });
+
+  it("keeps a stored value that the host happens to agree with", () => {
+    // The two can agree by coincidence. Since a save replaces the stored
+    // set whole, dropping the field on that coincidence DELETES the
+    // patient's preference — and it surfaces the day the host stops
+    // sending it, which is the day it was supposed to still be there.
+    expect(
+      filtersToStore(
+        { phase: "PHASE3", searchTitle: "mm" },
+        { phase: "PHASE3" },
+        { phase: "PHASE3" },
+      ),
+    ).toEqual({ phase: "PHASE3", searchTitle: "mm" });
+  });
+
+  it("keeps a value the reader changed away from the host's", () => {
+    expect(
+      filtersToStore({ phase: "PHASE3" }, { phase: "PHASE2" }),
+    ).toEqual({ phase: "PHASE3" });
+  });
+
+  it("stores nothing when the reader changed nothing", () => {
+    const host = { sponsor: "Acme", distance: 50, distanceUnits: "km" as const };
+    expect(filtersToStore(host, host)).toEqual({});
+  });
+});
+
+describe("a stored radius keeps its unit", () => {
+  it("even when the unit is the one the host asked for", () => {
+    // Subtracted as the host's, a saved 50 MILES comes back as 50 km the
+    // day the host stops sending the unit — a different set of trials, and
+    // nothing on screen to say why.
+    expect(
+      filtersToStore({ distance: 50, distanceUnits: "miles" }, { distanceUnits: "miles" }),
+    ).toEqual({ distance: 50, distanceUnits: "miles" });
+  });
+
+  it("and still stores no unit without a distance", () => {
+    expect(filtersToStore({ distanceUnits: "miles" })).toEqual({});
+  });
+});
+
+describe("an empty string is not a filter", () => {
+  it("is not stored", () => {
+    expect(filtersToStore({ searchTitle: "" })).toEqual({});
+  });
+
+  it("is not read back either", () => {
+    // A foreign writer's `{searchTitle: ""}` would otherwise ride into the
+    // panel and count on the badge as a filter that narrows nothing.
+    expect(sanitizeStoredFilters({ searchTitle: "" })).toEqual({});
   });
 });

--- a/frontend/src/federation/filters.ts
+++ b/frontend/src/federation/filters.ts
@@ -135,3 +135,135 @@ export function hasActiveFilters(
 ): boolean {
   return countActiveFilters(filters, baseline) > 0;
 }
+
+/** The fields that are saved to the patient's stored preferences.
+ *
+ *  Exactly the controls the panel renders, and nothing else. Three kinds of
+ *  field are deliberately absent:
+ *
+ *  - `type` and `sort` belong to the tab bar and the sort control.
+ *  - `country` is derived from the patient's own profile and has no control
+ *    (#430). Storing it would store a copy of a fact that can change.
+ *  - `region`, `studyType` and `validatedOnly` can only arrive through a
+ *    host's `initialFilters`. Saving them would pin the host's scope into
+ *    the patient's own preferences, where it would outlive a host that had
+ *    stopped sending it — a filter running with nothing on screen that can
+ *    turn it off.
+ *  - `trialType` is absent for a reason of its own: it is scoped to the
+ *    disease. A type chosen for one has no matching option under another,
+ *    and `by_trial_type` has no leniency for a value that is not there —
+ *    an empty result set from a control rendering blank. The component
+ *    already treats a type as belonging to the patient it was picked for
+ *    (`trialTypeOwner`); a stored one would arrive unclaimed, so nothing
+ *    would ever make it stale. Persisting it needs the panel to check it
+ *    against the disease's own options first, which is #437.
+ */
+export const PERSISTED_FIELDS = [
+  "searchTitle",
+  "searchTreatment",
+  "sponsor",
+  "trialPurpose",
+  "recruitmentStatus",
+  "phase",
+  "register",
+  "lastUpdate",
+  "distance",
+  "distanceUnits",
+] as const;
+
+/** Longest stored string accepted. These travel on as query parameters, and
+ *  nothing a person types into a search box is anywhere near this. */
+const MAX_STORED_STRING = 200;
+
+/** What to save: the persisted fields, with anything inactive left out so
+ *  the stored object says only what the reader actually set.
+ *
+ *  A value the HOST set is left out too. The panel is fed the effective
+ *  filters, so a host's `initialFilters` ride along in every field it
+ *  touched, and a save would copy them into the patient's own preferences —
+ *  where they outrank the host on the next mount and outlive a host that
+ *  stopped sending them. The rule the field list already states for
+ *  `region` and friends, applied to the fields that do have controls. */
+export function filtersToStore(
+  filters: FilterState,
+  hostFilters: FilterState = {},
+  stored: FilterState = {},
+): FilterState {
+  const out: FilterState = {};
+  for (const field of PERSISTED_FIELDS) {
+    const value = filters[field];
+    // Identical to what the host asked for: not the reader's choice to
+    // store, and storing it changes nothing except who owns it.
+    //
+    // Unless the patient had already stored it. The two can agree by
+    // coincidence — a host scoping to PHASE3 for someone whose saved phase
+    // is PHASE3 — and since a save replaces the stored set whole, dropping
+    // the field on that coincidence deletes their preference. It surfaces
+    // the day the host stops sending it, which is exactly the day it was
+    // supposed to still be there.
+    // Deliberate consequence: once the patient has a stored value for a
+    // field, whatever they select there is theirs — including a value that
+    // happens to be the host's. The alternative makes choosing the value
+    // the host already uses mean "delete my preference", which is a
+    // surprising thing for a dropdown to do, and it cannot be told apart on
+    // screen from choosing it on purpose.
+    if (value === hostFilters[field] && stored[field] === undefined) continue;
+    if (field === "distance") {
+      if (isActiveDistance(value)) out.distance = value as number;
+      continue;
+    }
+    if (field === "distanceUnits") continue; // settled after the loop
+
+    if (typeof value === "string" && value !== "") {
+      out[field] = value.slice(0, MAX_STORED_STRING) as never;
+    }
+  }
+  // The unit is settled last, and outside the host-equality rule above.
+  //
+  // Only alongside a distance: on its own it is a unit for nothing. But a
+  // stored radius must always carry one — subtracted because it matched the
+  // host's, a saved 50 MILES came back as 50 km the day the host stopped
+  // sending the unit, which is a different set of trials and nothing on
+  // screen to say so.
+  if (out.distance != null) {
+    const unit = filters.distanceUnits;
+    if (unit === "km" || unit === "miles") out.distanceUnits = unit;
+  }
+  return out;
+}
+
+/** What to trust on the way back.
+ *
+ *  The stored payload is opaque JSON on the server — PROMOP checks that it
+ *  is an object and nothing more — and this remote is not its only writer.
+ *  So a stored value is treated as a claim, not as a `FilterState`: unknown
+ *  keys are dropped, and a value of the wrong type is dropped rather than
+ *  handed to a control that expects a string and would render `[object
+ *  Object]`, or sent to the backend to be rejected.
+ */
+export function sanitizeStoredFilters(raw: unknown): FilterState {
+  // No array check: a JSON array has none of these keys, so it falls out
+  // of the loop as `{}` anyway, and a guard that cannot change an answer is
+  // a guard no test can pin.
+  if (raw == null || typeof raw !== "object") return {};
+  const input = raw as Record<string, unknown>;
+  const out: FilterState = {};
+  for (const field of PERSISTED_FIELDS) {
+    const value = input[field];
+    if (field === "distance") {
+      if (isActiveDistance(value)) out.distance = value as number;
+      continue;
+    }
+    if (field === "distanceUnits") {
+      if (value === "km" || value === "miles") out.distanceUnits = value;
+      continue;
+    }
+    if (typeof value === "string" && value !== "" && value.length <= MAX_STORED_STRING) {
+      out[field] = value as never;
+    }
+  }
+  // A unit without a distance qualifies nothing; drop it rather than let it
+  // ride along into the request.
+  if (out.distanceUnits != null && out.distance == null) delete out.distanceUnits;
+  return out;
+}

--- a/frontend/src/federation/hooks.ts
+++ b/frontend/src/federation/hooks.ts
@@ -10,6 +10,9 @@ import {
 import type { AxiosInstance } from "axios";
 
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useEffect, useRef, useState } from "react";
+
+import { filtersToStore, sanitizeStoredFilters } from "./filters";
 
 import { fetchFormSettings, fetchTrialDetail, fetchTrials } from "./api";
 import type { AdvancedStatus, TrialId, TrialStateAdapter } from "./state";
@@ -124,6 +127,320 @@ export function useAdvancedEnrollments(
     enabled: state != null && canReadAdvanced(state),
     staleTime: 30_000,
   });
+}
+
+/** How long a change waits before it is written.
+ *
+ *  The panel's text inputs fire on every keystroke, and this is a network
+ *  write: unthrottled, "myeloma" is seven PATCHes. Matches the debounce the
+ *  same fields already use for the search itself. */
+const SAVE_DEBOUNCE_MS = 500;
+
+export interface FilterPersistence {
+  /** The patient's stored filters, `undefined` until they are known. */
+  stored?: FilterState;
+  /** The first read is still outstanding. The list waits on it — otherwise
+   *  one request goes out unfiltered and a second follows with the saved
+   *  filters, which is the flicker the derived `country` exists to avoid. */
+  isPending: boolean;
+  /** The read failed, so the reader's saved filters are not applied and the
+   *  panel is showing the defaults instead. Worth saying. */
+  unavailable: boolean;
+  /** A save was refused. */
+  failed: boolean;
+  /** Record a change. Debounced, and serialised behind whatever is already
+   *  on the wire. */
+  save(filters: FilterState): void;
+  /** Clear the stored filters. */
+  reset(): void;
+}
+
+/** Read and write the patient's saved filters.
+ *
+ *  The writes are serialised, not merely debounced. The debounce only
+ *  collapses changes inside its own window: type, wait it out, type again
+ *  while that PATCH is still travelling, and two are in flight — applied in
+ *  whatever order they arrive, so the older set can be the one that sticks.
+ *  One write at a time with the newest queued behind it makes the last
+ *  change the last write by construction. (CB's filter panel carries the
+ *  same machinery for the same reason.)
+ */
+/** One write, carrying everything it needs to finish on its own.
+ *
+ *  Including the ADAPTER it was made for. An adapter is bound to one
+ *  person — `createPromopState` bakes the `person_id` in at construction —
+ *  so it, not the component's current props, is what says where a write
+ *  belongs. A write that outlives the patient on screen then still goes to
+ *  the right row; checked against the current key instead, a reset queued
+ *  behind a save was dropped when the host swapped patients, leaving the
+ *  filters that reset was clearing.
+ *
+ *  Every write is ABSOLUTE — a save carries the whole filter set, a reset
+ *  carries the empty one — which is why a single queue slot is enough: the
+ *  newest write says everything the older ones were going to say. */
+type PendingWrite =
+  | { kind: "save"; filters: FilterState; key: string; adapter: TrialStateAdapter }
+  | { kind: "reset"; key: string; adapter: TrialStateAdapter };
+
+/** Whether an adapter can do the whole of stored filters — read, write and
+ *  clear.
+ *
+ *  All three, deliberately. The interface is a compile-time contract and a
+ *  host may be plain JavaScript, or half-upgraded; with only some of the
+ *  methods the feature does not degrade into a smaller one, it degrades
+ *  into a wrong one — filters that load and then cannot be changed, or a
+ *  Reset that throws. Missing any, the panel simply works locally and says
+ *  so.
+ *
+ *  Same reasoning as `canReadAdvanced`, which guards the control that would
+ *  otherwise overwrite a status it could not read. */
+export function canPersistFilters(state?: TrialStateAdapter): boolean {
+  return (
+    typeof state?.getPreferences === "function" &&
+    typeof state?.savePreferences === "function" &&
+    typeof state?.resetPreferences === "function"
+  );
+}
+
+export function useFilterPersistence(
+  state: TrialStateAdapter | undefined,
+  key: string,
+  /** What the host asked for, so it is not saved as the patient's own. */
+  hostFilters: FilterState = {},
+): FilterPersistence {
+  const queryClient = useQueryClient();
+  const queryKey = ["exact-state-filters", key];
+  const query = useQuery({
+    queryKey,
+    queryFn: async () => sanitizeStoredFilters(await state!.getPreferences()),
+    enabled: state != null && canPersistFilters(state),
+    // No retries. The whole trial list waits on this read — otherwise the
+    // opening search goes out with the defaults and a second one follows
+    // with the saved filters — and under the host's default three retries
+    // with backoff a PROMOP outage held every tab on "Loading trials…" for
+    // seven seconds. One attempt; if it fails the panel shows the defaults
+    // and says so, and the search runs.
+    retry: false,
+    // Never refetched. The stored filters are adopted as what the panel
+    // shows before the reader touches it; a background refetch landing
+    // mid-session would move the controls under their hands. What that
+    // costs is that this cache has to be kept true by hand — see the write
+    // path, which puts each successful write into it. Without that, a host
+    // sharing one QueryClient across a route change remounts the remote
+    // onto the pre-write answer, and a saved filter quietly disappears.
+    staleTime: Infinity,
+    refetchOnWindowFocus: false,
+  });
+
+  // Keyed, like the bookmark write record: a rejection under one patient is
+  // not an error message for the next. (`unavailable` gets this for free —
+  // it is `isError` on a query whose key already carries the patient.)
+  const [failedFor, setFailedFor] = useState<string | null>(null);
+  const setFailed = (write: PendingWrite | null, value: boolean) =>
+    setFailedFor(value ? (write?.key ?? null) : null);
+  /** The debounce: the timer and the write it is holding, together.
+   *
+   *  One ref rather than two, because "there is a timer" and "there is a
+   *  payload" were the same fact kept in two places — true by convention,
+   *  and one edit away from a flush that sends a write nobody scheduled. */
+  const pending = useRef<{
+    timer: ReturnType<typeof setTimeout>;
+    write: PendingWrite;
+  } | null>(null);
+  const inFlight = useRef(false);
+  /** Patients whose reset has been issued and not yet come back.
+   *
+   *  `query.data` still holds the pre-reset set until the write lands, and
+   *  that is what tells a save to keep a value the host happens to agree
+   *  with. So an edit made while a reset was in flight rebuilt exactly the
+   *  preference the reset was clearing, and wrote it back afterwards. */
+  const resetting = useRef<string[]>([]);
+  /** Waiting writes, at most one per patient.
+   *
+   *  Not a single slot. A write supersedes an earlier one only within one
+   *  patient's preferences: B's filters say nothing about A's. Sharing one
+   *  slot, a reset for A queued behind A's in-flight save was overwritten
+   *  by B's next edit, and A kept on the server exactly the filters they
+   *  had just cleared.
+   *
+   *  Grouped by `key`, not by adapter. Those differ: a host that builds its
+   *  adapter inline — `state={createPromopState(...)}`, the obvious way to
+   *  write it — hands over a NEW object every render, all of them the same
+   *  person. `key` is the component's answer to "same patient"; the adapter
+   *  is how a write reaches them. Key groups, adapter delivers. */
+  const queued = useRef<PendingWrite[]>([]);
+  // Read through refs inside callbacks that outlive the render that made
+  // them: a debounced write fires after the host may have swapped patients,
+  // and the adapter it should use is the current one.
+  // The unmount flush closes over the FIRST render's values (its effect has
+  // an empty dependency list), so the client it writes the result into is
+  // read through a ref. Written in an effect, not during render: React may
+  // abandon a render, and a ref written there can hold a value that never
+  // commits. Every reader of it runs from a user event or a timer, so it is
+  // current by then.
+  const clientRef = useRef(queryClient);
+  useEffect(() => {
+    clientRef.current = queryClient;
+  });
+
+  const run = (write: PendingWrite) => {
+    const adapter = write.adapter;
+    // No check against the current patient. The write carries the adapter
+    // it was made for, and an adapter is bound to one person, so there is
+    // no state of the world in which sending it is wrong — including after
+    // the host has moved on.
+    //
+    // There is no generation counter either. Reset retires a superseded
+    // write by clearing what holds it — the debounce, and the queue by
+    // overwriting it — and every write is absolute, so a later one says
+    // everything an earlier one would have. A generation check on top was a
+    // second mechanism for the same thing, and provably dead.
+    if (inFlight.current) {
+      // Reset goes through the same queue as a save rather than straight
+      // out to the adapter: unserialised, a reset and a save could be in
+      // flight together, and the server applies them in whichever order
+      // they arrive — the losing order clearing a filter the panel still
+      // shows.
+      const at = queued.current.findIndex((w) => w.key === write.key);
+      if (at === -1) queued.current.push(write);
+      // Same patient: absolute, so the newer write says everything the
+      // older one would have.
+      else queued.current[at] = write;
+      return;
+    }
+    inFlight.current = true;
+    if (write.kind === "reset" && !resetting.current.includes(write.key)) {
+      resetting.current = [...resetting.current, write.key];
+    }
+    const stored = write.kind === "save" ? write.filters : {};
+    // Through `Promise.resolve().then`, so an adapter that throws
+    // SYNCHRONOUSLY becomes a rejection like any other. Called directly, the
+    // throw escapes before the chain is built: `.finally` never runs,
+    // `inFlight` stays true for ever, and every later write is queued behind
+    // a write that already failed.
+    Promise.resolve()
+      .then(() =>
+        write.kind === "save"
+          ? adapter.savePreferences(write.filters)
+          : adapter.resetPreferences(),
+      )
+      .then(
+        () => {
+          setFailed(write, false);
+          // Under the key the write was made for, not the current one.
+          clientRef.current.setQueryData(
+            ["exact-state-filters", write.key],
+            stored,
+          );
+        },
+        () => setFailed(write, true),
+      )
+      .finally(() => {
+        inFlight.current = false;
+        if (write.kind === "reset") {
+          resetting.current = resetting.current.filter((k) => k !== write.key);
+        }
+        const next = queued.current.shift();
+        if (next) run(next);
+      });
+  };
+
+  /** Empty the debounce, keeping what it held if it was somebody else's.
+   *
+   *  In one place because both callers need it and the two drifted: `save`
+   *  flushed the other patient's write and `reset` simply dropped it, so a
+   *  change made seconds earlier vanished if the next reader happened to
+   *  click Reset. A write waiting out its debounce belongs to the reader
+   *  who made it and carries the adapter that reaches them; only the same
+   *  patient's is superseded, for whom the newer write says everything. */
+  const clearPending = (forKey: string) => {
+    const waiting = pending.current;
+    if (!waiting) return;
+    clearTimeout(waiting.timer);
+    pending.current = null;
+    if (waiting.write.key !== forKey) run(waiting.write);
+  };
+
+  const save = (filters: FilterState) => {
+    // A save replaces the stored set whole. Writing one field while the
+    // rest are unknown — the read still in flight, or failed — would
+    // discard every filter the patient had saved, on the strength of a
+    // panel that is showing the defaults because we could not read them.
+    if (state == null || !query.isSuccess) return;
+    const write: PendingWrite = {
+      kind: "save",
+      filters: filtersToStore(
+        filters,
+        hostFilters,
+        // Nothing is "already stored" while a reset for this patient is on
+        // its way: the cache still says otherwise, and trusting it here
+        // rebuilds the very preference the reset is clearing.
+        resetting.current.includes(key) ? {} : query.data ?? {},
+      ),
+      key,
+      adapter: state,
+    };
+    clearPending(key);
+    pending.current = {
+      write,
+      timer: setTimeout(() => {
+        pending.current = null;
+        run(write);
+      }, SAVE_DEBOUNCE_MS),
+    };
+  };
+
+  const reset = () => {
+    // Gated on the read exactly as `save` is, and NOT because clearing
+    // needs to know what was there — because the banner shown when the read
+    // fails says nothing will be written. Reset writing anyway would make
+    // that a lie in the most expensive direction: it would destroy the
+    // stored set we had just admitted we could not read.
+    if (state == null || !query.isSuccess) return;
+    // The debounce is dropped, payload and all: a write scheduled a moment
+    // ago would otherwise be flushed on unmount and put back the filters it
+    // carries, after the reset.
+    //
+    // Nothing clears `queued` here. A queued write for THIS patient is
+    // superseded by the call below, which replaces the entry for this
+    // adapter; entries for other patients are not ours to drop.
+    clearPending(key);
+    if (!resetting.current.includes(key)) {
+      resetting.current = [...resetting.current, key];
+    }
+    run({ kind: "reset", key, adapter: state });
+  };
+
+  // A pending change is sent on the way out rather than dropped: the reader
+  // typed it, and a host unmounting the remote — a route change, a tab —
+  // is not them changing their mind.
+  useEffect(
+    () => () => {
+      const scheduled = pending.current;
+      if (!scheduled) return;
+      clearTimeout(scheduled.timer);
+      pending.current = null;
+      run(scheduled.write);
+    },
+    // Mount/unmount only; everything it reads is a ref.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [],
+  );
+
+  return {
+    stored: query.data,
+    // A DISABLED query stays `pending` for ever — so an adapter that cannot
+    // answer at all held the whole trial list on "Loading trials…"
+    // permanently, which is the same trap the state tabs fell into.
+    isPending: canPersistFilters(state) && query.isPending,
+    // Cannot be asked is as unavailable as asked-and-refused: the panel is
+    // showing the defaults and nothing will be written either way, so the
+    // reader is owed the same sentence.
+    unavailable: state != null && (query.isError || !canPersistFilters(state)),
+    failed: failedFor === key,
+    save,
+    reset,
+  };
 }
 
 interface UseTrialsArgs {

--- a/frontend/src/federation/state.ts
+++ b/frontend/src/federation/state.ts
@@ -56,8 +56,16 @@ export interface TrialStateAdapter {
   getPreferences(): Promise<FilterState>;
   /** Store the filters. */
   savePreferences(filters: FilterState): Promise<void>;
-  /** Clear them. Deliberately not `savePreferences({})`: the server merges
-   *  a partial update, so "reset" has to be its own call. */
+  /** Clear them.
+   *
+   *  Its own call rather than `savePreferences({})`, which as it happens
+   *  would also work — `preferences` is one JSON column and PATCHing it
+   *  replaces the lot. (What the server's docstring warns about is a PATCH
+   *  whose BODY is `{}`: that omits the field, so a partial update touches
+   *  nothing.) The reason to keep it separate is that "the default" is the
+   *  server's to define: today it is the empty object, and if it ever stops
+   *  being that, a client asserting `{}` would be asserting the wrong
+   *  thing. */
   resetPreferences(): Promise<void>;
 }
 

--- a/frontend/src/test/renderTrialMatches.tsx
+++ b/frontend/src/test/renderTrialMatches.tsx
@@ -218,6 +218,8 @@ export interface FakeState {
   /** Reads, counted. A write is supposed to invalidate the list it changed,
    *  and the only externally visible sign of that is a re-read. */
   reads: { favorites: number; registered: number };
+  /** The stored filters as they now stand. */
+  preferences: () => Record<string, unknown>;
 }
 
 /** A working adapter, backed by two arrays.
@@ -232,12 +234,17 @@ export function fakeState(
     registered?: string[];
     /** Trials a study team has moved past "registered". */
     advanced?: Record<string, AdvancedStatus>;
+    /** The patient's stored filter set. */
+    preferences?: Record<string, unknown>;
     overrides?: Partial<TrialStateAdapter>;
   } = {},
 ): FakeState {
   const favorites = [...(initial.favorites ?? [])];
   const registered = [...(initial.registered ?? [])];
   const reads = { favorites: 0, registered: 0 };
+  // The stored filters, as a real store: a test can assert what a save
+  // actually left behind rather than only that a spy was called.
+  let preferences: Record<string, unknown> = { ...(initial.preferences ?? {}) };
 
   const set = (list: string[], id: string, on: boolean) => {
     const at = list.indexOf(id);
@@ -257,13 +264,23 @@ export function fakeState(
     setFavorite: vi.fn(async (id: string, on: boolean) => set(favorites, id, on)),
     setRegistered: vi.fn(async (id: string, on: boolean) => set(registered, id, on)),
     listAdvancedEnrollments: vi.fn(async () => ({ ...(initial.advanced ?? {}) })),
-    getPreferences: vi.fn(async () => ({})),
-    savePreferences: vi.fn(async () => undefined),
-    resetPreferences: vi.fn(async () => undefined),
+    getPreferences: vi.fn(async () => ({ ...preferences })),
+    savePreferences: vi.fn(async (next: Record<string, unknown>) => {
+      preferences = { ...next };
+    }),
+    resetPreferences: vi.fn(async () => {
+      preferences = {};
+    }),
     ...initial.overrides,
   };
 
-  return { adapter, favorites, registered, reads };
+  return {
+    adapter,
+    favorites,
+    registered,
+    reads,
+    preferences: () => preferences,
+  };
 }
 
 export function renderTrialMatches(


### PR DESCRIPTION
The last of phase 2 in `docs/federated-ui-parity-plan.md`. Filters a patient sets now survive the session: read from PROMOP on mount, applied to the first search, written back as they change, cleared through the adapter's own reset. With #435 and #436 merged, this closes #419.

## The property everything follows from

**A save is absolute** — it replaces the stored set whole. That one fact produced almost every finding below, in both directions.

- Writing one field while the rest are unknown **discards every filter the patient had** — on the strength of a panel showing the defaults precisely *because* they could not be read. Saving is inert until the read succeeds, the panel is not editable until then, and the banner says so: *changes you make now apply to this search but won't be saved*. Reset is gated the same way, not because clearing needs to know what was there, but because that banner would otherwise be a lie in the most expensive direction.
- It also means the write queue holds **one write per patient**: a later write says everything an earlier one would have — but only within one patient's preferences. B's filters say nothing about A's, and with a single slot B's next edit swallowed A's queued reset.
- And it means reset goes through that queue too. Unserialised, a reset and a save can be in flight together, and the server applies them in whichever order they arrive.

## Key groups, adapter delivers

These are not the same thing, and conflating them was three separate bugs. A host that builds its adapter inline — `state={createPromopState({client, personId})}`, the obvious way to write it — hands over a **new object on every render**, all of them the same person. So the debounce and the queue are grouped by the component's patient key, while each write travels on the **adapter it was made with** — which is bound to one person, so it lands where it belongs no matter what the props do afterwards.

Judged against the component's *current* patient instead: a change made a moment before the host moved on was dropped, and so was a reset queued behind an in-flight save — leaving the reader holding exactly what they had cleared.

## What is stored, and what is trusted coming back

Saved: the ten fields the panel actually renders. Not `country` (derived from the patient), not `type`/`sort` (the tab bar and the sort control own those), not the host's own `initialFilters` — stored, they outrank the host next mount and outlive a host that stopped sending them. Not `trialType`, which is disease-scoped: a type chosen under one disease has no matching option under another and `by_trial_type` has no leniency for a value that is not there, so a stored one produces an empty list from a control rendering blank. Persisting it needs the panel to check it against the disease's options first — **#437**.

Read back, the payload is treated as a claim, not as a `FilterState`. PROMOP checks only that it is an object, and this remote is not its only writer: unknown keys, wrong types, over-long strings, a distance that is not a usable radius, a unit qualifying nothing, and a `type` or `sort` smuggled in as a filter are all dropped.

## Findings worth naming

| | |
|---|---|
| **The read gated the whole list for 7 seconds** | "A failed read is not a reason to wait" was true only of the suite's retry-free client; under a host's own, `status` stays `pending` through three retries with backoff. A *disabled* query is pending for ever too, so an adapter that cannot be asked at all stalled it permanently. |
| **The first edit dropped the other saved filters for 400ms** | The debounce is seeded at mount, before the stored filters exist. The Sponsor box read "Acme", the badge counted it, and the request did not carry it. |
| **A stored value the host happened to agree with was deleted** | And a saved radius lost its *unit* the same way: 50 miles came back as 50 km — a different set of trials, nothing on screen to say why. |
| **A save built during a reset rebuilt what the reset was clearing** | The cached stored set is the pre-reset one until the write lands, and that cache is what tells a save to keep a value the host agrees with. |
| **"No trials found" during the read** | A disabled query reports `isLoading` false, so nothing said the list was loading and the empty state fired instead. Every reader with saved filters saw it. |
| **A save failure outlived its patient**; **refs written during render**; **an adapter that throws synchronously** deadlocked the queue for ever (`.finally` never ran, `inFlight` stayed true) | |

Three pieces turned out to be dead and are gone: a `canSave` flag nothing read, a `generation` counter no path could reach with a stale value, and two lines in reset that cleared what was already null. The debounce's timer and payload are now one ref, so "there is a timer" and "there is a payload" stop being the same fact kept in two places.

## Judgment calls, stated

- **`listAdvancedEnrollments`-style capability check is all-or-nothing.** An adapter must implement read, write *and* clear or the feature is off: with only some, it does not degrade into a smaller feature but into a wrong one — filters that load and then cannot be changed.
- **A value the reader selects that happens to equal the host's is stored as theirs**, once they have any stored value for that field. Codex would rather it were dropped; the alternative makes choosing the value the host already uses mean "delete my preference", which is a surprising thing for a dropdown to do and cannot be told apart on screen from choosing it on purpose.
- **One limitation documented rather than fixed**: the identity these rules group on is `stateKey`, chosen for maximum discrimination as a *cache* key, so for the inline-payload host a change to the payload's content for the same person reads as a different patient and discards unfinished panel edits. The write half is no longer affected (the adapter routes it). **#438** proposes the real fix — a `patientKey` prop, so the remote is told rather than guessing.

## Tests

241, `tsc -b --force` clean, app and remote builds green. **56 mutations, all caught** — including "trust the cache during a reset", "one queue slot for everyone", "drop another patient's debounce", "group the queue by adapter instead of key", "call the adapter directly instead of through a promise", and "save without having read".

Reviewed by two fresh-context passes and seven `codex review` passes; every finding is either fixed above or listed under judgment calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015G5YkuAcDZQUTutNEBGwyX