### PR TITLE
ci: stop caching a downgraded pip on top of the image's own

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -21,10 +21,6 @@ jobs:
         key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}-v1
         restore-keys: |
           ${{ runner.os }}-pip-
-    - uses: actions/cache@v4
-      with:
-        path: ${{ env.pythonLocation }}
-        key: ${{ runner.os }}-${{ env.pythonLocation }}-${{ hashFiles('requirements.txt') }}-v2
     - name: Install system dependencies
       run: |
         sudo rm -f /etc/apt/sources.list.d/azure-cli.list /etc/apt/sources.list.d/microsoft-prod.list
@@ -37,31 +33,33 @@ jobs:
           libgeos-dev \
           postgresql-client
     - name: Install Python dependencies
-      # The toolcache pip on a hosted runner can be internally broken: 26.2.1
-      # ships a `build_env/installer.py` that imports `open_rich_spinner` from
-      # its own `cli/spinners.py`, which does not define it. Any `python -m pip`
-      # then raises ImportError before doing anything.
+      # This job exists to fail fast on a bad `requirements.txt`, and to fill
+      # `~/.cache/pip` before the three `test` jobs start — otherwise they
+      # race to save the same key and two of them lose.
       #
-      # `ensurepip --upgrade` does NOT repair that, which is what this step used
-      # to rely on: it compares versions, sees a NEWER pip installed, reports
-      # "Requirement already satisfied" and installs nothing — leaving the next
-      # line to run the broken one. That is the failure on every runner carrying
-      # the bad image.
+      # It does NOT hand its `site-packages` to `test` any more. That is what
+      # broke CI. The step used to pin pip down to 24.0 INSIDE the directory
+      # the workflow cached, so the saved entry could never agree with the
+      # image it was restored onto (26.2.1), and `actions/cache` untars OVER
+      # a tree rather than replacing it. The union was neither version:
+      # 26.2.1's `build_env/` package survived beside 24.0's `build_env.py`
+      # and won the import, then asked 24.0's overwritten `cli/spinners.py`
+      # for `open_rich_spinner`. Every `python -m pip` died there.
       #
-      # Bootstrapping from ensurepip's bundled WHEEL does repair it. Running
-      # `python <wheel>/pip` executes pip from inside the zip without importing
-      # the installed package at all, so a broken install cannot stop it, and
-      # `--force-reinstall` replaces the newer-but-broken version rather than
-      # skipping it.
+      # No image upgrade was involved, which is why it read as random:
+      # entries are scoped per `refs/pull/N/merge`, so each PR poisoned only
+      # itself — first run missed, passed, saved; second run hit what it had
+      # written and failed. PR #432, eleven minutes apart on one image: run
+      # 34570074256 missed and passed, run 34570854589 hit and died.
       #
-      # The `pip<24.1` pin stays: a build-isolation path in
-      # `pip install -r requirements.txt` imports `get_runnable_pip`, which
-      # 24.1 removed.
+      # The pin is gone with it. `get_runnable_pip` was never removed in 24.1
+      # — it sits in `build_env.py` in 24.0 and 24.1 and moved to
+      # `utils/misc.py` by 26.2.1 — so the August ImportError the pin was
+      # added for was this same mixed tree, read from the other side. The
+      # image's own pip installs this file: docker run 33601218069 does it
+      # under 26.2.1, psycopg2's sdist build isolation included.
       run: |
-        PIP_WHEEL="$(python -c 'import ensurepip, glob, pathlib; print(glob.glob(str(pathlib.Path(ensurepip.__file__).parent / "_bundled" / "pip-*.whl"))[0])')"
-        python "$PIP_WHEEL/pip" install --force-reinstall "pip<24.1"
-        python -m pip --version
-        pip install -r requirements.txt
+        python -m pip install -r requirements.txt
 
   test:
     runs-on: ubuntu-latest
@@ -89,10 +87,13 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: '3.12'
-    - uses: actions/cache@v4
+    - name: Cache pip
+      uses: actions/cache@v4
       with:
-        path: ${{ env.pythonLocation }}
-        key: ${{ runner.os }}-${{ env.pythonLocation }}-${{ hashFiles('requirements.txt') }}-v2
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}-v1
+        restore-keys: |
+          ${{ runner.os }}-pip-
     - name: Install system dependencies
       run: |
         sudo rm -f /etc/apt/sources.list.d/azure-cli.list /etc/apt/sources.list.d/microsoft-prod.list
@@ -105,6 +106,11 @@ jobs:
           libgeos-dev \
           libgeos-c1v5 \
           postgresql-client
+    - name: Install Python dependencies
+      # Its own, not `build`'s — see the comment there for what happened when
+      # this job had no install step and ran on a cached `site-packages`.
+      run: |
+        python -m pip install -r requirements.txt
     - name: Set environment
       run: |
         echo "SECRET_KEY=ci-secret-key-not-used-in-prod" >> $GITHUB_ENV


### PR DESCRIPTION
Supersedes the fix merged in #451, which does not work.

## What actually breaks CI

Two of our own decisions, harmless apart and fatal together:

1. the workflow cached the interpreter's whole `site-packages`, and
2. the install step downgraded pip to 24.0 **inside that same directory**.

So the saved entry could never agree with the image it was restored onto (26.2.1),
and `actions/cache` untars **over** an existing tree instead of replacing it. The
union is neither version:

```
pip/_internal/build_env/       <- 26.2.1 (package)  wins the import
pip/_internal/build_env.py     <- 24.0   (module)
pip/_internal/cli/spinners.py  <- 24.0   (overwritten, no open_rich_spinner)
pip-24.0.dist-info  pip-26.2.1.dist-info
```

No runner-image change is involved — every run below ran on `ubuntu24/20260907.300`.
It read as random because entries are scoped per `refs/pull/N/merge`, so **each PR
poisons only itself**: first run misses, passes, saves; the second — a re-run or
another push — hits what it just wrote and dies. PR #432 is the clean pair, eleven
minutes apart on one image:

| | run | cache | result |
|---|---|---|---|
| 06:30 | 34570074256 | not found | passed, then **saved** |
| 06:39 | 34570854589 | **hit** | `ImportError: open_rich_spinner` |

This is also why #443's red would never have cleared by re-running it, contrary to
what I said earlier — the entry it restores is its own, written 2026-09-11.

## Both halves go

**The cache**, because re-keying cannot help: the next entry is poisoned exactly
like the last. Keying the runner image into it would have been worse than useless —
**`test` had no install step at all**, it restored `build`'s `site-packages` and ran
on it, so a `test` job landing on a different image than `build` would have run with
nothing installed. Both jobs now install their own dependencies; the only cache left
is `~/.cache/pip`, which is downloads rather than an installed tree.

**The pin**, because its stated reason was never true:

```
pip 24.0    get_runnable_pip -> build_env.py
pip 24.1    get_runnable_pip -> build_env.py     (not removed)
pip 26.2.1  get_runnable_pip -> utils/misc.py    (moved)
```

The August ImportError the pin was added for (2a3cf84) was this same mixed tree read
from the other side; the pin has been treating a cache bug since. The image's own pip
installs this file — docker run 33601218069 does it under 26.2.1, psycopg2's sdist
build isolation included, which is the path `get_runnable_pip` lives on. And this
PR's own CI is green with no pin: pip stayed at 26.2.1, everything installed,
330 tests passed.

Dropping it also stops CI from testing an install two years older than the one that
ships in the container.

## Theories I had to discard

1. *Broken pip 26.2.1 in the image.* False — installed clean it works.
2. *A cache entry drifting between runner images.* False — identical image on both
   sides of every failure. I had taken the image version on trust without checking.

And #451's green tick proved nothing: its log reads `Cache not found`, so it ran on a
pristine tree and never met the failure. Rebuilding the mixed tree locally and running
#451's `--force-reinstall` against it leaves the ImportError untouched.

## Cost

Install with a warm wheel cache is 25.7s against ~4s to restore the old cache — but
*saving* that cache cost `build` 85s. The three `test` jobs run in parallel. Net:
roughly a wash, often faster, and about 160 MB of cache quota returned per
requirements hash.

## Reviews

Both ran, twice, and they earned their keep.

- `codex review` flagged that `env.ImageOS` never reaches the expression context,
  killing my image-key attempt before it shipped. Clean on the final diff.
- The fresh-context review caught the image-drift claim by pulling the image version
  from all six runs, produced the PR #432 pair, and found the `get_runnable_pip`
  claim to be false. Both are why this PR looks the way it does.

Findings I did not act on, deliberately:

- **`dev` and `main` still carry the broken workflow** (`dev` has both halves; `main`
  caches `site-packages` without the pin). Forward-porting is your call.
- **~16 stale `pythonLocation` cache entries, ~2.6 GB.** They stop mattering here the
  moment nothing restores that path. Deleting them would unblock one run on branches
  still using the old workflow, then those runs would save a fresh poisoned entry — a
  one-shot unblock, not a fix. Say the word and I'll purge them.
- **Built wheels in `~/.cache/pip/wheels`** (e.g. `psycopg2-...-linux_x86_64.whl`) are
  compiled against whatever image built them, and the key doesn't include the
  toolchain. Pre-existing, low risk, cannot reproduce this failure class — nothing is
  untarred over a live interpreter.