### PR TITLE
feat(federation): ask PROMOP what may be edited, before drawing anything (#421)

### DIFF
--- a/frontend/src/federation/state.test.ts
+++ b/frontend/src/federation/state.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import type { AxiosInstance } from "axios";
 
-import { createPromopState } from "./state";
+import { canEditFields, createPromopState } from "./state";
 
 function fakeClient(data: unknown = {}) {
   const get = vi.fn().mockResolvedValue({ data });
@@ -179,5 +179,197 @@ describe("the base path", () => {
     const state = createPromopState({ client, personId: 5, basePath: "/promop" });
     await state.listFavoriteIds();
     expect(client.get.mock.calls[0][0]).toBe("/promop/trial-enrollments/ids/");
+  });
+});
+
+describe("asking what may be edited", () => {
+  it("asks for this patient, not for the deployment", async () => {
+    // Without `person_id` the endpoint answers "could someone write this",
+    // which is a different question: an analyst has read-only access to every
+    // patient and would be shown a box whose every save is refused.
+    const client = fakeClient({ hemoglobin_g_dl: { kind: "direct", writable: true } });
+    const fields = await adapter(client).getWritableFields!();
+    expect(client.get).toHaveBeenCalledWith(
+      "/api/v1/patient-records/writable-fields/",
+      { params: { person_id: "9001" } },
+    );
+    expect(fields.hemoglobin_g_dl.writable).toBe(true);
+  });
+
+  it("reads an empty body as no fields rather than undefined", async () => {
+    const client = fakeClient(null);
+    expect(await adapter(client).getWritableFields!()).toEqual({});
+  });
+});
+
+describe("writing one attribute", () => {
+  const patching = (data: unknown) => {
+    const patch = vi.fn().mockResolvedValue({ data });
+    return { patch } as unknown as AxiosInstance & { patch: ReturnType<typeof vi.fn> };
+  };
+
+  it("patches the record with just that field", async () => {
+    const client = patching({ hemoglobin_g_dl: 12 });
+    await adapter(client).setPatientField!("hemoglobin_g_dl", 12);
+    expect(client.patch).toHaveBeenCalledWith(
+      "/api/v1/patient-records/9001/",
+      { hemoglobin_g_dl: 12 },
+    );
+  });
+
+  it("reports a value the server echoed back as saved", async () => {
+    const client = patching({ hemoglobin_g_dl: 12 });
+    expect(await adapter(client).setPatientField!("hemoglobin_g_dl", 12))
+      .toEqual({ status: "saved", value: 12 });
+  });
+
+  it("accepts the number the database returns as a string", async () => {
+    const client = patching({ hemoglobin_g_dl: "12.5" });
+    expect((await adapter(client).setPatientField!("hemoglobin_g_dl", 12.5)).status)
+      .toBe("saved");
+  });
+
+  it("accepts a decimal column's trailing scale", async () => {
+    // `numeric(5,2)` answers "12.50" for the 12.5 that was sent. Compared as
+    // text those differ, and the page would report a successful write as
+    // dropped. This is the case the test above only looked like it covered.
+    const client = patching({ hemoglobin_g_dl: "12.50" });
+    expect((await adapter(client).setPatientField!("hemoglobin_g_dl", 12.5)).status)
+      .toBe("saved");
+  });
+
+  it("does not let the numeric comparison swallow false or an emptied field", async () => {
+    // `Number(false)` and `Number("")` are both 0, so a careless numeric path
+    // makes "no" equal "0" and an erased value equal zero — for a lab result,
+    // the difference between not measured and measured as none.
+    expect((await adapter(patching({ meets_crab: "0" }))
+      .setPatientField!("meets_crab", false)).status).toBe("differs");
+    expect((await adapter(patching({ hemoglobin_g_dl: 0 }))
+      .setPatientField!("hemoglobin_g_dl", "")).status).toBe("differs");
+  });
+
+  it("sends the person in the path only, not twice", async () => {
+    // The endpoint reads the person from the path and nothing from the query
+    // string, so a `person_id` param would encode the same id a second time
+    // with only one of the two consulted.
+    const client = patching({ hemoglobin_g_dl: 12 });
+    await adapter(client).setPatientField!("hemoglobin_g_dl", 12);
+    expect(client.patch.mock.calls[0][2]).toBeUndefined();
+  });
+
+  it("catches the silent no-op: 200, unchanged value", async () => {
+    // PROMOP drops a read-only or unknown field without complaint — the older
+    // 405 was removed deliberately. Reported as success, the page would say
+    // "saved" over a value the record never took.
+    const client = patching({ bmi: 24 });
+    expect(await adapter(client).setPatientField!("bmi", 31))
+      .toEqual({ status: "differs", value: 24 });
+  });
+
+  it("says unconfirmed when the response does not mention the field", async () => {
+    // Not a failure: the record is a projection re-derived from the OMOP facts
+    // the write produced, so silence is not the same as refusal.
+    const client = patching({ person_id: 9001 });
+    expect(await adapter(client).setPatientField!("hemoglobin_g_dl", 12))
+      .toEqual({ status: "unconfirmed" });
+    expect(await adapter(patching(null)).setPatientField!("x", 1))
+      .toEqual({ status: "unconfirmed" });
+  });
+
+  it("compares a list by its members, in order", async () => {
+    const client = patching({ cytogenetic_markers: ["del17p", "t(4;14)"] });
+    expect((await adapter(client).setPatientField!(
+      "cytogenetic_markers", ["del17p", "t(4;14)"],
+    )).status).toBe("saved");
+    const shorter = patching({ cytogenetic_markers: ["del17p"] });
+    expect((await adapter(shorter).setPatientField!(
+      "cytogenetic_markers", ["del17p", "t(4;14)"],
+    )).status).toBe("differs");
+    // Same length, different members — the case a length check would wave
+    // through, and the one that matters: the record kept a marker the patient
+    // did not choose and dropped one they did.
+    const swapped = patching({ cytogenetic_markers: ["del17p", "t(11;14)"] });
+    expect((await adapter(swapped).setPatientField!(
+      "cytogenetic_markers", ["del17p", "t(4;14)"],
+    )).status).toBe("differs");
+    // Order is part of it too: the record echoes what it stored, and a
+    // reordered list is not proof the write landed as sent.
+    const reordered = patching({ cytogenetic_markers: ["t(4;14)", "del17p"] });
+    expect((await adapter(reordered).setPatientField!(
+      "cytogenetic_markers", ["del17p", "t(4;14)"],
+    )).status).toBe("differs");
+  });
+
+  it("compares JSON values structurally, not as [object Object]", async () => {
+    // `String({...})` is "[object Object]" for every object alive, so a
+    // stringified comparison calls any two of them equal. The record has 62
+    // JSON columns and several are writable, so this is the difference
+    // between noticing a dropped write and announcing it as saved.
+    const changed = patching({ sct_eligibility: { eligible: false } });
+    expect((await adapter(changed).setPatientField!(
+      "sct_eligibility", { eligible: true },
+    )).status).toBe("differs");
+
+    const same = patching({ sct_eligibility: { eligible: true, note: "x" } });
+    expect((await adapter(same).setPatientField!(
+      // Key order differs: jsonb does not preserve the order it was given, so
+      // insisting on it would report every JSON write as differing.
+      "sct_eligibility", { note: "x", eligible: true },
+    )).status).toBe("saved");
+  });
+
+  it("compares a list of objects element by element", async () => {
+    const client = patching({ genetic_mutations: [{ gene: "TP53" }] });
+    expect((await adapter(client).setPatientField!(
+      "genetic_mutations", [{ gene: "BRCA1" }],
+    )).status).toBe("differs");
+  });
+
+  it("accepts a single value echoed back wrapped in a list", async () => {
+    const client = patching({ cytogenetic_markers: ["del17p"] });
+    expect((await adapter(client).setPatientField!("cytogenetic_markers", "del17p")).status)
+      .toBe("saved");
+  });
+
+  it("does not accept the reverse: a list sent, a scalar echoed", async () => {
+    // Wrapping is normalised one way. A list that comes back as a scalar
+    // means the record holds a different shape than was sent — worth a
+    // re-read, not a confirmation.
+    const client = patching({ cytogenetic_markers: "del17p" });
+    expect((await adapter(client).setPatientField!("cytogenetic_markers", ["del17p"])).status)
+      .toBe("differs");
+  });
+
+  it("treats clearing a field as saved when the server agrees it is empty", async () => {
+    const client = patching({ hemoglobin_g_dl: null });
+    expect((await adapter(client).setPatientField!("hemoglobin_g_dl", null)).status)
+      .toBe("saved");
+  });
+});
+
+describe("the editing pair is all or nothing", () => {
+  const base = createPromopState({ client: fakeClient(), personId: 1 });
+
+  it("is on when a host implements both halves", () => {
+    expect(canEditFields(base)).toBe(true);
+  });
+
+  it("is off for a host that implements neither", () => {
+    const { getWritableFields, setPatientField, ...rest } = base;
+    expect(canEditFields(rest as typeof base)).toBe(false);
+  });
+
+  it("is off for a descriptor with no writer — pencils that lead nowhere", () => {
+    const { setPatientField, ...rest } = base;
+    expect(canEditFields(rest as typeof base)).toBe(false);
+  });
+
+  it("is off for a writer with no descriptor — that is the guess we avoid", () => {
+    const { getWritableFields, ...rest } = base;
+    expect(canEditFields(rest as typeof base)).toBe(false);
+  });
+
+  it("is off when there is no adapter at all", () => {
+    expect(canEditFields(undefined)).toBe(false);
   });
 });

--- a/frontend/src/federation/state.ts
+++ b/frontend/src/federation/state.ts
@@ -16,6 +16,7 @@
 import type { AxiosInstance } from "axios";
 
 import type { FilterState } from "./types";
+import type { WritableFields } from "./writable";
 
 /** Trial ids, as PROMOP stores them — strings, because they are opaque keys
  *  to it. EXACT's `trial_ids` filter accepts numeric strings. */
@@ -59,6 +60,62 @@ export interface TrialStateAdapter {
   /** Clear them. Deliberately not `savePreferences({})`: the server merges
    *  a partial update, so "reset" has to be its own call. */
   resetPreferences(): Promise<void>;
+
+  /** Which patient attributes this caller may edit for this patient, and how.
+   *
+   *  Asked rather than derived: EXACT names the attribute a row is about but
+   *  cannot know whether PROMOP will accept a write to it — that depends on a
+   *  reviewed concept set, on the field's kind, and on who is asking. See
+   *  `writable.ts`.
+   *
+   *  Optional, and paired with `setPatientField`: a host that implements
+   *  neither gets the read-only detail page it has today. Implementing only
+   *  one is refused by `canEditFields` rather than half-honoured — a
+   *  descriptor with no writer draws pencils that lead nowhere, and a writer
+   *  with no descriptor has to guess what is writable, which is the guess this
+   *  whole seam exists to avoid. */
+  getWritableFields?(): Promise<WritableFields>;
+  /** Write one attribute. See `WriteOutcome` for why this reports three
+   *  states rather than resolving or rejecting. */
+  setPatientField?(field: string, value: unknown): Promise<WriteOutcome>;
+}
+
+/** What the record showed after a write.
+ *
+ *  Three states, because PROMOP's `PATCH /patient-records/{id}/` answers 200
+ *  for a field it did not write: unknown and read-only fields are dropped
+ *  silently (the older 405 was removed deliberately). A seam that reported
+ *  that as success would let the page say "saved" over a value the record
+ *  never took — the exact failure this phase is here to prevent.
+ *
+ *  `differs` is deliberately NOT called "rejected", because most of the time
+ *  it is not. The record is a projection re-derived from the OMOP facts the
+ *  write produced, and the derivation canonicalises on the way back: free
+ *  light chains return in mg/L whatever unit they were entered in, WBC units
+ *  are normalised, a date comes back as a datetime, and clearing a field may
+ *  echo `null` where `""` was sent. All of those are successful writes whose
+ *  stored value is not character-for-character what was posted. `differs`
+ *  means re-read the record, not tell the reader they failed.
+ *
+ *  `unconfirmed` means the response did not mention the field at all, which
+ *  is rare — the endpoint returns the whole serialized record — but is not a
+ *  failure either.
+ *
+ *  None of the three covers a REFUSED write: the call rejects for those.
+ *  403 for a caller without write access, 404 for an unknown person, 400 for
+ *  a value the serializer will not take (too many decimal places, an
+ *  unrecognised choice). Every caller needs a catch. */
+export type WriteOutcome =
+  | { status: "saved"; value: unknown }
+  | { status: "differs"; value: unknown }
+  | { status: "unconfirmed" };
+
+/** Both halves, or neither. Mirrors `canPersistFilters`. */
+export function canEditFields(
+  adapter: TrialStateAdapter | undefined,
+): adapter is TrialStateAdapter &
+  Required<Pick<TrialStateAdapter, "getWritableFields" | "setPatientField">> {
+  return Boolean(adapter?.getWritableFields && adapter?.setPatientField);
 }
 
 interface PromopStateArgs {
@@ -84,6 +141,7 @@ export function createPromopState({
   const person = String(personId);
   const enrollments = `${basePath}/trial-enrollments`;
   const preferences = `${basePath}/trial-search-preferences`;
+  const records = `${basePath}/patient-records`;
 
   const ids = async (params: Record<string, string>): Promise<TrialId[]> => {
     const response = await client.get<{ trial_ids: TrialId[]; count: number }>(
@@ -153,5 +211,105 @@ export function createPromopState({
       client
         .patch(`${preferences}/reset/`, {}, { params: { person_id: person } })
         .then(() => undefined),
+
+    // `person_id` is not optional here even though the endpoint accepts its
+    // absence. Without it the answer describes the deployment — "could
+    // someone write this" — and an analyst holding read-only access to every
+    // patient would be handed a typeable box whose every save is refused.
+    getWritableFields: async () => {
+      const response = await client.get<WritableFields>(
+        `${records}/writable-fields/`,
+        { params: { person_id: person } },
+      );
+      return response.data ?? {};
+    },
+
+    // No `person_id` param here, unlike the calls above: this endpoint takes
+    // the person in the path and reads nothing from the query string, so
+    // sending it would encode the same id twice with only one of them
+    // consulted.
+    setPatientField: async (field, value) => {
+      const response = await client.patch<Record<string, unknown>>(
+        `${records}/${person}/`,
+        { [field]: value },
+      );
+      const body = response.data;
+      if (!body || typeof body !== "object" || !(field in body)) {
+        return { status: "unconfirmed" };
+      }
+      const echoed = body[field];
+      // Stringified, because the wire does not preserve the distinction: a
+      // number sent as 12 comes back as "12" from a decimal column, and an
+      // option sent as a string may return as one of several equal spellings
+      // of the same value. Both are the value the record took.
+      return sameValue(echoed, value)
+        ? { status: "saved", value: echoed }
+        : { status: "differs", value: echoed };
+    },
   };
+}
+
+/** Loose equality for a value that has been through JSON and a database.
+ *
+ *  Element-wise for lists, position included. Wrapping is normalised in ONE
+ *  direction only — see the function.
+ *
+ *  Objects compare structurally rather than through `String`, which renders
+ *  every one of them as "[object Object]" and would have called any two of
+ *  them equal. That is not academic: the record has 62 JSON columns, several
+ *  of them writable — `genetic_mutations`, `sct_eligibility`,
+ *  `active_malignancies`, the `genomics_*` family — and PROMOP handles some
+ *  of those specially on the way in, so they are the fields most likely to
+ *  come back as something other than what was sent. */
+function sameValue(echoed: unknown, sent: unknown): boolean {
+  // One direction only, and the arguments are named so it stays that way. A
+  // single value written to a multi-valued column comes back wrapped, and
+  // that is the same value. The reverse is not: a list that comes back as a
+  // scalar means the record holds a different shape than was sent, which is
+  // worth re-reading rather than confirming.
+  if (Array.isArray(echoed) && !Array.isArray(sent) && echoed.length === 1) {
+    return sameValue(echoed[0], sent);
+  }
+  if (Array.isArray(echoed) !== Array.isArray(sent)) return false;
+  if (Array.isArray(echoed) && Array.isArray(sent)) {
+    // Position included: the record echoes what it stored, and a reordered
+    // list is not proof the write landed as sent.
+    return echoed.length === sent.length
+      && echoed.every((v, i) => sameValue(v, sent[i]));
+  }
+  if (echoed == null || sent == null) return echoed == null && sent == null;
+  if (isObject(echoed) || isObject(sent)) {
+    return isObject(echoed) && isObject(sent) && canonical(echoed) === canonical(sent);
+  }
+  if (isNumeric(echoed) && isNumeric(sent)) return Number(echoed) === Number(sent);
+  return String(echoed) === String(sent);
+}
+
+function isObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+/** JSON with the keys sorted, so two objects that differ only in key order
+ *  compare equal — Postgres `jsonb` does not preserve the order they arrived
+ *  in, so insisting on it would report every JSON write as differing. */
+function canonical(v: unknown): string {
+  if (Array.isArray(v)) return `[${v.map(canonical).join(",")}]`;
+  if (isObject(v)) {
+    const keys = Object.keys(v).sort();
+    return `{${keys.map((k) => `${JSON.stringify(k)}:${canonical(v[k])}`).join(",")}}`;
+  }
+  return JSON.stringify(v ?? null);
+}
+
+/** A number, or a string that is one.
+ *
+ *  Booleans and empty strings are deliberately excluded even though `Number`
+ *  is happy to convert them: `Number(false)` is 0 and `Number("")` is 0, so
+ *  admitting either would make `false` equal to "0" and an emptied field equal
+ *  to zero. For a lab value that is the difference between "not measured" and
+ *  "measured as none". */
+function isNumeric(v: unknown): boolean {
+  if (typeof v === "number") return Number.isFinite(v);
+  if (typeof v !== "string" || v.trim() === "") return false;
+  return Number.isFinite(Number(v));
 }

--- a/frontend/src/federation/types.ts
+++ b/frontend/src/federation/types.ts
@@ -114,6 +114,18 @@ export interface TrialDetailField {
     | "not_evaluated"
     | string;
   ufield?: string | null;
+  /** The canonical patient attribute this row is about, in the spelling the
+   *  patient record uses (`hemoglobin_g_dl`), or null when the row is not
+   *  about a patient attribute at all.
+   *
+   *  Not derivable from `ufield`: that is camelCase, and un-camelising is not
+   *  mechanical here — `p53_ihc` camelises to `p53Ihc`, which a standard
+   *  snake-caser turns back into `p_53_ihc`, a field nobody has. EXACT sends
+   *  the canonical name rather than letting each client guess (#421).
+   *
+   *  It names the attribute. Whether it can be WRITTEN is a different
+   *  question, answered by PROMOP's descriptor — see `writable.ts`. */
+  upatientField?: string | null;
   uvalue?: unknown;
   utype?: string;
   uoptions?: { value: unknown; label: string }[] | null;

--- a/frontend/src/federation/writable.test.ts
+++ b/frontend/src/federation/writable.test.ts
@@ -1,0 +1,231 @@
+import { describe, expect, it } from "vitest";
+
+import { controlFor, editabilityOf, optionsOf } from "./writable";
+import type { WritableFieldEntry, WritableFields } from "./writable";
+
+const entry = (over: Partial<WritableFieldEntry> = {}): WritableFieldEntry => ({
+  kind: "direct",
+  writable: true,
+  ...over,
+});
+
+describe("the two shapes PROMOP sends options in", () => {
+  it("reads the curated-vocabulary shape, which has a value and no label", () => {
+    expect(optionsOf(entry({ options: [{ value: "Partial response" }] }))).toEqual([
+      { value: "Partial response", label: "Partial response" },
+    ]);
+  });
+
+  it("writes the value and never the code beside it", () => {
+    // The shape PROMOP actually sends for curator-managed choices and for
+    // demographics. `code` is vocabulary metadata for the OMOP projection;
+    // sending it would put `254837009` where the record wants a word.
+    const opts = optionsOf(entry({
+      options: [{ value: "Invasive ductal", code: "254837009" }],
+    }));
+    expect(opts).toEqual([{ value: "Invasive ductal", label: "Invasive ductal" }]);
+    expect(opts[0].value).not.toBe("254837009");
+  });
+
+  it("ignores the extra coding on a cytogenetics option, including `display`", () => {
+    // `display` there is the OMOP CONCEPT NAME, not a label for the value:
+    // showing it would replace "del(17p)" with a sentence of nomenclature.
+    const opts = optionsOf(entry({
+      options: [{
+        value: "del(17p)", code: "1220582008", vocabulary: "SNOMED",
+        concept_id: 4300134, display: "Deletion of short arm of chromosome 17",
+      }],
+    }));
+    expect(opts).toEqual([{ value: "del(17p)", label: "del(17p)" }]);
+  });
+
+  it("keeps the value when a choice has no code at all", () => {
+    expect(optionsOf(entry({ options: [{ value: "Unknown", code: null }] }))).toEqual([
+      { value: "Unknown", label: "Unknown" },
+    ]);
+  });
+
+  it("reads the array form display-first, though PROMOP does not send it", () => {
+    // Kept because the tuple it would come from still exists one function
+    // inside PROMOP; if it ever reaches the wire the order is pinned here.
+    expect(optionsOf(entry({ options: [["Invasive ductal", "254837009"]] })))
+      .toEqual([{ value: "Invasive ductal", label: "Invasive ductal" }]);
+  });
+
+  it("honours an explicit label when one is sent", () => {
+    expect(optionsOf(entry({ options: [{ value: "CR", label: "Complete response" }] })))
+      .toEqual([{ value: "CR", label: "Complete response" }]);
+  });
+
+  it("takes a bare list of strings too", () => {
+    expect(optionsOf(entry({ options: ["Yes", "No"] }))).toEqual([
+      { value: "Yes", label: "Yes" },
+      { value: "No", label: "No" },
+    ]);
+  });
+
+  it("drops entries with nothing to send, rather than offering a blank choice", () => {
+    // A blank option in a select writes an empty value when picked. Better to
+    // not offer it: the reader can always leave the field alone.
+    expect(optionsOf(entry({ options: [{ value: "" }, { value: null }, [""], ""] })))
+      .toEqual([]);
+  });
+
+  it("is empty, not a crash, when options are absent or the wrong type", () => {
+    expect(optionsOf(entry())).toEqual([]);
+    expect(optionsOf(entry({ options: { a: 1 } }))).toEqual([]);
+    expect(optionsOf(undefined)).toEqual([]);
+  });
+});
+
+describe("choosing the control", () => {
+  it("gives a select to anything carrying options, whatever its kind", () => {
+    // `direct` fields carry options as readily as `selectable` ones, so the
+    // presence of a bounded set decides this, not the kind.
+    expect(controlFor(entry({ kind: "direct", options: [["A", null]] }))).toBe("select");
+    expect(controlFor(entry({ kind: "selectable", options: [["A", null]] }))).toBe("select");
+  });
+
+  it("distinguishes a multi-valued field from a single choice", () => {
+    expect(controlFor(entry({ options: [["A", null]], multiple: true }))).toBe("multiselect");
+  });
+
+  it("reads the value kind when there is no bounded set", () => {
+    expect(controlFor(entry({ value_kind: "number" }))).toBe("number");
+    expect(controlFor(entry({ value_kind: "boolean" }))).toBe("boolean");
+    expect(controlFor(entry({ value_kind: "date" }))).toBe("date");
+    expect(controlFor(entry({ value_kind: "string" }))).toBe("text");
+  });
+
+  it("falls back to text for a value kind it has never heard of", () => {
+    expect(controlFor(entry({ value_kind: "quantity" }))).toBe("text");
+    expect(controlFor(entry())).toBe("text");
+  });
+});
+
+describe("deciding whether a row may be edited", () => {
+  const fields: WritableFields = {
+    hemoglobin_g_dl: entry({ value_kind: "number", unit: "g/dL" }),
+    bmi: entry({
+      kind: "computed",
+      writable: false,
+      reason: "Derived from height and weight; edit those instead.",
+    }),
+    hemoglobin_level: entry({
+      kind: "alias",
+      writable: false,
+      canonical: "hemoglobin_g_dl",
+      reason: "Mirrors hemoglobin_g_dl; edit that field instead.",
+    }),
+  };
+
+  it("says yes for a writable field, and which control it wants", () => {
+    const answer = editabilityOf("hemoglobin_g_dl", fields);
+    expect(answer.can).toBe("edit");
+    if (answer.can !== "edit") return;
+    expect(answer.control).toBe("number");
+    expect(answer.entry.unit).toBe("g/dL");
+  });
+
+  it("says no WITH the reason, so the row can explain itself", () => {
+    const answer = editabilityOf("bmi", fields);
+    expect(answer.can).toBe("no");
+    if (answer.can !== "no") return;
+    expect(answer.why).toBe("Derived from height and weight; edit those instead.");
+  });
+
+  it("names the field to edit instead of an alias", () => {
+    const answer = editabilityOf("hemoglobin_level", fields);
+    if (answer.can !== "no") throw new Error("expected no");
+    expect(answer.why).toContain("hemoglobin_g_dl");
+  });
+
+  it("answers unknown while the descriptor has not arrived", () => {
+    // Not "no": before the answer is known the page must look exactly as it
+    // does today. A control drawn early is a control that may be taken away.
+    expect(editabilityOf("hemoglobin_g_dl", undefined)).toEqual({ can: "unknown" });
+  });
+
+  it("answers unknown when EXACT could not name the attribute", () => {
+    // 19 of EXACT's eligibility fields have no patient-record column, and
+    // `upatientField` is null for them (#421). Nothing to look up.
+    expect(editabilityOf(null, fields)).toEqual({ can: "unknown" });
+    expect(editabilityOf(undefined, fields)).toEqual({ can: "unknown" });
+    expect(editabilityOf("", fields)).toEqual({ can: "unknown" });
+  });
+
+  it("answers unknown for a name the descriptor does not carry", () => {
+    // The descriptor documents the whole record, so this should not happen —
+    // but if the two sides drift, the row must not sprout a control that
+    // writes into nothing, and must not claim a reason it was never given.
+    expect(editabilityOf("no_such_field", fields)).toEqual({ can: "unknown" });
+  });
+
+  it("refuses a control for a field written through another resource", () => {
+    // `genetic_mutations` is `writable: true` with `target: "genomics"`.
+    // PATCHing the record would write nothing at all, so the pencil must not
+    // appear — and its own reason names where the edit does belong.
+    const fields: WritableFields = {
+      genetic_mutations: entry({
+        kind: "editable",
+        writable: true,
+        target: "genomics",
+        reason: "Edit individual variants in the Genomics tab.",
+      }),
+    };
+    const answer = editabilityOf("genetic_mutations", fields);
+    expect(answer.can).toBe("no");
+    if (answer.can !== "no") return;
+    expect(answer.why).toContain("Genomics tab");
+  });
+
+  it("still edits a field PROMOP routes onward from the record itself", () => {
+    // Demographics carry `projection_target: "person"` but `target` stays
+    // `patient_record` — PROMOP routes them internally from the same PATCH,
+    // so refusing them would remove working controls.
+    const fields: WritableFields = {
+      gender: entry({ target: "patient_record", projection_target: "person",
+                      options: [{ value: "Female", code: "F" }] }),
+    };
+    expect(editabilityOf("gender", fields).can).toBe("edit");
+  });
+
+  it("refuses a text box for a structured value", () => {
+    const fields: WritableFields = {
+      genomics_ngs: entry({ kind: "editable", writable: true, value_kind: "json" }),
+    };
+    const answer = editabilityOf("genomics_ngs", fields);
+    expect(answer.can).toBe("no");
+    if (answer.can !== "no") return;
+    expect(answer.why).toContain("structured");
+  });
+
+  it("does not treat a note on a writable field as a refusal", () => {
+    // PROMOP attaches `reason` to writable entries too — "Inferred by
+    // default; enter a value to override". Reading it as an error would take
+    // away a control that works.
+    const fields: WritableFields = {
+      relapse_count: entry({
+        value_kind: "number",
+        reason: "Inferred by default; enter a value to override.",
+      }),
+    };
+    expect(editabilityOf("relapse_count", fields).can).toBe("edit");
+  });
+
+  it("does not let a writable:false entry through on kind alone", () => {
+    // `kind` is descriptive; `writable` is the permission. A read-only caller
+    // gets every entry back with `writable` flipped to false and the kinds
+    // untouched, so reading the kind instead would put a box in front of
+    // someone whose every save is refused.
+    const readOnly: WritableFields = {
+      hemoglobin_g_dl: entry({
+        kind: "direct",
+        writable: false,
+        reason: "You have read-only access to this patient record.",
+      }),
+    };
+    const answer = editabilityOf("hemoglobin_g_dl", readOnly);
+    expect(answer.can).toBe("no");
+  });
+});

--- a/frontend/src/federation/writable.ts
+++ b/frontend/src/federation/writable.ts
@@ -1,0 +1,195 @@
+// What the patient may edit, asked rather than assumed.
+//
+// EXACT knows which patient attribute a row is about (`upatientField`, #421).
+// It does not know whether that attribute can be written: PROMOP's
+// `PatientRecord` is a read-only projection re-derived from OMOP facts, so a
+// write is a write into OMOP, and whether one exists depends on a reviewed
+// concept set, on the field's kind, and on who is asking. EXACT cannot answer
+// any of those — 19 of its fields have no PatientRecord column at all.
+//
+// So the descriptor is fetched at runtime from
+// `GET /api/v1/patient-records/writable-fields/?person_id=N` and it decides.
+// Passing `person_id` matters: without it the answer describes the deployment
+// ("could someone write this"), and an analyst with read-only access to every
+// patient would be shown a typeable box whose every save is refused.
+
+/** The kinds PROMOP resolves every field to. Exactly one each. */
+export type WritableKind =
+  | "editable"    // write an OMOP fact; derivation follows
+  | "selectable"  // choose from a bounded set, carried on the fact
+  | "computed"    // derived from other fields; never authored alone
+  | "alias"       // mirrors a canonical field; edit that one instead
+  | "profile"     // a Person attribute, written at the persons endpoint
+  | "unmapped"    // no write path yet
+  | "authored"    // written by authoring a different resource entirely
+  | "direct";     // write to PatientRecord; no OMOP fact required yet
+
+export interface WritableFieldEntry {
+  kind: WritableKind | (string & {});
+  writable: boolean;
+  /** Why, in words fit to show a reader.
+   *
+   *  NOT only on refusals. PROMOP attaches a `reason` to plenty of writable
+   *  entries too — "Written directly to PatientRecord. No OMOP mapping yet.",
+   *  or `relapse_count`'s "Inferred by default; enter a value to override".
+   *  Rendering it as an error message would be wrong; it is a note. */
+  reason?: string;
+  /** The field this one mirrors. Usually an `alias`, but not only: PROMOP
+   *  sets it on `refractory_status`, which is `direct` and writable. */
+  canonical?: string;
+  value_kind?: string;
+  unit?: string;
+  multiple?: boolean;
+  /** Where the write goes. `patient_record` is the one this seam can reach;
+   *  `genomics` and `episode` are edited through their own resources, and
+   *  those entries carry a `reason` saying where. */
+  target?: string;
+  options?: unknown;
+  [key: string]: unknown;
+}
+
+/** Keyed by the canonical patient attribute name (`hemoglobin_g_dl`), which is
+ *  what EXACT puts in `upatientField`. */
+export type WritableFields = Record<string, WritableFieldEntry>;
+
+export interface FieldOption {
+  value: string;
+  label: string;
+}
+
+/** An option's `value` is the string to write. Everything beside it is coding.
+ *
+ *  PROMOP sends objects, in four widths: `{value}` alone, `{value, code}` for
+ *  curator-managed choices and demographics, and for `cytogenetic_markers`
+ *  `{value, code, vocabulary, concept_id, display}`. What matters is that only
+ *  `value` is the thing the record stores — `FieldChoice.display` is
+ *  documented as "one allowed value for a PatientRecord field", and the `code`
+ *  beside it is vocabulary metadata for the OMOP projection. Sending the code
+ *  would put `254837009` where the record wants "Invasive ductal".
+ *
+ *  `display` is a trap of its own: on cytogenetics options it holds the OMOP
+ *  CONCEPT NAME ("Deletion of short arm of chromosome 17"), not a label for
+ *  the value. Only an explicit `label` is used as one.
+ *
+ *  The array form is not something PROMOP sends. It is kept because the tuple
+ *  it would come from still exists one function inside PROMOP
+ *  (`_field_choice_options` returns `(display, code)` pairs, dict-ified by its
+ *  only caller), so the order is worth pinning: display first.
+ */
+export function optionsOf(entry: WritableFieldEntry | undefined): FieldOption[] {
+  const raw = entry?.options;
+  if (!Array.isArray(raw)) return [];
+  const out: FieldOption[] = [];
+  for (const item of raw) {
+    if (typeof item === "string") {
+      if (item !== "") out.push({ value: item, label: item });
+      continue;
+    }
+    if (Array.isArray(item)) {
+      const display = item[0];
+      if (typeof display === "string" && display !== "") {
+        out.push({ value: display, label: display });
+      }
+      continue;
+    }
+    if (item && typeof item === "object") {
+      const value = (item as { value?: unknown }).value;
+      const label = (item as { label?: unknown }).label;
+      if (value == null || value === "") continue;
+      out.push({
+        value: String(value),
+        label: typeof label === "string" && label !== "" ? label : String(value),
+      });
+    }
+  }
+  return out;
+}
+
+/** The control a writable field wants. `select` is decided by the presence of
+ *  options rather than by `kind`, because `direct` fields carry them too. */
+export type EditControl =
+  | "select" | "multiselect" | "number" | "boolean" | "date" | "datetime" | "text";
+
+export function controlFor(entry: WritableFieldEntry): EditControl {
+  if (optionsOf(entry).length > 0) return entry.multiple ? "multiselect" : "select";
+  switch (entry.value_kind) {
+    // PROMOP maps every numeric model field to `number`; `integer` and
+    // `float` are here so a future widening lands on a number box rather
+    // than a text one.
+    case "number":
+    case "integer":
+    case "float":
+      return "number";
+    case "boolean":
+      return "boolean";
+    case "date":
+      return "date";
+    // Kept apart from `date`: a control that drops the time silently rewrites
+    // the value it was given the moment the reader saves an unrelated edit.
+    case "datetime":
+      return "datetime";
+    default:
+      return "text";
+  }
+}
+
+/** The answer for one eligibility row.
+ *
+ *  `unknown` is deliberately not folded into `no`. "PROMOP will not accept this
+ *  write" and "nobody has told us either way" look the same on screen if both
+ *  render a disabled control with no explanation, and they are not the same
+ *  thing: the first has a reason worth showing, the second is a gap in our own
+ *  plumbing (#449) and should simply leave the row as it is today.
+ */
+export type Editability =
+  | { can: "edit"; field: string; entry: WritableFieldEntry; control: EditControl }
+  | { can: "no"; field: string; entry: WritableFieldEntry; why: string }
+  | { can: "unknown" };
+
+const NOT_IN_RECORD =
+  "This attribute is not part of the patient record, so there is nowhere to save it.";
+
+/** Decide whether the row named by `patientField` may be edited.
+ *
+ *  `fields` being undefined means the descriptor has not arrived (or the host
+ *  supplied no writer): every row is `unknown`, and the page stays exactly as
+ *  it is today. That is the safe direction — a control drawn before the answer
+ *  is known is a control that may have to be taken away.
+ */
+export function editabilityOf(
+  patientField: string | null | undefined,
+  fields: WritableFields | undefined,
+): Editability {
+  if (!patientField || !fields) return { can: "unknown" };
+  const entry = fields[patientField];
+  // A name the descriptor does not carry is the ORDINARY case, not drift: the
+  // descriptor covers PROMOP's record, and 19 of EXACT's 133 mapped
+  // attributes have no column in it — `mipi_risk`, `high_risk_mcl_criteria`,
+  // `p53_ihc` and others. So this is `unknown` and not `no`: PROMOP has not
+  // refused the write, it has never been asked about the field, and there is
+  // no reason worth showing. The row stays as it reads today.
+  if (!entry) return { can: "unknown" };
+  // Writable, but not through this endpoint. `genetic_mutations` is
+  // `writable: true` with `target: "genomics"` and a reason naming the tab to
+  // edit it in; PATCHing the record would write nothing. Its own reason is
+  // the right thing to show, so this joins the `no` branch rather than
+  // pretending the field does not exist.
+  const elsewhere = entry.writable && entry.target != null && entry.target !== "patient_record";
+  // A structured value has no control here. `value_kind: "json"` covers
+  // findings blobs; offering a text box would let a reader type over one.
+  const structured = entry.writable && entry.value_kind === "json";
+  if (!entry.writable || elsewhere || structured) {
+    const why =
+      typeof entry.reason === "string" && entry.reason !== ""
+        ? entry.reason
+        : entry.kind === "alias" && typeof entry.canonical === "string"
+          ? `Mirrors ${entry.canonical}; edit that field instead.`
+          : structured
+            ? "This value is structured; it cannot be edited as plain text here."
+            : elsewhere
+              ? "This field is edited elsewhere in the patient record."
+              : NOT_IN_RECORD;
+    return { can: "no", field: patientField, entry, why };
+  }
+  return { can: "edit", field: patientField, entry, control: controlFor(entry) };
+}


### PR DESCRIPTION
First slice of #421. It draws no control — it asks the question everything else
depends on: **which patient attributes may this caller edit, for this patient, right
now.**

EXACT knows which attribute a row is about (`upatientField`, #450). It cannot know
whether that attribute can be written: PROMOP's `PatientRecord` is a read-only
projection re-derived from OMOP facts, so a write is a write into OMOP, and whether one
exists depends on a reviewed concept set, on the field's kind, and on who is asking. So
`GET /api/v1/patient-records/writable-fields/?person_id=N` decides, at runtime.

`person_id` is not optional even though the endpoint accepts its absence: without it the
answer describes the deployment — "could someone write this" — and an analyst holding
read-only access to every patient would be handed a typeable box whose every save is
refused.

## What reading PROMOP's source settled, that guessing would have got wrong

| | |
|---|---|
| `writable` vs `kind` | `writable` is the permission; `kind` is description. A read-only caller gets every entry back with `writable` false and the kinds untouched. |
| `writable: true` ≠ editable here | `genetic_mutations` is writable with `target: "genomics"` — PATCHing the record writes nothing. `value_kind: "json"` has no sane text box. Both refused, with PROMOP's own reason naming where the edit belongs. |
| `reason` is not an error | PROMOP attaches one to writable entries too ("Inferred by default; enter a value to override"). Shown as a note. |
| an option's `value` is the string to write | `{value}`, `{value, code}`, and for cytogenetics `{value, code, vocabulary, concept_id, display}`. Sending `code` would put `254837009` where the record wants "Invasive ductal"; `display` there is the OMOP **concept name**, not a label. |

## Why a write reports three states

PROMOP's PATCH answers **200 for a field it did not write** — unknown and read-only
fields are dropped silently, the older 405 having been removed deliberately. A seam that
called that success would let the page say "saved" over a value the record never took.

The third state is `differs`, not "rejected", and that naming is load-bearing for the
next slice. The record is re-derived from the OMOP facts the write produced and the
derivation canonicalises on the way back: free light chains return in mg/L whatever unit
went in, a date returns as a datetime, clearing a field may echo `null` for a sent `""`.
Those are **successful** writes whose stored value is not the posted one. `differs` means
re-read, not fail.

None of the three covers a refused write — the call rejects (403, 404, a 400 from the
serializer), so every caller needs a catch. Said in the type's doc rather than left to be
discovered.

## Reviews, and what they cost me

Both ran. They caught three things I had wrong, and the pattern is the same each time: a
claim I did not follow all the way to its source.

1. **The headline claim in my first commit message was false.** I said curator-managed
   options arrive as `[display, code]` tuples. They do not — PROMOP dict-ifies them
   before they leave the function I read, and tuples have never been on the wire on any
   branch. Worse, the test that "proved" the defence pinned that invented shape, so a
   mutation preferring `code` over `value` — the exact bug I claimed to prevent —
   **passed the suite**. The real shapes are tested now, and that mutation fails.
2. **`sameValue` compared objects with `String`**, which renders every object as
   `"[object Object]"` and called any two equal. The record has 62 JSON columns, several
   writable and several handled specially by PROMOP on the way in — precisely the fields
   most likely to come back as something else. Now structural, with sorted keys, because
   `jsonb` does not preserve key order.
3. **A test comment promised a `"12.50"` echo and asserted `"12.5"`**, which compares
   equal as text and proved nothing. Fixed, and numbers now compare as numbers — with
   booleans and empty strings kept out of that path, since `Number(false)` and
   `Number("")` are both 0, and for a lab result "no" equalling "0" is the difference
   between not measured and measured as none.

A later codex pass caught a fourth: list-wrapping was normalised symmetrically while the
comment claimed one direction. A scalar echoed for a sent list now reports `differs`.

## Testing

282 pass. Sixteen mutations fail the suite, including every item above. Three mutations
survived earlier rounds and are covered now — two of them were tests that looked like
proof and were not, which is the reason this section exists at all.

## One thing found on the way, filed separately

19 of EXACT's 133 mapped attributes have no column in PROMOP's record, so absence is the
ordinary case and those rows answer `unknown` — PROMOP has not refused the write, it has
never been asked. But one of the 19 is a typo, not a gap: EXACT spells it
`cytogenic_markers` where PROMOP's column is `cytogenetic_markers`. It costs a field
PROMOP has curated options and a full projection recipe for.

## Next

Slice 2 is the control itself, driven by this descriptor, silent when the answer is
unknown. Slice 3 is the autosave queue and the `subform_details` dialogs.
