### PR TITLE
fix(trials): the country filter could not match what the UI sends

### DIFF
--- a/tests/querysets/test_country_filter.py
+++ b/tests/querysets/test_country_filter.py
@@ -1,0 +1,221 @@
+"""The country filter matches what the options list actually offers (#430).
+
+`allCountries` is built from `PreferredCountry`, whose `code` is what the UI
+sends — `US`, `GB`. `Country` rows carry only a title, so `by_location`
+matched nothing and, returning `self`, narrowed nothing. The control was
+decoration.
+
+The trap underneath it: `US` names "United States of America", and the catalog
+ALSO holds "United States" — 18,365 site links against the other's one in the
+real corpus. Translating the code and stopping at the first match would have
+narrowed a US search to a single trial, which is worse than not filtering.
+"""
+import pytest
+
+from trials.models import Country, Location, LocationTrial, PreferredCountry, State
+from tests.factories import TrialFactory
+
+
+def _sited(study_id, country, state=None):
+    trial = TrialFactory(study_id=study_id)
+    LocationTrial.objects.create(
+        trial=trial,
+        location=Location.objects.create(
+            city=study_id, title=f'Site {study_id}', country=country, state=state,
+        ),
+    )
+    return trial
+
+
+def _found(country, state=None):
+    from trials.models import Trial
+    return {
+        t.study_id
+        for t in Trial.objects.all().by_location(country, state).only('study_id')
+    }
+
+
+@pytest.fixture
+def catalog(db):
+    """The shape the real corpus has: one country split across two titles, the
+    options list naming the emptier of the two."""
+    big = Country.objects.create(title='United States')
+    stray = Country.objects.create(title='United States of America')
+    germany = Country.objects.create(title='Germany')
+    PreferredCountry.objects.create(code='US', title='United States of America')
+    PreferredCountry.objects.create(code='DE', title='Germany')
+
+    _sited('US_MAIN_1', big)
+    _sited('US_MAIN_2', big)
+    _sited('US_STRAY', stray)
+    _sited('DE_ONE', germany)
+    TrialFactory(study_id='NO_SITE')
+    return {'big': big, 'stray': stray, 'germany': germany}
+
+
+@pytest.mark.django_db
+class TestTheCodeTheUiActuallySends:
+    def test_a_code_narrows(self, catalog):
+        assert _found('DE') == {'DE_ONE'}
+
+    def test_case_and_whitespace_do_not_defeat_it(self, catalog):
+        assert _found(' de ') == {'DE_ONE'}
+
+    def test_a_title_still_works(self, catalog):
+        """A caller who was not reading the options list is unaffected."""
+        assert _found('Germany') == {'DE_ONE'}
+
+
+@pytest.mark.django_db
+class TestACountrySplitAcrossTwoTitles:
+    def test_every_spelling_finds_every_site(self, catalog):
+        """The whole point. Resolving `US` to its options-list title alone
+        would return `US_STRAY` — one trial out of three — which reads as a
+        working filter and is the worst outcome available."""
+        for spelling in ('US', 'us', 'United States', 'United States of America', 'usa'):
+            assert _found(spelling) == {'US_MAIN_1', 'US_MAIN_2', 'US_STRAY'}, spelling
+
+    def test_it_does_not_drag_in_another_country(self, catalog):
+        assert 'DE_ONE' not in _found('US')
+
+
+@pytest.mark.django_db
+class TestWhatStillMeansNoFilter:
+    def test_an_unknown_country_narrows_nothing(self, catalog):
+        """Unchanged, and deliberately: a value this cannot resolve has always
+        meant "no filter" rather than "no results"."""
+        assert _found('Atlantis') == {'US_MAIN_1', 'US_MAIN_2', 'US_STRAY', 'DE_ONE', 'NO_SITE'}
+
+    def test_and_so_does_an_empty_one(self, catalog):
+        for value in ('', '   ', None):
+            assert _found(value) == {
+                'US_MAIN_1', 'US_MAIN_2', 'US_STRAY', 'DE_ONE', 'NO_SITE'
+            }, value
+
+
+@pytest.mark.django_db
+class TestTheStateStillNarrowsWithin:
+    def test_a_state_is_looked_up_across_both_rows(self, catalog):
+        """The state lookup was scoped to the single `Country` row the old code
+        picked, so a state filed under the other title could not be found."""
+        ny = State.objects.create(country=catalog['stray'], title='New York')
+        _sited('US_NY', catalog['stray'], state=ny)
+
+        assert _found('US', 'New York') == {'US_NY'}
+
+    def test_a_state_split_across_both_rows_is_found_in_both(self, catalog):
+        """A country split across two catalog rows has its states split too,
+        so "New York" exists under each — and picking one arbitrarily drops
+        the trials filed under the other. The same mistake as `.first()` on the
+        country, one level down."""
+        ny_stray = State.objects.create(country=catalog['stray'], title='New York')
+        ny_big = State.objects.create(country=catalog['big'], title='New York')
+        _sited('NY_UNDER_STRAY', catalog['stray'], state=ny_stray)
+        _sited('NY_UNDER_BIG', catalog['big'], state=ny_big)
+
+        assert _found('US', 'New York') == {'NY_UNDER_STRAY', 'NY_UNDER_BIG'}
+
+    def test_an_unknown_state_falls_back_to_the_country(self, catalog):
+        assert _found('US', 'Atlantis') == {'US_MAIN_1', 'US_MAIN_2', 'US_STRAY'}
+
+
+@pytest.mark.django_db
+class TestTheOtherSplitCountries:
+    """The US was not a quirk. Nine countries are split across titles in the
+    corpus, and once the code translation works, an ungrouped one narrows to
+    PART of a country while looking like it worked.
+
+    Grouped by an explicit table rather than a rule: stripping ", Republic of"
+    or a parenthetical would merge `Korea, South` with a `Korea, Democratic
+    People's Republic of` that a later import may add — two countries, one
+    answer, in a clinical tool.
+    """
+
+    @pytest.mark.parametrize('titles,code,options_title', [
+        (['Czechia', 'Czech Republic'], 'CZ', 'Czechia'),
+        (['Russian Federation', 'Russia'], 'RU', 'Russian Federation'),
+        (['Turkey (Türkiye)', 'Turkey'], 'TR', 'Turkey (Türkiye)'),
+        (['Korea, Republic of', 'South Korea', 'Korea, South'], 'KR', 'Korea, Republic of'),
+        (['Iran, Islamic Republic of', 'Iran'], 'IR', 'Iran, Islamic Republic of'),
+    ])
+    def test_every_spelling_finds_every_site(self, db, titles, code, options_title):
+        PreferredCountry.objects.create(code=code, title=options_title)
+        expected = set()
+        for i, title in enumerate(titles):
+            country = Country.objects.create(title=title)
+            study_id = f'{code}_{i}'
+            _sited(study_id, country)
+            expected.add(study_id)
+
+        # The code, and every spelling the catalog holds.
+        assert _found(code) == expected
+        for title in titles:
+            assert _found(title) == expected, title
+
+    def test_it_does_not_merge_two_different_countries(self, db):
+        """The reason this is a table. North and South Korea share a prefix and
+        a naming convention, and nothing here may put them together."""
+        south = Country.objects.create(title='Korea, Republic of')
+        north = Country.objects.create(title="Korea, Democratic People's Republic of")
+        _sited('SOUTH', south)
+        _sited('NORTH', north)
+
+        assert _found('South Korea') == {'SOUTH'}
+        assert _found("Korea, Democratic People's Republic of") == {'NORTH'}
+
+
+@pytest.mark.django_db
+class TestTheOptionThatIsNotACountry:
+    def test_other_narrows_nothing_and_that_is_a_decision(self, catalog):
+        """`other` is a real, shipped option (`load_preferred_countries_options`
+        creates it). It resolves to no catalog row, so the search is
+        unnarrowed while its 30 neighbours narrow — the #430 symptom preserved
+        for one value.
+
+        Left unnarrowed deliberately: "Other" cannot be expressed as a set of
+        countries without inverting the catalog, and quietly ignoring it is the
+        honest answer until someone decides what it should mean."""
+        PreferredCountry.objects.create(code='other', title='Other')
+
+        assert _found('other') == {
+            'US_MAIN_1', 'US_MAIN_2', 'US_STRAY', 'DE_ONE', 'NO_SITE'
+        }
+
+
+@pytest.mark.django_db
+class TestACountryTheOptionsListDoesNotCarry:
+    def test_a_plain_title_still_works(self, db):
+        """The claim that "a caller who was not reading the options list is
+        unaffected" — asserted on a country with NO `PreferredCountry` row, so
+        it exercises the title path rather than resolving through the code
+        table by accident."""
+        canada = Country.objects.create(title='Canada')
+        _sited('CA_ONE', canada)
+        _sited('DE_ONE', Country.objects.create(title='Germany'))
+
+        assert _found('Canada') == {'CA_ONE'}
+        assert _found('canada') == {'CA_ONE'}
+
+
+@pytest.mark.django_db
+class TestACountryWhoseNameIsNotASCII:
+    """This database is `LC_CTYPE=C`, where Postgres `upper()` leaves non-ASCII
+    alone and Python's `.lower()` does not. Lowercasing the value in Python
+    before an `iexact` therefore does NOT commute: `Å` becomes `å`, `upper()`
+    hands it back unchanged, and the catalog's own `Å` no longer matches. The
+    exact spelling the catalog ships is the one a caller is most likely to
+    send, so this is the common path, not an edge."""
+
+    def test_the_catalogs_own_spelling_finds_its_trials(self, db):
+        aland = Country.objects.create(title='Åland Islands')
+        _sited('AX_ONE', aland)
+        _sited('DE_ONE', Country.objects.create(title='Germany'))
+
+        assert _found('Åland Islands') == {'AX_ONE'}
+
+    def test_and_so_does_shouting_it(self, db):
+        aland = Country.objects.create(title='Åland Islands')
+        _sited('AX_ONE', aland)
+        _sited('DE_ONE', Country.objects.create(title='Germany'))
+
+        assert _found('ÅLAND ISLANDS') == {'AX_ONE'}

--- a/trials/querysets/trial.py
+++ b/trials/querysets/trial.py
@@ -9,7 +9,7 @@ from django.contrib.postgres.search import SearchVector, SearchQuery
 from django.db import models
 from django.db.models import Case, Count, Q, When, Exists, OuterRef, Value, QuerySet, Min, Subquery
 from django.db.models.expressions import RawSQL
-from django.db.models.functions import Coalesce, Least
+from django.db.models.functions import Coalesce, Least, Lower
 from django.contrib.gis.geos import Point
 from django.db.models import BigIntegerField, F, FloatField, ExpressionWrapper, IntegerField
 
@@ -48,6 +48,104 @@ def cast_str_to_int(value):
 
     if type(value) == str and value.isdigit():
         return int(value)
+
+
+#: Titles that name the same country. The catalog holds a row per title and
+#: nothing links them, so a search for one misses every site filed under the
+#: other — and once the code translation below works, that stops being
+#: harmless: it becomes a filter that narrows to PART of a country while
+#: looking like it worked.
+#:
+#: Measured in the corpus (location counts), which is why this is a table and
+#: not a rule. Normalising titles by stripping ", Republic of" or a
+#: parenthetical would merge `Korea, South` with a `Korea, Democratic People's
+#: Republic of` that a later import may well add — two different countries, one
+#: answer, in a clinical tool.
+#:
+#:     United States (9427)            + United States of America (1)
+#:     Czechia (197)                   + Czech Republic (51)
+#:     Korea, Republic of (295)        + South Korea (240) + Korea, South (1)
+#:     Russian Federation (282)        + Russia (231)
+#:     Turkey (Türkiye) (231)          + Turkey (194)
+#:     Iran, Islamic Republic of (14)  + Iran (17)
+#:     North Macedonia (3)             + Macedonia, The Former Yugoslav … (2)
+#:     Moldova, Republic of (1)        + Moldova (1)
+#:     Syrian Arab Republic (1)        + Syria (1)
+#:
+#: A table rather than a data migration: merging catalog rows changes what
+#: every other consumer reads, and the duplicates are recorded in #430 for
+#: whoever owns the catalog. This makes the FILTER right without touching them.
+_COUNTRY_TITLE_ALIASES = (
+    {'united states', 'united states of america', 'usa'},
+    {'czechia', 'czech republic'},
+    {'korea, republic of', 'south korea', 'korea, south'},
+    {'russia', 'russian federation'},
+    {'turkey', 'turkey (türkiye)', 'türkiye'},
+    {'iran', 'iran, islamic republic of'},
+    {'north macedonia', 'macedonia, the former yugoslav republic of'},
+    {'moldova', 'moldova, republic of'},
+    {'syria', 'syrian arab republic'},
+)
+
+#: An option in the list that is not a country. It resolves to no catalog row,
+#: which would leave the search unnarrowed while 30 of its 31 neighbours
+#: narrow — the #430 symptom preserved for one value. Named so the behaviour is
+#: a decision: "Other" cannot be expressed as a set of countries without
+#: inverting the whole catalog, and quietly ignoring it is the honest answer
+#: until someone decides what it should mean.
+_COUNTRY_NOT_A_COUNTRY = {'other'}
+
+
+def _country_ids_for(value):
+    """Every `Country` id the given country value can mean.
+
+    Takes a code from the options list (`US`), a title (`Germany`), or any of
+    the spellings in `_COUNTRY_TITLE_ALIASES`. Empty when the value names
+    nothing this catalog holds, which the caller treats as "no filter".
+    """
+    from trials.models import Country, PreferredCountry
+
+    value = str(value or '').strip()
+    if not value or value.lower() in _COUNTRY_NOT_A_COUNTRY:
+        return []
+
+    titles = {value}
+    # A code is what the options list emits, and it is not a title.
+    titles.update(
+        PreferredCountry.objects.filter(code__iexact=value).values_list('title', flat=True)
+    )
+
+    # To a fixed point: a value can enter through one spelling and the group it
+    # joins can carry a spelling belonging to another group. One pass over an
+    # ordered tuple would apply part of the merge and leave the rest, which is
+    # a partially resolved country — the outcome this table exists to prevent.
+    #
+    # `probe` is lowercase because the table is, and it is used ONLY to decide
+    # membership. What gets queried is `titles`, which keeps the value exactly
+    # as it arrived.
+    grew = True
+    while grew:
+        grew = False
+        probe = {t.lower() for t in titles}
+        for group in _COUNTRY_TITLE_ALIASES:
+            if probe & group and not group <= probe:
+                titles |= group
+                grew = True
+
+    # Case folding happens in SQL, on both sides, and the value is NOT folded
+    # in Python on the way there. The two are not the same operation: this
+    # database is `LC_CTYPE=C` (so is the corpus), where Postgres `upper()`
+    # leaves non-ASCII alone and Python's `.lower()` does not. Lowering
+    # `Åland Islands` to `åland islands` first hands `iexact` an `å` that
+    # `upper()` returns unchanged, and the catalog's own `Å` stops matching —
+    # the exact spelling the catalog ships being the one a caller is likeliest
+    # to send. The alias literals are safe to add lowercase because they are
+    # spelled as the catalog spells them (`türkiye` already carries `ü`).
+    match = Q()
+    for title in titles:
+        match |= Q(title__iexact=title)
+
+    return list(Country.objects.filter(match).values_list('id', flat=True))
 
 
 def get_recruitment_status_filter_values(recruitment_status):
@@ -612,24 +710,56 @@ class TrialQuerySet(models.QuerySet):
         return self.filter(sponsor_name__icontains=str(value).lower())
 
     def by_location(self, country, state):
-        from trials.models import Country, State
+        """Narrow to trials with a site in that country, and state if given.
+
+        The country arrives as whatever the options list offers, which is a
+        CODE — `US`, `GB` — while `Country` rows carry only a title. So the
+        filter matched nothing and, returning `self`, narrowed nothing: the
+        control was decoration (#430).
+
+        Three things had to line up, not one:
+
+        * a code has to be translated. `PreferredCountry` holds the code→title
+          pair the options list is built from, and 30 of its 31 entries match
+          a `Country` title exactly.
+        * the last entry is the one that matters: `US` names "United States of
+          America", and the catalog ALSO holds "United States" — with 18,365
+          site links against the other's one. Translating the code and stopping
+          at the first match would have narrowed a US search to a single
+          trial, which is worse than the filter doing nothing.
+        * so every row that means the country is used, not `.first()`.
+
+        A raw title still works, so a caller who was not reading the options
+        list is unaffected.
+        """
+        from trials.models import State
 
         if not state and not country:
             return self
 
-        if country:
-            country_by_name = Country.objects.filter(title__iexact=country).first()
-            if not country_by_name:
-                return self
+        if not country:
+            return self
 
-            if state:
-                state_by_name = State.objects.filter(country=country_by_name, title__iexact=state).first()
-                if state_by_name:
-                    return self.filter(locationtrial__location__state_id=state_by_name.id).distinct()
+        country_ids = _country_ids_for(country)
+        if not country_ids:
+            return self
 
-            return self.filter(locationtrial__location__country_id=country_by_name.id).distinct()
+        if state:
+            # Every matching state row, for the same reason as the country: a
+            # country split across two catalog rows has its states split too,
+            # so "New York" exists under each and `.first()` picks one
+            # arbitrarily — dropping the trials filed under the other.
+            state_ids = list(
+                State.objects.filter(
+                    country_id__in=country_ids, title__iexact=state
+                ).values_list('id', flat=True)
+            )
+            if state_ids:
+                return self.filter(
+                    locationtrial__location__state_id__in=state_ids
+                ).distinct()
 
-        return self
+        return self.filter(locationtrial__location__country_id__in=country_ids).distinct()
 
     def by_distance(self, geo_point, distance, distance_units):
         if not geo_point or not distance or distance <= 0 or not distance_units:  # skip


### PR DESCRIPTION
Closes #430.

## What was wrong

`by_location` filtered on `country__title__iexact=<value>`, but the value the
UI sends is the **code** from `load_preferred_countries_options` — `US`, `DE`,
`CZ`. No `Country` row is titled `US`, so the filter matched nothing, and
`by_location` reads "matched nothing" as "no filter". `?country=US` returned
all 3114 trials in the corpus. Every country search was a no-op.

## Why it was not a one-line fix

Translating the code to a title and taking `.first()` would have been worse
than the bug. The catalog holds the **same country under several titles**, and
I only found that out by measuring — my first version covered the United
States because that was the one I happened to look at. A review asked whether
it was a quirk. It is not; nine countries are split:

    United States (9427)            + United States of America (1)
    Czechia (197)                   + Czech Republic (51)
    Korea, Republic of (295)        + South Korea (240) + Korea, South (1)
    Russian Federation (282)        + Russia (231)
    Turkey (Türkiye) (231)          + Turkey (194)
    Iran, Islamic Republic of (14)  + Iran (17)
    North Macedonia (3)             + Macedonia, The Former Yugoslav … (2)
    Moldova, Republic of (1)        + Moldova (1)
    Syrian Arab Republic (1)        + Syria (1)

`.first()` on `US` would have narrowed the search to a **single trial** — a
filter that looks like it works, which is the failure mode worth avoiding here.

So the fix resolves a value to **every** `Country` row that means it.

## A table, not a rule

The aliases are an explicit table. Stripping `", Republic of"` or a
parenthetical would merge `Korea, South` with a
`Korea, Democratic People's Republic of` that a later import may well add —
two different countries, one answer, in a tool clinicians use. A table is also
not a data migration: merging the catalog rows changes what every other
consumer reads, and the duplicates are recorded in a comment on #430 for
whoever owns the catalog.

`other` is a real shipped option and stays unnarrowed, named in
`_COUNTRY_NOT_A_COUNTRY` so that is a decision rather than the bug surviving
in one value.

## Measured, against `exact_mm` (3114 trials)

    'US' / 'United States' / 'USA' / 'United States of America'  -> 2038
    'DE'                                                         ->  266
    'Canada'                                                     ->  247
    'Czechia' / 'Czech Republic' / 'CZ'                          ->  108
    'South Korea' / 'Korea, Republic of'                         ->  105
    'Turkey' / 'Türkiye'                                         ->   67
    'Russia' / 'Russian Federation'                              ->   61
    'other', 'Atlantis'                                          -> no filter

Before this change every one of those was "no filter".

## Two things the reviews caught

**Alias expansion runs to a fixed point.** A value can enter through one
spelling and the group it joins can carry a spelling from another; one pass
over an ordered tuple applies part of the merge and leaves the rest — the
partially-resolved country this table exists to prevent.

**Case folding happens in SQL, on both sides, and the value is not folded in
Python on the way there.** I had written that as a comment and then broken it
on the line above; `codex review` caught it. This database is `LC_CTYPE=C` (so
is the corpus), where Postgres `upper()` leaves non-ASCII alone and Python's
`.lower()` does not. Lowering `Åland Islands` to `åland islands` first hands
`iexact` an `å` that `upper()` returns unchanged, the catalog's own `Å` stops
matching, and the filter falls through to matching nothing — i.e. straight
back to the bug this PR fixes, for every country whose name is not ASCII.

## Tests

20, in `tests/querysets/test_country_filter.py`. Including: all five US
spellings finding all three US trials; each split country parametrised; an
explicit assertion that North and South Korea are **not** merged; a country
the options list does not carry (`Canada`), so the plain-title path is
exercised rather than resolving through the code table by accident; and the
non-ASCII pair above. Each fix was mutation-tested — reverted, watched the new
test fail, restored.

Full suite: 1003 passed, 5 skipped.
