### PR TITLE
fix(trials): answer a detail request that has no patient, instead of 500ing

### DIFF
--- a/tests/views/test_detail_without_patient.py
+++ b/tests/views/test_detail_without_patient.py
@@ -1,0 +1,173 @@
+"""`GET /trials/{id}/` with no patient context (#362, #374, #423 — one bug,
+filed three times).
+
+`resolve_patient_info` returns None for a request with no inline payload and
+no resolvable `person_id`. That is the documented public-browsing path, and
+the LIST endpoint answers it with unfiltered results. Only the detail endpoint
+fell over, five frames down, as `'NoneType' object has no attribute
+'prior_therapy'`.
+
+The answer is the list's answer: 200, and the trial unscored. A 400 would make
+this the one endpoint that refuses a request the rest of the API serves, and
+the trial's own requirements are worth reading whether or not there is anyone
+to compare them to.
+"""
+import pytest
+from rest_framework.authtoken.models import Token
+from rest_framework.test import APIClient
+
+from accounts.models import Identity
+from tests.factories import TrialFactory
+
+
+@pytest.fixture
+def authed_client(db):
+    user, _ = Identity.objects.get_or_create(issuer='urn:local', sub='no-patient-tester')
+    token, _ = Token.objects.get_or_create(user=user)
+    client = APIClient()
+    client.credentials(HTTP_AUTHORIZATION=f'Token {token.key}')
+    return client
+
+
+@pytest.mark.django_db
+class TestDetailWithoutPatientContext:
+    def test_it_answers_rather_than_500ing(self, authed_client):
+        trial = TrialFactory(disease='multiple myeloma', brief_title='A study')
+
+        response = authed_client.get(f'/trials/{trial.id}/')
+
+        assert response.status_code == 200
+        assert response.data['briefTitle'] == 'A study'
+
+    def test_it_says_nothing_about_a_patient_who_is_not_there(self, authed_client):
+        """No score and no verdict — rather than a zero, which is the sentinel
+        for a disqualification, or `eligible`, which is a claim."""
+        trial = TrialFactory(disease='multiple myeloma', age_low_limit=18)
+
+        data = authed_client.get(f'/trials/{trial.id}/').data
+
+        assert data['matchScore'] is None
+        assert data['matchingType'] is None
+        for row in data['details']['trialEligibilityAttributes']:
+            assert not row.get('matchingType'), row
+            assert row.get('uvalue') in (None, '', [])
+
+    def test_the_trial_side_is_all_still_there(self, authed_client):
+        """The point of answering at all — and asserted as PARITY with the
+        patient-carrying response, not as "some rows came back".
+
+        The first version of this test checked that `disease` was present.
+        `disease` is hardcoded into `ATTR_NAME_ALWAYS_INCLUDED`, so it survives
+        by construction: the test was green precisely because it named the one
+        row that cannot be dropped, while nine others were being dropped
+        silently. Twelve rows became two and nothing failed.
+        """
+        trial = TrialFactory(
+            disease='multiple myeloma',
+            age_low_limit=18,
+            age_high_limit=75,
+            ecog_performance_status_max=2,
+            platelet_count_min=75,
+            hemoglobin_level_min=8,
+        )
+
+        without = authed_client.get(f'/trials/{trial.id}/').data
+        with_patient = authed_client.post(
+            f'/trials/{trial.id}/match/',
+            {'patient_info': {'disease': 'multiple myeloma', 'patientAge': 45}},
+            format='json',
+        ).data
+
+        names = lambda d: sorted(
+            r['name'] for r in d['details']['trialEligibilityAttributes']
+        )
+        assert names(without) == names(with_patient)
+        # And they are the trial's real requirements, not a single always-on row.
+        assert {'age', 'ecogPerformanceStatusMax', 'plateletCountMin'} <= set(names(without))
+
+        rows = {r['name']: r for r in without['details']['trialEligibilityAttributes']}
+        assert rows['disease']['value'] == 'multiple myeloma'
+        assert rows['ecogPerformanceStatusMax']['value'] == 2
+
+    def test_the_general_rows_claim_nothing_about_a_distance(self, authed_client):
+        """`get_distance_penalty` answers 0 with no patient — the scoring
+        neutral for "no distance known", which a located-less patient gets too.
+        Printed in a cell labelled "distance Penalty" it reads as "this patient
+        is next door", about somebody who is not there."""
+        trial = TrialFactory(disease='multiple myeloma')
+
+        data = authed_client.get(f'/trials/{trial.id}/').data
+        general = {r['name']: r for r in data['details']['general']}
+
+        assert general['distancePenalty']['value'] == ''
+        assert general['matchScore']['uvalue'] in (None, '')
+
+    def test_the_therapy_criteria_are_there_too(self, authed_client):
+        """`therapies()` returned an empty dict with no patient, so the one
+        kind of criterion a reader browsing a trial most wants to see was
+        missing from the response with no indication it had been left out.
+
+        Nothing in that method reads the patient — the patient side of these
+        rows is filled in later by the matcher."""
+        trial = TrialFactory(
+            disease='multiple myeloma',
+            therapies_required=['vrd'],
+            therapies_excluded=['dara'],
+        )
+
+        data = authed_client.get(f'/trials/{trial.id}/').data
+        rows = {r['name']: r for r in data['details']['trialEligibilityAttributes']}
+
+        assert 'therapiesRequired' in rows, sorted(rows)
+        assert rows['therapiesRequired']['value'] == ['vrd']
+        # And still no claim about anybody.
+        assert not rows['therapiesRequired'].get('matchingType')
+        assert rows['therapiesRequired'].get('uvalue') in (None, [], '')
+
+    def test_a_trial_with_sites_still_lists_them(self, authed_client):
+        """`sorted_locations_by_distance` was handed the patient's geo point
+        without a guard. With nobody, the sites come back in the trial's own
+        order — which is the only honest answer to "closest to whom?"."""
+        from trials.models import Location, LocationTrial
+
+        trial = TrialFactory(disease='multiple myeloma')
+        for name in ('Guy\'s', 'St Thomas\''):
+            location = Location.objects.create(city='London', title=name)
+            LocationTrial.objects.create(trial=trial, location=location)
+
+        data = authed_client.get(f'/trials/{trial.id}/').data
+        general = {r['name']: r for r in data['details']['general']}
+        assert set(general['locationsName']['value']) == {"Guy's", "St Thomas'"}
+
+    def test_the_same_request_with_a_patient_still_scores(self, authed_client):
+        """The guard must not have turned the ordinary path off."""
+        trial = TrialFactory(disease='multiple myeloma', age_low_limit=18, age_high_limit=75)
+
+        response = authed_client.post(
+            f'/trials/{trial.id}/match/',
+            {'patient_info': {'disease': 'multiple myeloma', 'patientAge': 45}},
+            format='json',
+        )
+
+        assert response.status_code == 200
+        assert response.data['matchScore'] is not None
+        assert response.data['matchingType'] is not None
+
+
+@pytest.mark.django_db
+class TestTheMatcherSaysSoItself:
+    def test_building_one_without_a_patient_is_refused(self):
+        """Rather than discovered five frames down. Every question the matcher
+        answers is "how does THIS patient compare", so with nobody there is no
+        answer — and the caller is the one who has to decide what to render
+        instead."""
+        from trials.services.user_to_trial_attr_matcher import UserToTrialAttrMatcher
+
+        trial = TrialFactory(disease='multiple myeloma')
+        with pytest.raises(ValueError, match='needs a patient'):
+            UserToTrialAttrMatcher(trial=trial, patient_info=None)
+
+    @pytest.mark.parametrize('method', ['get_match_score', 'matching_type'])
+    def test_the_model_helpers_answer_none_instead(self, method):
+        trial = TrialFactory(disease='multiple myeloma')
+        assert getattr(trial, method)(None) is None

--- a/trials/models.py
+++ b/trials/models.py
@@ -768,12 +768,27 @@ class Trial(TimeStampMixin):
         return UserToTrialAttrsMapper().potential_attrs_for_trial(self, counts)
 
     def get_match_score(self, patient_info):
+        """How well this trial matches that patient, or None for no patient.
+
+        `resolve_patient_info` legitimately returns None — a request with no
+        inline payload and no resolvable `person_id` is the documented
+        public-browsing path, and the list endpoint answers it with unfiltered
+        results. Asking a matcher to score against nobody is not a question
+        with an answer, so this says so rather than dereferencing None several
+        frames further down.
+        """
+        if patient_info is None:
+            return None
         return UserToTrialAttrMatcher(trial=self, patient_info=patient_info).trial_match_score()
 
     def details_and_group_names(self, patient_info, template, attrs_to_fill_in):
         return TrialTemplates(trial=self, patient_info=patient_info).details_and_group_names(template, attrs_to_fill_in)
 
     def matching_type(self, patient_info):
+        """The verdict for that patient, or None for no patient — see
+        `get_match_score`."""
+        if patient_info is None:
+            return None
         return UserToTrialAttrMatcher(trial=self, patient_info=patient_info).trial_match_status()
 
     @property

--- a/trials/services/patient_info/patient_info_attributes.py
+++ b/trials/services/patient_info/patient_info_attributes.py
@@ -98,6 +98,16 @@ BULKY_DISEASE_CRITERIA_SOURCES = {
 
 
 class PatientInfoAttributes:
+    """The patient side of a comparison — or the shape of one, with no patient.
+
+    `patient_info` may be None: `resolve_patient_info` returns None on the
+    public-browsing path, and the trial-detail view still has to describe what
+    the trial requires. Every accessor then answers None, which is what "there
+    is no patient" means about a patient's value. Nothing infers from those
+    Nones that a patient HAS nothing — `UserToTrialAttrMatcher` refuses to be
+    built without one, so no verdict is computed from them.
+    """
+
     def __init__(self, patient_info):
         self.patient_info = patient_info
         self.mapping = USER_TO_TRIAL_ATTRS_MAPPING
@@ -146,6 +156,11 @@ class PatientInfoAttributes:
         return is_blank
 
     def get_value(self, attr_name):
+        # No patient, no value. See the class docstring: this is the shape of a
+        # comparison rather than one, and the trial-detail view needs the shape
+        # to describe what the trial asks for.
+        if self.patient_info is None:
+            return None
         if attr_name == 'pre_existing_condition_categories':
             if self.patient_info.no_pre_existing_conditions is True:
                 return ['none']
@@ -233,6 +248,8 @@ class PatientInfoAttributes:
 
     @cached_property
     def disease_code(self):
+        if self.patient_info is None:
+            return None
         # Tolerate surrounding whitespace + None/empty (CB #4323): a bare
         # str(None).lower() would be 'none'. Kept consistent with the MCL disease
         # gate in normalize._normalize_mcl_derivations so a padded title can't

--- a/trials/services/trial_details/trial_attributes.py
+++ b/trials/services/trial_details/trial_attributes.py
@@ -196,6 +196,20 @@ class TrialAttributes:
 
         return out
 
+    @property
+    def _scoping_disease_code(self):
+        """Whose disease decides which criteria apply.
+
+        The patient's when there is one — a myeloma patient should not be shown
+        a mantle-cell criterion. With no patient, the TRIAL's, which is the
+        right answer anyway: the row belongs to the trial, and a trial has a
+        disease even when nobody is looking at it.
+        """
+        if self._patient_info is not None:
+            return self._patient_info_attr.disease_code
+        from trials.services.user_to_trial_attr_matcher import UserToTrialAttrMatcher
+        return UserToTrialAttrMatcher.get_disease_code_from_trial(self._trial)
+
     def get_field_name(self, field):
         return AttributeNames.get_by_snake_case(field.name)
 
@@ -269,7 +283,10 @@ class TrialAttributes:
             return True
         elif value is False and field_name in ATTR_FALSE_VALUE_IS_BLANK:
             return True
-        elif self._context['gender'] == 'M' and field_name in ATTR_SKIP_FOR_MALE:
+        # `.get`: `get_context_from_user` returns an EMPTY dict when there is
+        # no patient, so the subscript was a KeyError on the public-browsing
+        # path. With nobody to be male, the rule does not apply.
+        elif self._context.get('gender') == 'M' and field_name in ATTR_SKIP_FOR_MALE:
             return True
         return False
 
@@ -545,9 +562,17 @@ class TrialAttributes:
           "dependencies": []
         }
 
-        distance_penalty = self._trial.get_distance_penalty(self._patient_info)
-        if distance_penalty:
-            distance_penalty = str(distance_penalty)
+        # Empty with no patient, the way `matchScore` beside it already is.
+        # The SCORING neutral for "no distance known" is 0 — a located-less
+        # patient gets it too, so the model keeps it — but printing that 0 in a
+        # cell labelled "distance Penalty" reads as "this patient is next
+        # door", which is a claim about somebody who is not there.
+        if self._patient_info is None:
+            distance_penalty = ''
+        else:
+            distance_penalty = self._trial.get_distance_penalty(self._patient_info)
+            if distance_penalty:
+                distance_penalty = str(distance_penalty)
 
         computed_fields['distancePenalty'] = {
           "name": "distancePenalty",
@@ -564,7 +589,10 @@ class TrialAttributes:
         }
 
         locations_name = self._trial.sorted_locations_by_distance(
-            self._patient_info.geo_point,
+            # `None` with no patient: the sites are then in the trial's own
+            # order rather than nearest-first, which is the only honest answer
+            # to "closest to whom?" — and the method already takes it.
+            self._patient_info.geo_point if self._patient_info else None,
             recruitment_status=recruitment_status
         )
         locations_name = [x.location.title for x in locations_name if x.location]
@@ -585,9 +613,17 @@ class TrialAttributes:
         return computed_fields
 
     def therapies(self, subform_attrs):
+        """The trial's therapy criteria, with the patient's values where there
+        is a patient.
+
+        Nothing below reads the patient — `user_value` is None throughout, and
+        the patient side of these rows is filled in later by the matcher. The
+        early return that used to stand here therefore dropped the trial's own
+        therapy requirements from a no-patient response: the one kind of
+        criterion a reader browsing a trial most wants to see, missing with no
+        indication it had been left out.
+        """
         out = {}
-        if not self._patient_info:
-            return out
 
         for field_name in THERAPIES_ATTRS_UNDERSCORED:
             user_value = None
@@ -845,9 +881,21 @@ class TrialAttributes:
         return out
 
     def get_user_details(self, subform_attrs):
+        """Which trial columns are eligibility criteria, and the patient's value
+        for each where there is a patient.
+
+        It used to return nothing at all without one — and `details()` only
+        emits a trial column that appears here or in `ATTR_NAME_ALWAYS_INCLUDED`,
+        so a detail response with no patient carried two rows out of twelve.
+        The trial's own requirements were not rendered verdict-less; they were
+        dropped, with nothing to say so.
+
+        Which columns are criteria is a property of the MAPPING, not of the
+        patient. The only patient-dependent parts are the value (None without
+        one) and the disease scoping, which falls back to the TRIAL's disease —
+        the right answer anyway, since the row belongs to the trial.
+        """
         out = {}
-        if not self._patient_info:
-            return out
 
         mapping = USER_TO_TRIAL_ATTRS_MAPPING
 
@@ -858,8 +906,8 @@ class TrialAttributes:
             ureadonly = ('is_computed_value' in trial_attr_meta and trial_attr_meta['is_computed_value'] is True) or subform_details is not None
 
             if "disease" in trial_attr_meta and (
-                self._patient_info_attr.disease_code is None
-                or not disease_attr_applies(trial_attr_meta["disease"], self._patient_info_attr.disease_code)
+                self._scoping_disease_code is None
+                or not disease_attr_applies(trial_attr_meta["disease"], self._scoping_disease_code)
             ):
                 continue
 
@@ -939,8 +987,13 @@ class TrialAttributes:
                 if isinstance(attr_names, str):
                     attr_names = [attr_names]
                 for attr_name in attr_names:
-                    uvalue_function = trial_attr_meta["uvalue_function"][attr_name]
-                    uvalue = uvalue_function(self._patient_info)
+                    # The lambdas in `configs.py` dereference the patient
+                    # directly — `lambda patient_info: patient_info.ethnicity` —
+                    # so they are not asked when there is nobody to ask about.
+                    uvalue = None
+                    if self._patient_info is not None:
+                        uvalue_function = trial_attr_meta["uvalue_function"][attr_name]
+                        uvalue = uvalue_function(self._patient_info)
                     uvalue = self.get_uvalue(f'u{attr_name}', uvalue)
                     out[attr_name] = {
                         'ureadonly': ureadonly,

--- a/trials/services/trial_details/trial_templates.py
+++ b/trials/services/trial_details/trial_templates.py
@@ -58,7 +58,11 @@ class TrialTemplates:
 
         details = self._trial_attributes.details()
         patient_info = self._patient_info
-        service = UserToTrialAttrMatcher(self._trial, patient_info)
+        # No patient, no matcher — and no claim about one. The rows still carry
+        # what the trial requires; what they do not carry is a verdict, which
+        # is the honest shape for "here is a trial" as opposed to "here is how
+        # you compare to it".
+        service = UserToTrialAttrMatcher(self._trial, patient_info) if patient_info else None
         label = ''
 
         def order_weight(value):
@@ -66,9 +70,11 @@ class TrialTemplates:
                 return 10, ''
             if value['name'] == 'matchScore':
                 return 0, ''
-            return mapping_for_order.get(value['matchingType'], 5), value['label']
+            # `.get`: without a patient no row has a `matchingType` at all,
+            # and they all land on the default weight and sort by label.
+            return mapping_for_order.get(value.get('matchingType'), 5), value['label']
 
-        therapy_match_statuses = service.therapy_related_things_match_status()
+        therapy_match_statuses = service.therapy_related_things_match_status() if service else {}
 
         for field in details.values():
             if not isinstance(field, dict):
@@ -85,15 +91,18 @@ class TrialTemplates:
                 elif field_name in THERAPIES_ATTRS:
                     if field['value'] == []:
                         continue  # skip — active column (legacy or OMOP) has no criteria
-                    field['matchingType'] = therapy_match_statuses[field_name]["status"]
-                    field['uvalue'] = therapy_match_statuses[field_name]["values"]
-                    # OMOP code + title for the OMOP-mapped levels (regimen/component);
-                    # absent for legacy/type criteria. See therapy_related_things_match_status.
-                    if 'omopConcepts' in therapy_match_statuses[field_name]:
-                        field['omopConcepts'] = therapy_match_statuses[field_name]['omopConcepts']
+                    if field_name in therapy_match_statuses:
+                        field['matchingType'] = therapy_match_statuses[field_name]["status"]
+                        field['uvalue'] = therapy_match_statuses[field_name]["values"]
+                        # OMOP code + title for the OMOP-mapped levels (regimen/component);
+                        # absent for legacy/type criteria. See therapy_related_things_match_status.
+                        if 'omopConcepts' in therapy_match_statuses[field_name]:
+                            field['omopConcepts'] = therapy_match_statuses[field_name]['omopConcepts']
                     out['trialEligibilityAttributes'].append(field)
                 elif not self._trial_attributes.is_blank(field_name, field['value'], field.get('search_type')):
-                    if field['ufield']:
+                    if service is None:
+                        pass  # no patient, so no verdict — see above
+                    elif field['ufield']:
                         field['matchingType'] = service.attr_match_status(AttributeNames.get_by_camel_case(field['ufield']))
                     else:
                         field['matchingType'] = 'matched'

--- a/trials/services/user_to_trial_attr_matcher.py
+++ b/trials/services/user_to_trial_attr_matcher.py
@@ -149,13 +149,34 @@ def _resolve_omop_concepts(concept_id_values):
 
 class UserToTrialAttrMatcher:
     def __init__(self, trial: 'Trial', patient_info: 'PatientInfo') -> None:
+        if patient_info is None:
+            # `resolve_patient_info` returns None for a request with no inline
+            # payload and no resolvable `person_id` — the documented
+            # public-browsing path, which the list endpoint answers with
+            # unfiltered results. Every question this class exists to answer
+            # is "how does THIS patient compare", so with nobody to compare
+            # there is no answer to give, and the caller has to decide what to
+            # render instead.
+            #
+            # Said here rather than discovered five frames down as
+            # `'NoneType' object has no attribute 'prior_therapy'`, which is
+            # what the detail endpoint did for three separately-filed issues
+            # (#362, #374, #423).
+            raise ValueError(
+                'UserToTrialAttrMatcher needs a patient to match against; '
+                'callers with no patient context must not build one.'
+            )
         self.trial = trial
         self.patient_info = patient_info
         self.mapping = USER_TO_TRIAL_ATTRS_MAPPING
         self.patient_info_attr = PatientInfoAttributes(patient_info)
         self.disease_code: Optional[str] = self.get_disease_code_from_trial(trial)
 
-    def get_disease_code_from_trial(self, trial: 'Trial') -> Optional[str]:
+    # Static: it reads nothing but the trial, and the trial-detail view needs
+    # it with no matcher in hand — that is the only disease code available when
+    # there is no patient to take one from.
+    @staticmethod
+    def get_disease_code_from_trial(trial: 'Trial') -> Optional[str]:
         disease = str(trial.disease).lower()
         if disease == 'multiple myeloma':
             return 'MM'


### PR DESCRIPTION
Closes #362, closes #374, closes #423 — one bug, filed three times over several months, which is its own argument for fixing it.

`resolve_patient_info` returns `None` for a request with no inline payload and no resolvable `person_id`. That is the documented public-browsing path, and the **list** endpoint answers it with unfiltered results. The detail endpoint fell over five frames down, as `'NoneType' object has no attribute 'prior_therapy'`.

### The answer is 200, unscored

A 400 would make this the one endpoint that refuses a request the rest of the API serves, and what a trial requires is worth reading whether or not there is anyone to compare it to.

**Not** because "that is what the list does" — I wrote that first and it is wrong. The list answers 200 but it is *not* unscored: `TrialSerializer` sets `matchingType` to `eligible` or `potential` unconditionally, so a patient-less browse shows every trial as eligible and the remote groups them all under "Eligible". That is its own bug, and it is filed rather than folded in here.

A row without a verdict carries **no** `matchingType` — not `unknown`. `unknown` means the trial asked and the patient's data is missing, which is a statement about a patient who does not exist.

### Four places assumed a patient, each a different shape of the same assumption

- `Trial.get_match_score` / `matching_type` built a matcher unconditionally. They return `None` now — the formatter beside them already rendered `None` as an empty cell, which is what "we did not score this" looks like.
- `potential_attributes_first_view` built one too, and asked it for a verdict per row. With no patient it does not build one at all.
- `get_user_details()` returned nothing without a patient, and `details()` only emits a trial column that appears there or in `ATTR_NAME_ALWAYS_INCLUDED`. So the rows were not rendered verdict-less — they were **dropped**. Measured on a trial with nine requirements: twelve rows with a patient, **two** without. Which columns are criteria is a property of the mapping, not of the patient; the patient-dependent parts are the value (`None`) and the disease scoping, which now falls back to the **trial's** disease — the right answer anyway, since the row belongs to the trial.
- `therapies()` returned an empty dict with no patient, so the trial's own therapy criteria — the kind a reader browsing a trial most wants to see — were missing too. Nothing in that method reads the patient.
- the `uvalue_function` lambdas in `configs.py` dereference the patient directly (`lambda patient_info: patient_info.ethnicity`), so they are not asked when there is nobody to ask about.
- the `distancePenalty` cell printed `0`. That is the *scoring* neutral for "no distance known" — a located-less patient gets it too, so the model keeps it — but in a cell labelled "distance Penalty" it reads as "this patient is next door", about somebody who is not there.
- `sorted_locations_by_distance` was handed `patient_info.geo_point`. It already takes `None`, and answers with the trial's own order — the only honest answer to "closest to whom?".
- `is_blank` read `self._context['gender']`, and the context is an empty dict with no patient. With nobody to be male, the male-skip rule does not apply.

### The matcher now refuses rather than crashing

Building `UserToTrialAttrMatcher` with no patient raises a `ValueError` that names the problem. Every question it answers is "how does **this** patient compare", so with nobody there is no answer to give, and the caller is the one who has to decide what to render instead.

#362 asked for exactly this — *"whether the matcher should refuse to run at all rather than each caller guarding"* — and the answer is both: it refuses, and the one caller on this path decides.

### Tests

Ten. The one that matters asserts **parity** — the same rows with and without a patient — rather than "some rows came back". Its first version checked that `disease` was present, and `disease` is hardcoded into `ATTR_NAME_ALWAYS_INCLUDED`: it was green precisely because it named the one row that cannot be dropped, while nine others vanished. That is the review finding I am most glad of, because the test and the commit message agreed with each other and both were wrong.

Also asserted: the endpoint still scores normally when a patient **is** supplied, because a guard that turned the ordinary path off would pass every other test here.

993 backend tests pass. Both halves of the gate run and reconciled — the second pass found the dropped rows, the distance claim, and the false premise above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
