### PR TITLE
ci: stop caching a downgraded pip on top of the image's own

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -21,10 +21,6 @@ jobs:
         key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}-v1
         restore-keys: |
           ${{ runner.os }}-pip-
-    - uses: actions/cache@v4
-      with:
-        path: ${{ env.pythonLocation }}
-        key: ${{ runner.os }}-${{ env.pythonLocation }}-${{ hashFiles('requirements.txt') }}-v2
     - name: Install system dependencies
       run: |
         sudo rm -f /etc/apt/sources.list.d/azure-cli.list /etc/apt/sources.list.d/microsoft-prod.list
@@ -37,17 +33,34 @@ jobs:
           libgeos-dev \
           postgresql-client
     - name: Install Python dependencies
-      # The runner's cached/toolcache pip is a broken 24.1+ mix: importing pip
-      # itself raises `ImportError: cannot import name 'get_runnable_pip'`, so
-      # even `python -m pip install "pip<24.1"` can't run. Repair pip first with
-      # the stdlib `ensurepip` bootstrap (it unpacks a bundled wheel without
-      # importing the broken pip), THEN pin pip < 24.1 — a build-isolation path
-      # in `pip install -r requirements.txt` still imports get_runnable_pip,
-      # which 24.1 removed. Deterministic fix until the build backend is fixed.
+      # This job exists to fail fast on a bad `requirements.txt`, and to fill
+      # `~/.cache/pip` before the three `test` jobs start — otherwise they
+      # race to save the same key and two of them lose.
+      #
+      # It does NOT hand its `site-packages` to `test` any more. That is what
+      # broke CI on the feature branches. The step used to pin pip down to
+      # 24.0 INSIDE the directory the workflow cached, so the saved entry
+      # could never agree with the image it was restored onto (26.2.1), and
+      # `actions/cache` untars OVER a tree rather than replacing it. The
+      # union was neither version: 26.2.1's `build_env/` package survived
+      # beside 24.0's `build_env.py` and won the import, then asked 24.0's
+      # overwritten `cli/spinners.py` for `open_rich_spinner`. Every
+      # `python -m pip` died there.
+      #
+      # No image upgrade was involved, which is why it read as random:
+      # entries are scoped per `refs/pull/N/merge`, so each PR poisoned only
+      # itself — first run missed, passed, saved; second run hit what it had
+      # written and failed. PR #432, eleven minutes apart on one image: run
+      # 34570074256 missed and passed, run 34570854589 hit and died.
+      #
+      # The pin goes with it. `get_runnable_pip` was never removed in 24.1 —
+      # it sits in `build_env.py` in 24.0 and 24.1 and moved to
+      # `utils/misc.py` by 26.2.1 — so the ImportError the pin was added for
+      # was this same mixed tree read from the other side. The image's own
+      # pip installs this file: docker run 33601218069 does it under 26.2.1,
+      # psycopg2's sdist build isolation included.
       run: |
-        python -m ensurepip --upgrade
-        python -m pip install "pip<24.1"
-        pip install -r requirements.txt
+        python -m pip install -r requirements.txt
 
   test:
     runs-on: ubuntu-latest
@@ -75,10 +88,13 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: '3.12'
-    - uses: actions/cache@v4
+    - name: Cache pip
+      uses: actions/cache@v4
       with:
-        path: ${{ env.pythonLocation }}
-        key: ${{ runner.os }}-${{ env.pythonLocation }}-${{ hashFiles('requirements.txt') }}-v2
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}-v1
+        restore-keys: |
+          ${{ runner.os }}-pip-
     - name: Install system dependencies
       run: |
         sudo rm -f /etc/apt/sources.list.d/azure-cli.list /etc/apt/sources.list.d/microsoft-prod.list
@@ -91,6 +107,12 @@ jobs:
           libgeos-dev \
           libgeos-c1v5 \
           postgresql-client
+    - name: Install Python dependencies
+      # Its own, not `build`'s — see the comment there for what happened
+      # when this job had no install step at all and ran on a cached
+      # `site-packages`.
+      run: |
+        python -m pip install -r requirements.txt
     - name: Set environment
       run: |
         echo "SECRET_KEY=ci-secret-key-not-used-in-prod" >> $GITHUB_ENV


### PR DESCRIPTION
Forward-port of #452 (on `cb-like-trials`). **`dev` carries both halves of the bug**,
so it is affected exactly as the feature branches were — this is a repair, not a
precaution. The `main` port is #454 and is preventive.

## The bug

Two of our own decisions, harmless apart and fatal together: the workflow cached the
interpreter's whole `site-packages`, and the install step downgraded pip to 24.0
**inside that directory**. The saved entry can therefore never agree with the image it
is restored onto (26.2.1), and `actions/cache` untars **over** a tree rather than
replacing it. The union is neither version:

```
pip/_internal/build_env/       <- 26.2.1 (package)  wins the import
pip/_internal/build_env.py     <- 24.0   (module)
pip/_internal/cli/spinners.py  <- 24.0   (overwritten, no open_rich_spinner)
```

No runner-image change is involved. Entries are scoped per `refs/pull/N/merge`, so each
PR poisons only itself: first run misses, passes, saves; the second — a re-run or
another push — hits what it just wrote and dies. PR #432 is the clean pair, eleven
minutes apart on one image: run 34570074256 missed and passed, run 34570854589 hit and
got `ImportError: open_rich_spinner`.

**`dev`'s own entry is already the mixed tree.** Run 33601218036 (push, 2026-09-02)
missed the cache, downgraded pip, and saved — so PRs based on `dev` can restore it.
`dev` itself stayed green only because its `test` job never invokes pip.

## Both halves go

**The cache**, because re-keying cannot help — the next entry is poisoned like the last
— and because keying the runner image in would be worse than useless: `test` had **no
install step**, it ran on `build`'s `site-packages`, so a `test` job landing on a
different image would run with nothing installed. Both jobs now install their own; the
only cache left is `~/.cache/pip`, which is downloads rather than an installed tree.

**The pin**, because its stated reason was never true:

```
pip 24.0    get_runnable_pip -> build_env.py
pip 24.1    get_runnable_pip -> build_env.py     (not removed)
pip 26.2.1  get_runnable_pip -> utils/misc.py    (moved)
```

So the ImportError this branch's `ensurepip` repair was built around (a13f4c7) was this
same mixed tree read from the other side.

## Evidence this is safe here

`requirements.txt` is the **same git blob** on `dev`, `main` and `cb-like-trials`
(`a75d9c9`), so #452's green CI is direct evidence for this port: pip stayed at the
image's 26.2.1, everything installed including psycopg2's sdist build isolation, 330
tests passed.

## Reviews

`codex review` clean. A fresh-context review compared both ports against the reviewed
#452 file, confirmed `dev` is byte-identical to it bar comment wording, and verified the
blob equality and `dev`'s poisoned entry above. Its findings on comment wording are
folded in.

## Notes for the merger

- Push to `dev` triggers `backend` + `docker` (tags `dev` + sha; `:latest` is gated on
  the default branch, so not). No staging deploy — `deploy-staging.yml` is manual.
- `main` and `dev` diverge on `docker.yml` and `deploy-staging.yml`, with **`main`
  ahead**. A future dev→main merge must not resolve those toward `dev`.