### PR TITLE
ci: repair the runner's pip from the bundled wheel, not with ensurepip

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -37,16 +37,30 @@ jobs:
           libgeos-dev \
           postgresql-client
     - name: Install Python dependencies
-      # The runner's cached/toolcache pip is a broken 24.1+ mix: importing pip
-      # itself raises `ImportError: cannot import name 'get_runnable_pip'`, so
-      # even `python -m pip install "pip<24.1"` can't run. Repair pip first with
-      # the stdlib `ensurepip` bootstrap (it unpacks a bundled wheel without
-      # importing the broken pip), THEN pin pip < 24.1 — a build-isolation path
-      # in `pip install -r requirements.txt` still imports get_runnable_pip,
-      # which 24.1 removed. Deterministic fix until the build backend is fixed.
+      # The toolcache pip on a hosted runner can be internally broken: 26.2.1
+      # ships a `build_env/installer.py` that imports `open_rich_spinner` from
+      # its own `cli/spinners.py`, which does not define it. Any `python -m pip`
+      # then raises ImportError before doing anything.
+      #
+      # `ensurepip --upgrade` does NOT repair that, which is what this step used
+      # to rely on: it compares versions, sees a NEWER pip installed, reports
+      # "Requirement already satisfied" and installs nothing — leaving the next
+      # line to run the broken one. That is the failure on every runner carrying
+      # the bad image.
+      #
+      # Bootstrapping from ensurepip's bundled WHEEL does repair it. Running
+      # `python <wheel>/pip` executes pip from inside the zip without importing
+      # the installed package at all, so a broken install cannot stop it, and
+      # `--force-reinstall` replaces the newer-but-broken version rather than
+      # skipping it.
+      #
+      # The `pip<24.1` pin stays: a build-isolation path in
+      # `pip install -r requirements.txt` imports `get_runnable_pip`, which
+      # 24.1 removed.
       run: |
-        python -m ensurepip --upgrade
-        python -m pip install "pip<24.1"
+        PIP_WHEEL="$(python -c 'import ensurepip, glob, pathlib; print(glob.glob(str(pathlib.Path(ensurepip.__file__).parent / "_bundled" / "pip-*.whl"))[0])')"
+        python "$PIP_WHEEL/pip" install --force-reinstall "pip<24.1"
+        python -m pip --version
         pip install -r requirements.txt
 
   test:


### PR DESCRIPTION
`build` is failing on `cb-like-trials` PRs — #443 first, and everything else the moment its runner picks up the same image:

```
ImportError: cannot import name 'open_rich_spinner'
from 'pip._internal.cli.spinners'
```

## What is actually broken

The toolcache pip (26.2.1) is internally inconsistent: its `build_env/installer.py` imports a symbol its own `cli/spinners.py` does not define. So **any** `python -m pip` raises before doing anything. Nothing to do with the diff under test.

The step already carried a repair for an older version of this problem, and the repair is what stopped working. `ensurepip --upgrade` compares versions: seeing a *newer* pip installed it reports "Requirement already satisfied" and installs nothing, leaving the next line to run the broken one. The log shows exactly that, two lines apart:

```
Requirement already satisfied: pip in /opt/hostedtoolcache/... (26.2.1)
ImportError: cannot import name 'open_rich_spinner' ...
```

Not a flake: [run 34656799923](https://github.com/healthkey-ai/exact/actions/runs/34656799923) reproduced it identically on re-run. The other branches are green because they landed on a different image — it is a coin toss, and the four #420 PRs are exposed to the same one.

## The fix

Bootstrap from the wheel in `ensurepip._bundled` instead. Two properties matter, and they are separate:

- `python "$PIP_WHEEL/pip"` runs pip **from inside the zip**, importing nothing from site-packages — so a broken install cannot stop it;
- `--force-reinstall` replaces a newer-but-broken version rather than skipping it, which is the half `ensurepip --upgrade` gets wrong.

Verified locally on 3.12 (not on a runner — I cannot run Actions): running pip from the wheel reports the wheel's own version, and `--force-reinstall "pip<24.1"` leaves 24.0 in a venv that had a newer one. The step now also prints `python -m pip --version` after the repair, so the next failure of this kind says which pip ran instead of only that it crashed.

The `pip<24.1` pin stays — the existing comment says a build-isolation path in `pip install -r requirements.txt` imports `get_runnable_pip`, removed in 24.1.

Only `build` installs Python dependencies (`test` restores the cached `pythonLocation`), so this is the one step that needs it.

## Two things for a human to decide

- **The same file is on `dev` and `main`** and will hit this the moment a runner there picks up the bad image. This branch targets `cb-like-trials` because that is where the blocked PRs are; it wants forward-porting.
- **The `pip<24.1` pin may be stale.** `Dockerfile` does `python3 -m pip install --upgrade pip` with no pin and builds fine, which is hard to square with the comment's claim about `requirements.txt`. Worth testing whether the pin is still needed rather than removing it blind — that is a separate change with its own way of failing.

## Review status, stated exactly

`codex review` passed on this diff. The fresh-context review was still in flight when this was opened at your request; I will fold whatever it finds into this branch before it is merged, and say so here either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015G5YkuAcDZQUTutNEBGwyX