### PR TITLE
fix(trials): ?studyId= narrowed nothing unless you also asked for ?type=all

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -127,7 +127,7 @@ trial-search request.
 | `country` | string | Filter by country code |
 | `region` | string | Filter by region |
 | `postalCode` | string | Override postal code for distance calculation |
-| `studyId` | string | Filter by study ID (e.g. NCT number) |
+| `studyId` | string | Filter by study ID (e.g. NCT number). Case-insensitive, surrounding whitespace ignored |
 | `phase` | string | Keep trials at this phase or later (`EARLY_PHASE1` … `PHASE4`); trials with no ingested phase are excluded |
 | `lastUpdate` | date | Filter trials updated after this date |
 | `firstEnrolment` | date | Filter trials with first enrolment after this date |
@@ -243,9 +243,15 @@ study-preference query params as `GET /trials/`, plus:
 **`type=all` takes a different branch.** Omitting `type` runs the eligibility
 filter and the full study-preference set. `all` routes through the admin
 branch instead, which skips eligibility *and* the `phase`, `recruitmentStatus`,
-`sponsor`, `searchTreatment`, `country`/`region` and date filters — while being
-the only branch that applies `studyId`. Filters silently do nothing on that
-path rather than erroring (issue #424).
+`sponsor`, `searchTreatment`, `country`/`region`, `distance` and date filters.
+`distance` still *annotates* each row there, so trials carry a distance while
+the radius narrows nothing. Filters
+silently do nothing on that path rather than erroring (issue #424 — a fix is
+open, after which only `country`/`region` will differ, and #430 is why).
+
+`studyId` is applied on **both** branches. It used to be `all`-only, so an
+ordinary search naming one trial answered with every trial the patient matched
+(#458).
 
 **Response extra key — `tabCounts`:**
 

--- a/tests/querysets/test_study_id_filter.py
+++ b/tests/querysets/test_study_id_filter.py
@@ -1,0 +1,124 @@
+"""`?studyId=` narrows an ordinary search, not only `?type=all` (#458).
+
+`by_study_id` was applied in `filter_for_admin` and nowhere else, so a caller
+naming one trial on the default path got every trial the patient matched.
+Measured on the real corpus before the fix: 3114 rows against 1 for the same
+id with `?type=all`.
+
+Same shape as #424 — a parameter neither rejected nor honoured — in the
+direction #424's own guard could not see, which is how it was found.
+"""
+import pytest
+
+from trials.models import Trial
+from trials.services.study_preferences import StudyPreferences
+from tests.factories import TrialFactory
+
+
+def _search(search_type=None, **prefs):
+    query, _ = Trial.objects.all().filtered_trials(
+        search_options={}, study_info=StudyPreferences(**prefs),
+        patient_info=None, search_type=search_type,
+    )
+    return {t.study_id for t in query}
+
+
+@pytest.mark.django_db
+class TestStudyIdNarrowsAnOrdinarySearch:
+    def test_it_narrows_to_the_trial_that_was_named(self):
+        TrialFactory(study_id='NCT_WANTED')
+        TrialFactory(study_id='NCT_OTHER')
+
+        assert _search(study_id='NCT_WANTED') == {'NCT_WANTED'}
+
+    def test_and_still_does_on_the_all_branch(self):
+        """The half that already worked — a fix that moved the filter rather
+        than adding it would pass the test above and break this one."""
+        TrialFactory(study_id='NCT_WANTED')
+        TrialFactory(study_id='NCT_OTHER')
+
+        assert _search(search_type='all', study_id='NCT_WANTED') == {'NCT_WANTED'}
+
+    def test_an_id_nobody_has_returns_nothing_rather_than_everything(self):
+        """The failure this fixes, stated the other way round: the old
+        behaviour for an unknown id was the whole corpus."""
+        TrialFactory(study_id='NCT_WANTED')
+        TrialFactory(study_id='NCT_OTHER')
+
+        assert _search(study_id='NCT_NOT_HERE') == set()
+
+    def test_no_id_still_means_no_narrowing(self):
+        TrialFactory(study_id='A')
+        TrialFactory(study_id='B')
+
+        assert _search() == {'A', 'B'}
+        assert _search(study_id='') == {'A', 'B'}
+        assert _search(study_id=None) == {'A', 'B'}
+
+    def test_it_narrows_alongside_the_other_filters_rather_than_instead_of_them(self):
+        """Applied in the same block as the rest, so a request carrying both
+        gets both — and an id that does not match the other filters returns
+        nothing, which is the honest answer to a contradictory request."""
+        TrialFactory(study_id='NCT_WANTED', sponsor_name='Janssen')
+        TrialFactory(study_id='NCT_OTHER', sponsor_name='Janssen')
+
+        assert _search(study_id='NCT_WANTED', sponsor='Janssen') == {'NCT_WANTED'}
+        assert _search(study_id='NCT_WANTED', sponsor='Somebody else') == set()
+
+    def test_it_forgives_the_case_and_the_stray_space(self):
+        """Strictness was cheap while this was `?type=all`-only: a miss meant
+        the whole corpus came back, which is obviously wrong. On the ordinary
+        path the same miss returns NOTHING, and "no trials" reads as "that
+        trial does not exist" rather than "you typed it in lower case".
+
+        Every sibling text filter here is already lenient."""
+        TrialFactory(study_id='NCT01145989')
+
+        assert _search(study_id='nct01145989') == {'NCT01145989'}
+        assert _search(study_id=' NCT01145989 ') == {'NCT01145989'}
+        assert _search(study_id='   ') == {'NCT01145989'}  # blank after strip: no filter
+
+
+@pytest.mark.django_db
+class TestTheChosenSemanticIsPinned:
+    """`by_study_id` runs BEFORE the patient filter, so a named trial the
+    patient does not match returns an empty list rather than the trial.
+
+    None of the other tests exercise that — they all pass `patient_info=None` —
+    so a later change that special-cased `study_id` to bypass the patient
+    filter (the plausible response to a "why is my trial missing?" report)
+    would keep every one of them green.
+    """
+
+    def test_a_named_trial_the_patient_cannot_enter_is_not_returned(self):
+        from trials.services.patient_info.patient_info import PatientInfo
+        from trials.services.patient_info.normalize import normalize_patient_info
+
+        TrialFactory(study_id='NCT_TOO_OLD', disease='multiple myeloma', age_low_limit=80)
+        patient = PatientInfo(disease='multiple myeloma', patient_age=45)
+        normalize_patient_info(patient)
+
+        query, _ = Trial.objects.all().filtered_trials(
+            search_options={}, study_info=StudyPreferences(study_id='NCT_TOO_OLD'),
+            patient_info=patient, search_type=None,
+        )
+
+        assert list(query) == []
+
+    def test_and_type_all_is_the_way_to_get_it_anyway(self):
+        """The escape hatch the comment points at — NOT `GET /trials/{id}/`,
+        which is keyed on the internal primary key, so a caller holding an NCT
+        number cannot reach it without a search."""
+        from trials.services.patient_info.patient_info import PatientInfo
+        from trials.services.patient_info.normalize import normalize_patient_info
+
+        TrialFactory(study_id='NCT_TOO_OLD', disease='multiple myeloma', age_low_limit=80)
+        patient = PatientInfo(disease='multiple myeloma', patient_age=45)
+        normalize_patient_info(patient)
+
+        query, _ = Trial.objects.all().filtered_trials(
+            search_options={}, study_info=StudyPreferences(study_id='NCT_TOO_OLD'),
+            patient_info=patient, search_type='all',
+        )
+
+        assert {t.study_id for t in query} == {'NCT_TOO_OLD'}

--- a/trials/querysets/trial.py
+++ b/trials/querysets/trial.py
@@ -345,6 +345,33 @@ class TrialQuerySet(models.QuerySet):
         if add_traces:
             count = query.count()
 
+        # `studyId` was applied ONLY on the admin branch, so an ordinary
+        # search carrying it answered with the whole matched corpus — measured
+        # at 3114 rows against 1 for the same id with `?type=all`. Not
+        # rejected, not narrowed: the caller named one trial and got every
+        # trial. Same shape as #424, in the other direction (#458).
+        #
+        # Before the patient filter, with the rest of the study preferences:
+        # this is a search, so "the trial I named, if this patient can be in
+        # it" is the question it answers.
+        #
+        # A caller who wants the trial regardless of the patient uses
+        # `?type=all&studyId=…`, which skips the eligibility filter. NOT
+        # `GET /trials/{id}/`, which this comment said first and which is
+        # keyed on the internal primary key — someone holding an NCT number
+        # cannot reach it without resolving the id through a search, and
+        # search was the thing sending them there.
+        query = query.by_study_id(study_info.study_id)
+        if add_traces:
+            new_count = query.count()
+            traces.append({
+                'attr': 'study_info.study_id',
+                'val': study_info.study_id,
+                'records': new_count,
+                'dropped': count-new_count
+            })
+            count = new_count
+
         query = query.by_titles(study_info.search_title)
         if add_traces:
             new_count = query.count()
@@ -522,10 +549,28 @@ class TrialQuerySet(models.QuerySet):
         return query, traces
 
     def by_study_id(self, study_id):
+        """Narrow to one trial by its registry id.
+
+        Case-insensitive and whitespace-tolerant, which it was not while this
+        was reachable only through `?type=all`. Strictness was cheap there —
+        a missed match meant the whole corpus came back, an obviously wrong
+        answer. On the ordinary search path the same miss returns NOTHING, and
+        "no trials" reads as "that trial does not exist" rather than "you typed
+        it in lower case". Every sibling text filter here is already lenient:
+        `by_sponsor` is `icontains`, `by_study_type` and `by_titles` fold case.
+
+        `__iexact` costs the `study_id` btree on a lookup that is neither hot
+        nor large — a scan over a few thousand rows — and buys a caller who
+        pasted an id with a trailing space the answer they asked for.
+        """
         if not study_id:
             return self
 
-        return self.filter(study_id=study_id)
+        study_id = str(study_id).strip()
+        if not study_id:
+            return self
+
+        return self.filter(study_id__iexact=study_id)
 
     def by_titles(self, search_title):
         if not search_title or search_title == '':


### PR DESCRIPTION
Closes #458.

`by_study_id` was applied in `filter_for_admin` and nowhere else, so a caller naming one trial on the ordinary path got every trial the patient matched. Measured on the real corpus (`exact_mm`, 3114 trials), same id both ways:

```
?studyId=NCT01145989            -> 3114 rows
?studyId=NCT01145989&type=all   ->    1 row
```

`docs/api.md` documents the parameter as "Filter by study ID", so this was the documented behaviour failing silently — not an undocumented extra.

Same shape as #424, in the direction #424's own drift guard could not see. That guard now runs both ways, and this is what it reported.

### It also stops being strict

`by_study_id` matched exactly, case-sensitively, unstripped. That was cheap while it was `?type=all`-only: a miss returned the whole corpus, which is obviously wrong. On the ordinary path the same miss returns **nothing**, and "no trials" reads as *"that trial does not exist"* rather than *"you typed it in lower case"*.

Every sibling text filter here is already lenient — `by_sponsor` is `icontains`, `by_study_type` and `by_titles` fold case. `__iexact` costs the `study_id` btree on a lookup that is neither hot nor large, and buys the caller who pasted an id with a trailing space the answer they asked for.

### Where it sits, and the escape hatch

Before the patient filter, with the rest of the study preferences: this is a search, so *"the trial I named, if this patient can be in it"* is the question it answers. A named trial the patient cannot enter therefore returns an empty list.

The way to get it anyway is `?type=all&studyId=…`, which skips the eligibility filter. My comment first said `GET /trials/{id}/` — wrong: that route is keyed on the internal primary key, so a caller holding an NCT number cannot reach it without a search, and search is what sent them there.

### Tests

Eight. Two are the shapes a careless fix passes: the `all` branch must **keep** working (a fix that moved the filter rather than adding it would look right), and an unknown id must return nothing rather than everything — the old behaviour stated the other way round.

One pins the semantic above against a real patient the trial excludes. Every other test passes `patient_info=None`, so without it the choice this change deliberately made is unpinned, and the plausible response to a *"why is my trial missing?"* report — special-casing `study_id` past the patient filter — would keep them all green.

### Docs

The `?type=all` section was written around this quirk ("while being the only branch that applies `studyId`"). It now records that `studyId` is on both branches, and keeps the list of what `all` still skips, because that list is #424's to shorten and #424 is not merged — my first draft described the state after both land, which is a description of nothing that currently exists.

`distance` joins that skip list, where it was missing: the `all` branch annotates a distance on every row while the radius narrows nothing, so a reader who set 25 miles and switched tabs got trials 3000 miles away with nothing saying the radius had been dropped.

### For whoever merges this alongside #457

That branch names `study_id` in `DELIBERATELY_STANDARD_ONLY_SKIPS`, recording it as a known divergence. With this change it is no longer one, so the entry goes stale — harmless to the guard's arithmetic, but it should go when the two meet.

991 backend tests pass. Both halves of the gate run and reconciled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
