### PR TITLE
ci: stop caching an installed site-packages across runner images

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -21,10 +21,6 @@ jobs:
         key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}-v1
         restore-keys: |
           ${{ runner.os }}-pip-
-    - uses: actions/cache@v4
-      with:
-        path: ${{ env.pythonLocation }}
-        key: ${{ runner.os }}-${{ env.pythonLocation }}-${{ hashFiles('requirements.txt') }}-v1
     - name: Install system dependencies
       run: |
         sudo apt-get -qq update && \
@@ -36,7 +32,39 @@ jobs:
           libgeos-dev \
           postgresql-client
     - name: Install Python dependencies
-      run: pip install -r requirements.txt
+      # This job exists to fail fast on a bad `requirements.txt`, and to fill
+      # `~/.cache/pip` before the three `test` jobs start — otherwise they
+      # race to save the same key and two of them lose.
+      #
+      # It does NOT hand its `site-packages` to `test` any more, and on this
+      # branch that is the whole point: `test` had NO install step of its own.
+      # It restored `build`'s installed tree and ran on it, so anything that
+      # kept the entry from being there left the job with zero dependencies.
+      #
+      # That is not hypothetical. Run 32647557900 (2026-08-23) logged
+      # `Failed to save: Unable to reserve cache with key ... another job may
+      # be creating this cache` in `build`, and its three `test` jobs got a
+      # hit only because a push 38 seconds earlier had written the key. On
+      # its own it would have died at `makemigrations` with a bare
+      # ModuleNotFoundError.
+      #
+      # The second hazard is subtler and is what broke the feature branches:
+      # `actions/cache` untars OVER an existing tree rather than replacing
+      # it, so a restored entry and the image are unioned, not swapped. There
+      # they had pinned pip down inside the cached directory, and the union
+      # put 26.2.1's `build_env/` package beside 24.0's `build_env.py`; the
+      # package won the import and asked the overwritten `cli/spinners.py`
+      # for `open_rich_spinner`, so every `python -m pip` died. This branch
+      # never downgraded pip, so its entry has matched the image so far.
+      # Note the key embeds the interpreter's patch path, so a new image
+      # usually MISSES rather than unions — the union needs pip to change
+      # under an unchanged 3.12.x, which a toolcache rebuild can do.
+      #
+      # Both hazards end the same way: don't ship one job's installed tree to
+      # another. Only `~/.cache/pip` is left, which is downloads and not an
+      # installed tree.
+      run: |
+        python -m pip install -r requirements.txt
 
   test:
     runs-on: ubuntu-latest
@@ -64,10 +92,13 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: '3.12'
-    - uses: actions/cache@v4
+    - name: Cache pip
+      uses: actions/cache@v4
       with:
-        path: ${{ env.pythonLocation }}
-        key: ${{ runner.os }}-${{ env.pythonLocation }}-${{ hashFiles('requirements.txt') }}-v1
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}-v1
+        restore-keys: |
+          ${{ runner.os }}-pip-
     - name: Install system dependencies
       run: |
         sudo apt-get -qq update && \
@@ -79,6 +110,12 @@ jobs:
           libgeos-dev \
           libgeos-c1v5 \
           postgresql-client
+    - name: Install Python dependencies
+      # Its own, not `build`'s — see the comment there for what happened
+      # when this job had no install step at all and ran on a cached
+      # `site-packages`.
+      run: |
+        python -m pip install -r requirements.txt
     - name: Set environment
       run: |
         echo "SECRET_KEY=ci-secret-key-not-used-in-prod" >> $GITHUB_ENV


### PR DESCRIPTION
Forward-port of #452 (on `cb-like-trials`). **Preventive here** — and the reason differs
from the feature branches, which is worth stating because the weaker reason is the one
that looks obvious. The `dev` port is #453 and is a repair.

## `main` is not broken today

The failure on the feature branches needed two things: caching the interpreter's whole
`site-packages`, and downgrading pip **inside** that cached directory. This branch does
the first but not the second, so its entry has matched the image so far. Last backend run
on `main` (2026-08-23) was green.

## The hazard that already came close

`test` has **no install step**. It restores `build`'s installed tree and runs on it, so
anything that keeps the entry from being there leaves the job with no dependencies at
all. Run 32647557900 logged, in `build`:

```
Failed to save: Unable to reserve cache with key
Linux-/opt/hostedtoolcache/Python/3.12.14/x64-...-v1,
another job may be creating this cache.
```

Its three `test` jobs got a hit anyway — but only because a push **38 seconds earlier**
(run 32647521764) had written that key. Alone, they would have died at `makemigrations`
with a bare `ModuleNotFoundError`, on `main`.

## The second hazard, stated precisely

`actions/cache` untars **over** an existing tree rather than replacing it, so a restored
entry and the image are unioned, not swapped. On the feature branches the union put
26.2.1's `build_env/` package beside 24.0's `build_env.py`; the package won the import
and asked the overwritten `cli/spinners.py` for a symbol 24.0 never had.

Here it needs pip to change under an **unchanged** 3.12.x — the cache key embeds the
interpreter's patch path, so a new image usually misses rather than unions. A toolcache
rebuild can do exactly that. Narrower than the first hazard, and not zero.

Both end the same way: don't ship one job's installed tree to another. So the
site-packages cache goes, `test` installs its own dependencies, and the only cache left
is `~/.cache/pip` — downloads rather than an installed tree, validated by pip when it
uses them, never untarred over a live interpreter.

## Evidence this is safe here

Unlike `dev`, there is no pip pin to remove. `requirements.txt` is the **same git blob**
on this branch, `dev` and `cb-like-trials` (`a75d9c9`), so #452's green CI is direct
evidence for this port.

## Reviews

`codex review` clean. A fresh-context review compared both ports against the reviewed
#452 file and produced the run 32647557900 near-miss above; its finding that my first
comment named the *less likely* failure mode is folded in.

## Notes for the merger

- Push to `main` triggers `backend` + `docker`, and `main`'s `docker.yml` publishes
  `:latest` — so a CI-only commit here **republishes the `:latest` image** and a new sha
  tag. Expected, but not obvious for a workflow-only change. No staging deploy;
  `deploy-staging.yml` is manual-only on this branch.
- This branch still lacks the `sudo rm -f .../azure-cli.list` guard the others carry
  (0cd7400). Left alone deliberately — it is a separate port. Say the word if you want it
  folded in; the argument for it is that an unrelated apt flake on the merge commit would
  otherwise be misread as this change breaking `main`.
- `main` is **ahead** of `dev` on `docker.yml` and `deploy-staging.yml`. A future dev→main
  merge must not resolve those toward `dev`.